### PR TITLE
Fix: Update date format handling in KnowledgeCheck insert function

### DIFF
--- a/database/knowledgeCheck/insert.ts
+++ b/database/knowledgeCheck/insert.ts
@@ -11,6 +11,7 @@ export default async function insertKnowledgeCheck(user_id: User['id'], check: K
 
   await db.beginTransaction()
 
+  // todo: update open-date value to be date-object or enforce date-string-format
   const { id: check_id } = await db.insert(
     'INSERT INTO KnowledgeCheck (id, name, description, owner_id, public_token, openDate, closeDate, difficulty, createdAt, updatedAt, expiresAt) Values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
     [
@@ -19,7 +20,7 @@ export default async function insertKnowledgeCheck(user_id: User['id'], check: K
       check.description || null,
       user_id,
       check.share_key || null,
-      new Date(Date.parse(check.openDate)).toISOString().slice(0, 19).replace('T', ' '),
+      new Date(Date.parse(check.openDate.split('.').reverse().join('/'))).toISOString().slice(0, 19).replace('T', ' '),
       check.closeDate ? new Date(Date.parse(check.closeDate)).toISOString().slice(0, 19).replace('T', ' ') : null,
       check.difficulty,
       new Date(Date.now()).toISOString().slice(0, 19).replace('T', ' '),


### PR DESCRIPTION
> Automatically generated by [auto-pr-description](https://github.com/Marty-Byrde/auto-pr-description-g4f-action)

This pull request updates the `insertKnowledgeCheck` function to correctly parse date strings. Specifically, it modifies the date parsing logic to handle dates in a different format. This ensures that date values are correctly stored in the database.

### Date Parsing Update

-   `database/knowledgeCheck/insert.ts`: Updated the `openDate` parsing logic to handle a different date string format by splitting the date string by periods and reversing the order before joining with slashes.