### PR TITLE
Fix: Docker workflow trigger and image existence check

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image Build and Push on Release
 
 on:
   release:
-    types: [published]
+    types: [published, created, prereleased, released]
 
 permissions:
   contents: write

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -42,7 +42,21 @@ jobs:
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
 
+      - name: Check if image with previous tag already exists
+        id: check-image
+        run: |
+          IMAGE="ghcr.io/${{ env.LOWER_REPO_NAME }}:${{ steps.previoustag.outputs.tag }}"
+          echo "Checking if image $IMAGE exists..."
+          if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "Image exists. Skipping build and push."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Image does not exist. Proceeding with build and push."
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push multi-platform image
+      if: steps.check-image.outputs.exists == 'false'
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm64 \


### PR DESCRIPTION
This pull request enhances the Docker image build and push workflow to include checks for existing images. The workflow now checks if an image with the previous tag already exists in the container registry before attempting to rebuild and push. This change optimizes the build process by skipping redundant operations when an image with the same tag is already available.

### Workflow Enhancements

-   `.github/workflows/build-push-docker-image.yml`: The workflow trigger now includes `created`, `prereleased`, and `released` release types, in addition to `published`. A new step was added to check if an image with the previous tag exists in the container registry, skipping the build and push steps if it does. The build and push step now depends on the check image step.