### PR TITLE
CI: Add summary job + code coverage upload

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,6 +92,16 @@ jobs:
         if: needs.check-file-changes.outputs.relevant == 'true'
         run: yarn start & npx wait-on --timeout 120000 ${{ env.NEXT_PUBLIC_BASE_URL }} && yarn test:component
 
+      - name: Upload Coverage to Codecov
+        if: needs.check-file-changes.outputs.relevant == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: Master-Thesis-188199/KnowledgeCheckr
+          files: /coverage/**/lcov.info
+          fail_ci_if_error: true
+          verbose: true
+
   build:
     name: Production Build
     runs-on: ubuntu-latest
@@ -279,6 +289,16 @@ jobs:
           browser: chrome
           install: false
           spec: ${{ matrix.chunk.paths }}
+
+      - name: Upload Coverage to Codecov
+        if: needs.check-file-changes.outputs.relevant == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: Master-Thesis-188199/KnowledgeCheckr
+          files: /coverage/**/lcov.info
+          fail_ci_if_error: true
+          verbose: true
 
   e2e-test-summary:
     name: E2E Tests Summary

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -280,6 +280,17 @@ jobs:
           install: false
           spec: ${{ matrix.chunk.paths }}
 
+  e2e-test-summary:
+    name: E2E Tests Summary
+    runs-on: ubuntu-latest
+    needs: run-e2e-tests
+    if: ${{ always() }}
+    steps:
+      - run: |
+          if [[ "${{ needs.*.result }}" =~ failure ]]; then
+            echo "Some e2e tests failed"; exit 1
+          fi
+
   Skip-Executions:
     name: Skip Build And Test
     needs: check-file-changes


### PR DESCRIPTION
This pull request enhances the CI workflow by integrating Codecov for test coverage reporting and adding a summary step for end-to-end (E2E) test results. These changes improve visibility into code quality and test outcomes.

### Enhancements to CI Workflow:

* **Integration with Codecov for Coverage Reporting**:
  - Added a step to upload test coverage report chunks to Codecov in the `build-and-test.yml` workflow for component and e2e tests  [[1]](diffhunk://#diff-bc668a2c9f2299cef15b222055b4b4d5311646caec2e7610e540cee18ae9b948R95-R104) [[2]](diffhunk://#diff-bc668a2c9f2299cef15b222055b4b4d5311646caec2e7610e540cee18ae9b948R293-R313)

* **E2E Test Summary Step**:
  - Introduced a new `e2e-test-summary` job to make summarize the outcome of all parallelized e2e jobs to detect failures. This workflow is then required to merge a PR indirectly requiring all parallelized e2e jobs to pass as well.
