### PR TITLE
Fix: Use BASE_URL env variable for auth client

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,7 +3,7 @@ name: Build and Test
 on: push
 
 env:
-  BASE_URL: ${{ secrets.BASE_URL }}
+  NEXT_PUBLIC_BASE_URL: ${{ secrets.NEXT_PUBLIC_BASE_URL }}
   AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
 
   DATABASE_HOST: ${{ secrets.DATABASE_HOST}}
@@ -82,7 +82,7 @@ jobs:
           echo '{  
             "GOOGLE_USERNAME": "${{ secrets.TEST_GOOGLE_USERNAME }}",  
             "GOOGLE_PASSWORD": "${{ secrets.TEST_GOOGLE_PASSWORD }}",  
-            "BASE_URL": "${{ env.BASE_URL }}", 
+            "NEXT_PUBLIC_BASE_URL": "${{ env.NEXT_PUBLIC_BASE_URL }}", 
             "SkipOnCi": true 
           }' > cypress.env.json
 

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Create .env File
         run: |
-          echo "BASE_URL=${{ secrets.BASE_URL }}" >> .env
+          echo "NEXT_PUBLIC_BASE_URL=${{ secrets.NEXT_PUBLIC_BASE_URL }}" >> .env
           echo "AUTH_SECRET=${{ secrets.AUTH_SECRET }}" >> .env
 
           echo "DATABASE_HOST=${{ secrets.DATABASE_HOST }}" >> .env

--- a/cypress/e2e/page-load.cy.ts
+++ b/cypress/e2e/page-load.cy.ts
@@ -1,6 +1,6 @@
 describe('Page Load Tests - ', () => {
   it('ensure page is accessible', () => {
-    const baseUrl = Cypress.env('BASE_URL')
+    const baseUrl = Cypress.env('NEXT_PUBLIC_BASE_URL')
     cy.visit(baseUrl)
   })
 })

--- a/src/lib/Shared/Env.ts
+++ b/src/lib/Shared/Env.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 dotenv.config()
 
 export const envSchema = z.object({
-  BASE_URL: z.string().startsWith('http').includes('://'),
+  NEXT_PUBLIC_BASE_URL: z.string().startsWith('http').includes('://'),
   AUTH_SECRET: z.string().base64(),
 
   DATABASE_HOST: z.union([

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -1,8 +1,9 @@
+import env from '@/src/lib/Shared/Env'
 import { createAuthClient } from 'better-auth/react'
 
 export const auth_client = createAuthClient({
   /** the base url of the server (optional if you're using the same domain) */
-  baseURL: 'http://localhost:3000',
+  baseURL: env.BASE_URL,
 })
 
 export const { signIn, signUp, signOut, useSession } = auth_client

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -1,9 +1,8 @@
-import env from '@/src/lib/Shared/Env'
 import { createAuthClient } from 'better-auth/react'
 
 export const auth_client = createAuthClient({
   /** the base url of the server (optional if you're using the same domain) */
-  baseURL: env.BASE_URL,
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
 })
 
 export const { signIn, signUp, signOut, useSession } = auth_client


### PR DESCRIPTION
> Automatically generated by [auto-pr-description](https://github.com/Marty-Byrde/auto-pr-description-g4f-action)

This pull request updates environment variable usage throughout the project, specifically renaming and updating the `BASE_URL` variable to `NEXT_PUBLIC_BASE_URL`. This change ensures that the base URL is correctly configured in various environments, including CI/CD pipelines and the Cypress testing environment. Additionally, the changes ensure the base URL is correctly passed to the authentication client.

### Environment Variable Updates

-   `.github/workflows/build-and-test.yml`: Updates the build and test workflow to use `NEXT_PUBLIC_BASE_URL` instead of `BASE_URL` for environment variables and within the `cypress.env.json` file.
-   `.github/workflows/semantic-versioning.yml`: Updates the semantic versioning workflow to use `NEXT_PUBLIC_BASE_URL` instead of `BASE_URL` in the `.env` file.
-   `cypress/e2e/page-load.cy.ts`: Updates the Cypress test to use `NEXT_PUBLIC_BASE_URL` instead of `BASE_URL` for accessing the base URL.
-   `src/lib/Shared/Env.ts`: Updates the environment variable schema to use `NEXT_PUBLIC_BASE_URL` instead of `BASE_URL`.
-   `src/lib/auth/client.ts`: Updates the authentication client to use `process.env.NEXT_PUBLIC_BASE_URL` for the base URL.