### PR TITLE
Fix: Environment Variables in test script and test script port-in-use check to pre-push hook 

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -25,6 +25,18 @@ done
 # Check if any changed file matches the specified extensions
 if echo "$CHANGED_FILES" | grep -E "$EXTENSIONS_REGEX" > /dev/null; then
   echo "Detected changes in files matching $EXTENSIONS_REGEX. Running tests..."
+
+  # Check if port 3000 is already in use
+  if lsof -i :3000 | grep LISTEN > /dev/null; then
+    echo "Error: Another app is already running on PORT 3000. Aborting push."
+    if [ "$(uname)" = "Darwin" ]; then
+      osascript -e 'display notification "Another app is already running on PORT 3000. Aborting push." with title "Pre-Push Hook Error" sound name "Submarine"'
+    else
+      echo "Non-macOS system detected. No notification will be shown."
+    fi
+    exit 1
+  fi
+
   if npm run test; then
     echo "Tests passed."
     # Check if running on macOS for notifications

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY --from=builder app/tsconfig.json /app/tsconfig.json
 COPY --from=builder app/tsconfig.env.json /app/tsconfig.env.json
 COPY --from=builder app/src/lib/Shared/Env.ts /app/src/lib/Shared/Env.ts
 COPY --from=builder app/node_modules/ts-node /app/node_modules/ts-node
+COPY --from=builder app/node_modules/dotenv /app/node_modules/dotenv
 COPY --from=builder app/node_modules/zod /app/node_modules/zod
 COPY --from=builder app/node_modules/process /app/node_modules/process
 COPY --from=builder app/node_modules/@types/node /app/node_modules/@types/node

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-plugin-istanbul": "^7.0.0",
     "cypress": "^14.1.0",
     "cypress-social-logins": "^1.14.2",
+    "dotenv": "^16.4.7",
     "eslint": "^9",
     "eslint-config-next": "15.2.0",
     "husky": "^8.0.0",

--- a/src/lib/Shared/Env.ts
+++ b/src/lib/Shared/Env.ts
@@ -1,4 +1,7 @@
 import { z } from 'zod'
+import dotenv from 'dotenv'
+
+dotenv.config()
 
 export const envSchema = z.object({
   NEXTAUTH_URL: z.string().startsWith('http').includes('://'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2989,6 +2989,11 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.4.7:
+  version "16.4.7"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.7.tgz#0e20c5b82950140aa99be360a8a5f52335f53c26"
+  integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
+
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"


### PR DESCRIPTION
This pull request updates the pre-push hook to abort if port is already in use. This prevents potential conflicts and errors during deployment. Additionally, the changes include the installation and configuration of the `dotenv` package to access environment variables when running the test-script locally.

### Refactorigns

-   `.husky/pre-push`: Updated pre-push hook to check if port 3000 is in use before running test-script and allowing a push. If the port is in use, an error message is displayed, and the push is aborted.
-   `src/lib/Shared/Env.ts`: Imports and configures `dotenv` to load environment variables when running test-script locally or e.g. through pre-push hook.
- -   `Dockerfile`: Added `dotenv` to the list of copied `node_modules`.

### Dependency Updates

-   `package.json`: Added `dotenv` as a project dependency.
-   `yarn.lock`: Added `dotenv` to the lock file.
