### PR TITLE
Chore: Improve hover accessibility for sidebar animation

### DIFF
--- a/src/components/root/Navigation/RenderSideBarItems.tsx
+++ b/src/components/root/Navigation/RenderSideBarItems.tsx
@@ -29,7 +29,7 @@ export default function RenderSideBarItems() {
 }
 
 function SideBarHeader({ title, icon }: { title: string; icon: ReactNode }) {
-  const { isOpen, isAnimationEnabled, toggleAnimation } = useSidebarStore((state) => state)
+  const { isOpen, isAnimationEnabled, toggleAnimation, canDeviceHover } = useSidebarStore((state) => state)
 
   return (
     <Link href='#' className='font-normal flex space-x-2 items-center text-sm text-black py-1 relative z-20'>
@@ -46,7 +46,10 @@ function SideBarHeader({ title, icon }: { title: string; icon: ReactNode }) {
         </motion.span>
 
         <div className='flex-1' />
-        <motion.div animate={{ opacity: isAnimationEnabled ? (isOpen ? 1 : 0.2) : 1, rotate: isAnimationEnabled ? 45 : 0 }} className='flex justify-end overflow-hidden' onClick={toggleAnimation}>
+        <motion.div
+          animate={{ opacity: isAnimationEnabled ? (isOpen ? 1 : 0.2) : 1, rotate: isAnimationEnabled ? 45 : 0 }}
+          className={tw('flex justify-end overflow-hidden', !canDeviceHover && 'hidden')}
+          onClick={toggleAnimation}>
           <Pin className={tw('size-5 stroke-1', !isAnimationEnabled && 'stroke-2')} />
         </motion.div>
       </>

--- a/src/hooks/root/SidebarStore.ts
+++ b/src/hooks/root/SidebarStore.ts
@@ -35,7 +35,7 @@ export const createSidebarStore = ({ ...initState }: SidebarState = defaultInitS
     return {
       ...initState,
       toggleSidebar: () => set((state) => ({ isOpen: !state.isOpen })),
-      toggleAnimation: () => set((state) => ({ isAnimationEnabled: !state.isAnimationEnabled })),
+      toggleAnimation: () => set((state) => ({ isAnimationEnabled: state.canDeviceHover ? !state.isAnimationEnabled : state.isAnimationEnabled })),
       setOpen: (open_state) => set(() => ({ isOpen: open_state })),
       setAnimation: (animation_state) => set(() => ({ isAnimationEnabled: animation_state })),
       debounceClosure: (new_open_state) => {


### PR DESCRIPTION
This pull request introduces enhancements to the sidebar component, including improvements to the animation toggle functionality and conditional rendering based on device capabilities. The changes aim to provide a more intuitive user experience by adjusting the animation behavior and visibility of certain elements depending on the device's hovering capabilities. These adjustments ensure the sidebar functions optimally across different devices.

### Sidebar Animation and Visibility Adjustments

-   `src/components/root/Navigation/RenderSideBarItems.tsx`: The animation toggle button is now conditionally hidden when the device does not support hovering, and the `canDeviceHover` state from the `useSidebarStore` is used to control the visibility of the pin icon.
-   `src/hooks/root/SidebarStore.ts`: The `toggleAnimation` function now checks `canDeviceHover` to determine if the animation should be toggled. This prevents animation toggling on devices that don't support hover. The store now also includes `canDeviceHover`.