### PR TITLE
Fix: Resolve missing general information when saving KnowledeCheck

### DIFF
--- a/src/app/checks/create/GeneralSection.tsx
+++ b/src/app/checks/create/GeneralSection.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import Card from '@/src/components/Shared/Card'
+import Input from '@/src/components/Shared/form/Input'
+import { Textarea } from '@headlessui/react'
+import { ComponentType, InputHTMLAttributes } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+export default function GeneralSection() {
+  return (
+    <Card className='@container flex flex-col gap-8 p-3' disableHoverStyles>
+      <div className='header -m-3 flex flex-col rounded-t-md border-b border-neutral-400 bg-neutral-300 p-2 px-3 text-neutral-600 dark:border-neutral-500 dark:bg-neutral-700/60 dark:text-neutral-300'>
+        <div className='flex items-center justify-between'>
+          <h2 className=''>General Information</h2>
+        </div>
+      </div>
+      <div className='grid grid-cols-[auto_1fr] items-center gap-9 gap-x-7 p-2'>
+        <InputGroup label='Name' placeholder='Enter the name of your knowledge check' />
+        <InputGroup label='Description' className='min-h-20 resize-none' as={Textarea} placeholder='Describe the concept of your knowledge check using a few words.' />
+        <InputGroup
+          label='Deadline'
+          type='date'
+          defaultValue={new Date(Date.now())
+            .toLocaleDateString('de')
+            .split('.')
+            .reverse()
+            .map((el) => (el.length < 2 ? '0' + el : el))
+            .join('-')}
+          className='text-sm text-neutral-500 dark:text-neutral-400'
+        />
+        <InputGroup label='Administrators' />
+      </div>
+    </Card>
+  )
+}
+
+function InputGroup<E extends ComponentType>({ label, as, ...props }: { label: string; as?: E } & InputHTMLAttributes<HTMLInputElement>) {
+  const Element = as || Input
+
+  return (
+    <>
+      <label className='text-neutral-600 dark:text-neutral-400'>{label}</label>
+      <Element
+        placeholder='Enter some text'
+        {...props}
+        className={twMerge(
+          'rounded-md px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 hover:cursor-text hover:ring-neutral-500 focus:ring-[1.2px] focus:ring-neutral-700 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50 dark:hover:ring-neutral-300/60 dark:focus:ring-neutral-300/80',
+          props.className,
+        )}
+      />
+    </>
+  )
+}

--- a/src/app/checks/create/GeneralSection.tsx
+++ b/src/app/checks/create/GeneralSection.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useCreateCheckStore } from '@/src/components/check/create/CreateCheckProvider'
 import Card from '@/src/components/Shared/Card'
 import Input from '@/src/components/Shared/form/Input'
 import { Textarea } from '@headlessui/react'
@@ -7,6 +8,8 @@ import { ComponentType, InputHTMLAttributes } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 export default function GeneralSection() {
+  const { setName, setDescription } = useCreateCheckStore((state) => state)
+
   return (
     <Card className='@container flex flex-col gap-8 p-3' disableHoverStyles>
       <div className='header -m-3 flex flex-col rounded-t-md border-b border-neutral-400 bg-neutral-300 p-2 px-3 text-neutral-600 dark:border-neutral-500 dark:bg-neutral-700/60 dark:text-neutral-300'>
@@ -15,8 +18,14 @@ export default function GeneralSection() {
         </div>
       </div>
       <div className='grid grid-cols-[auto_1fr] items-center gap-9 gap-x-7 p-2'>
-        <InputGroup label='Name' placeholder='Enter the name of your knowledge check' />
-        <InputGroup label='Description' className='min-h-20 resize-none' as={Textarea} placeholder='Describe the concept of your knowledge check using a few words.' />
+        <InputGroup onChange={(e) => setName(e.target.value)} label='Name' placeholder='Enter the name of your knowledge check' />
+        <InputGroup
+          onChange={(e) => setDescription(e.target.value)}
+          label='Description'
+          className='min-h-20 resize-none'
+          as={Textarea}
+          placeholder='Describe the concept of your knowledge check using a few words.'
+        />
         <InputGroup
           label='Deadline'
           type='date'

--- a/src/app/checks/create/SaveAction.ts
+++ b/src/app/checks/create/SaveAction.ts
@@ -2,7 +2,9 @@
 
 import insertKnowledgeCheck from '@/database/knowledgeCheck/insert'
 import { KnowledgeCheck } from '@/src/schemas/KnowledgeCheck'
+import { redirect } from 'next/navigation'
 
 export async function saveAction({ user_id, check }: { user_id: string; check: KnowledgeCheck }) {
   await insertKnowledgeCheck(user_id, check)
+  redirect('/checks')
 }

--- a/src/app/checks/create/page.tsx
+++ b/src/app/checks/create/page.tsx
@@ -8,7 +8,7 @@ import { SaveCreateCheckButton } from '@/src/app/checks/create/SaveCheckButton'
 import { Button } from '@/src/components/shadcn/button'
 import { getServerSession } from '@/src/lib/auth/server'
 import { getUUID } from '@/src/lib/Shared/getUUID'
-import { unauthorized } from 'next/navigation'
+import { redirect, unauthorized } from 'next/navigation'
 
 export default async function CreateCheckPage() {
   const { user } = await getServerSession()
@@ -69,6 +69,8 @@ export default async function CreateCheckPage() {
         },
       ],
     })
+
+    redirect('/checks')
   }
 
   return (

--- a/src/app/checks/create/page.tsx
+++ b/src/app/checks/create/page.tsx
@@ -8,6 +8,7 @@ import { SaveCreateCheckButton } from '@/src/app/checks/create/SaveCheckButton'
 import { Button } from '@/src/components/shadcn/button'
 import { getServerSession } from '@/src/lib/auth/server'
 import { getUUID } from '@/src/lib/Shared/getUUID'
+import { lorem } from 'next/dist/client/components/react-dev-overlay/ui/utils/lorem'
 import { redirect, unauthorized } from 'next/navigation'
 
 export default async function CreateCheckPage() {
@@ -18,10 +19,21 @@ export default async function CreateCheckPage() {
 
   const createDummyCheckAction = async () => {
     'use server'
+    const { user } = await getServerSession()
+    if (!user) unauthorized()
+
     insertKnowledgeCheck(user.id, {
       id: getUUID(),
-      name: '',
-      description: '',
+      name: (Math.random() * 100 + 10)
+        .toPrecision(20)
+        .replace(/\./g, '')
+        .split('')
+        .map((char) => String.fromCharCode(65 + parseInt(char)).toLowerCase())
+        .join(''),
+      description: lorem
+        .split(' ')
+        .slice(0, Math.random() * 100 + 10)
+        .join(' '),
       share_key: null,
       closeDate: null,
       difficulty: 2,

--- a/src/app/checks/create/page.tsx
+++ b/src/app/checks/create/page.tsx
@@ -3,15 +3,12 @@ import { CreateCheckStoreProvider } from '@/components/check/create/CreateCheckP
 import Card from '@/components/Shared/Card'
 import PageHeading from '@/components/Shared/PageHeading'
 import insertKnowledgeCheck from '@/database/knowledgeCheck/insert'
+import GeneralSection from '@/src/app/checks/create/GeneralSection'
 import { SaveCreateCheckButton } from '@/src/app/checks/create/SaveCheckButton'
 import { Button } from '@/src/components/shadcn/button'
-import { Textarea } from '@/src/components/shadcn/textarea'
-import Input from '@/src/components/Shared/form/Input'
 import { getServerSession } from '@/src/lib/auth/server'
 import { getUUID } from '@/src/lib/Shared/getUUID'
 import { unauthorized } from 'next/navigation'
-import { ComponentType, InputHTMLAttributes } from 'react'
-import { twMerge } from 'tailwind-merge'
 
 export default async function CreateCheckPage() {
   const { user } = await getServerSession()
@@ -78,29 +75,7 @@ export default async function CreateCheckPage() {
     <CreateCheckStoreProvider>
       <PageHeading title='Create KnowledgeCheck' />
       <div className='columns-xl gap-12 space-y-12'>
-        <Card className='@container flex flex-col gap-8 p-3' disableHoverStyles>
-          <div className='header -m-3 flex flex-col rounded-t-md border-b border-neutral-400 bg-neutral-300 p-2 px-3 text-neutral-600 dark:border-neutral-500 dark:bg-neutral-700/60 dark:text-neutral-300'>
-            <div className='flex items-center justify-between'>
-              <h2 className=''>General Information</h2>
-            </div>
-          </div>
-          <div className='grid grid-cols-[auto_1fr] items-center gap-9 gap-x-7 p-2'>
-            <InputGroup label='Name' placeholder='Enter the name of your knowledge check' />
-            <InputGroup label='Description' className='min-h-20 resize-none' as={Textarea} placeholder='Describe the concept of your knowledge check using a few words.' />
-            <InputGroup
-              label='Deadline'
-              type='date'
-              defaultValue={new Date(Date.now())
-                .toLocaleDateString('de')
-                .split('.')
-                .reverse()
-                .map((el) => (el.length < 2 ? '0' + el : el))
-                .join('-')}
-              className='text-sm text-neutral-500 dark:text-neutral-400'
-            />
-            <InputGroup label='Administrators' />
-          </div>
-        </Card>
+        <GeneralSection />
         <Card disableHoverStyles className='break-inside-avoid'>
           <h2 className='text-lg'>Settings</h2>
           <div className='h-[500px]'></div>
@@ -116,23 +91,5 @@ export default async function CreateCheckPage() {
       </form>
       <div />
     </CreateCheckStoreProvider>
-  )
-}
-
-function InputGroup<E extends ComponentType>({ label, as, ...props }: { label: string; as?: E } & InputHTMLAttributes<HTMLInputElement>) {
-  const Element = as || Input
-
-  return (
-    <>
-      <label className='text-neutral-600 dark:text-neutral-400'>{label}</label>
-      <Element
-        placeholder='Enter some text'
-        {...props}
-        className={twMerge(
-          'rounded-md px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 hover:cursor-text hover:ring-neutral-500 focus:ring-[1.2px] focus:ring-neutral-700 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50 dark:hover:ring-neutral-300/60 dark:focus:ring-neutral-300/80',
-          props.className,
-        )}
-      />
-    </>
   )
 }

--- a/src/hooks/checks/create/CreateCheckStore.ts
+++ b/src/hooks/checks/create/CreateCheckStore.ts
@@ -6,6 +6,8 @@ import { createStore } from 'zustand/vanilla'
 export type CreateCheckState = KnowledgeCheck
 
 export type CreateCheckActions = {
+  setName: (name: string) => void
+  setDescription: (description: string) => void
   addQuestion: (question: Question) => void
 }
 
@@ -33,6 +35,8 @@ const defaultInitState: CreateCheckState = {
 export const createCheckCreateStore = (initialState: CreateCheckState = defaultInitState) => {
   return createStore<CreateCheckStore>()((set) => ({
     ...initialState,
+    setName: (name) => set((prev) => ({ ...prev, name })),
+    setDescription: (description) => set((prev) => ({ ...prev, description })),
     addQuestion: (question: Question) =>
       set((prev) => {
         const { questionCategories } = prev

--- a/src/tests/e2e/checks/create/CreatePage.cy.tsx
+++ b/src/tests/e2e/checks/create/CreatePage.cy.tsx
@@ -35,7 +35,7 @@ describe('/checks/create - Create Page ', () => {
 
       expect(body.at(0)).to.have.property('user_id')
       expect(body.at(0)).to.have.property('check')
-      expect(response?.statusCode).to.eq(200)
+      expect(response?.statusCode).to.eq(303)
     })
   })
 })


### PR DESCRIPTION

This pull request externalizes the general information card in the /checks/create pages into a new `GeneralSection` component to make it easier to maintain. In this component the inputs for name and description where modified to update the properties of the KnowledgeCheck state object onChange.

### Most important Changes
- `src/app/checks/create/page.tsx`: Integrated the new `GeneralSection` component into the create check page, replacing the previous inline input fields. This refactor improves code organization and readability.
- `src/app/checks/create/GeneralSection.tsx`: Added a new component that externalizes the general information card for creating a knowledge check. It uses the useCreateCheckStore to update the state object.
- `src/hooks/checks/create/CreateCheckStore.ts`: Added `setName` and `setDescription` actions to the Zustand store for managing the state of the knowledge check creation process.

### Other Changes
- `src/app/checks/create/SaveAction.ts`: Modified the `saveAction` function to include a redirect to the `/checks` page after successfully inserting a knowledge check into the database to give users a feedback to their request.
- `src/tests/e2e/checks/create/CreatePage.cy.tsx`: Updated the test to expect a 303 status code instead of 200 after the save action, reflecting the new redirect behavior.
