### PR TITLE
Fix: Changed Node Version in Semantic-Versioning Workflow

### DIFF
--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Node 21
+      - name: Set up Node 23.7
         uses: actions/setup-node@v3
         with:
-          node-version: 21
+          node-version: 23.7
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
This pull request includes an update to the Node.js version used in the GitHub Actions workflow for semantic versioning.

* [`.github/workflows/semantic-versioning.yml`](diffhunk://#diff-2e03ee4e8990e529eb053f6703dba8e81e9f64be6d488bee5948c8e96b633b77L23-R26): Updated Node.js version from 21 to 23.7 in the setup step.