### PR TITLE
Fix: Resolve test-case failures due to newly introduced bugs

### DIFF
--- a/src/app/checks/create/QuestionsSection.tsx
+++ b/src/app/checks/create/QuestionsSection.tsx
@@ -12,7 +12,7 @@ export default function QuestionsSection() {
   const [dialogOpen, setDialogOpen] = useState(false)
 
   return (
-    <Card disableHoverStyles className='break-inside-avoid'>
+    <Card disableHoverStyles className='question-section break-inside-avoid'>
       <div className='header -m-3 mb-0 flex flex-col rounded-t-md border-b border-neutral-400 bg-neutral-300 p-2 px-3 text-neutral-600 dark:border-neutral-500 dark:bg-neutral-700/60 dark:text-neutral-300'>
         <div className='flex items-center justify-between'>
           <h2 className=''>Questions</h2>

--- a/src/components/Shared/ConditionalBreakpointRendering.tsx
+++ b/src/components/Shared/ConditionalBreakpointRendering.tsx
@@ -2,7 +2,7 @@
 
 import useMatchMedia from '@/hooks/Shared/useMatchMedia'
 
-interface ConditionalSidebarProps {
+interface ConditionalBreakpointProps {
   children: React.ReactNode
 
   hideBreakPoint?: string
@@ -10,7 +10,7 @@ interface ConditionalSidebarProps {
   logIdentifier?: string
 }
 
-export default function ConditionalBreakpointRendering({ children, showBreakPoint, hideBreakPoint, logIdentifier }: ConditionalSidebarProps) {
+export default function ConditionalBreakpointRendering({ children, showBreakPoint, hideBreakPoint, logIdentifier }: ConditionalBreakpointProps) {
   if (!showBreakPoint && !hideBreakPoint) throw new Error('[ConditionalBreakpointRendering]: Either showBreakPoint or hideBreakPoint must be provided')
 
   const mediaQuery = hideBreakPoint ? `(max-width: ${hideBreakPoint})` : `(min-width: ${showBreakPoint})`

--- a/src/components/Shared/Toast/ToastBox.tsx
+++ b/src/components/Shared/Toast/ToastBox.tsx
@@ -1,23 +1,7 @@
 'use client'
-
 import '@/components/Shared/Toast/ToastStyles.css'
-import { useEffect } from 'react'
 import { ToastContainer, ToastContainerProps } from 'react-toastify'
 
-// Module-level flag – its value is shared by every instance
-let alreadyMounted = false
-
 export default function ToastBox(config?: ToastContainerProps) {
-  useEffect(() => {
-    if (alreadyMounted) {
-      throw new Error('ToastBox has already been mounted. Only one instance is allowed.')
-    }
-    alreadyMounted = true
-
-    return () => {
-      alreadyMounted = false
-    }
-  }, [])
-
-  return <ToastContainer toastClassName='md:ml-12' autoClose={5000} closeOnClick limit={5} pauseOnHover={false} pauseOnFocusLoss theme='colored' position='bottom-center' {...config} />
+  return <ToastContainer toastClassName='md:ml-12' autoClose={5000} closeOnClick limit={5} pauseOnHover={false} pauseOnFocusLoss={true} theme={'colored'} position={'bottom-center'} {...config} />
 }

--- a/src/components/root/Navigation/SideBar.tsx
+++ b/src/components/root/Navigation/SideBar.tsx
@@ -19,14 +19,12 @@ export default async function SideBar({ children, initialStoreProps }: { initial
   return (
     <SidebarStoreProvider initialStoreProps={initialStoreProps}>
       <ConditionalBreakpointRendering hideBreakPoint='768px' logIdentifier='mobile-sidebar'>
-        <MobileSideBar children={children} />
+        <MobileSideBar children={children} visibilityBreakpoints='flex md:hidden opacity-100 md:opacity-0' />
       </ConditionalBreakpointRendering>
 
       <ConditionalBreakpointRendering showBreakPoint='768px' logIdentifier='desktop-sidebar'>
-        <DesktopSidebar className='flex' children={children} />
+        <DesktopSidebar className='hidden md:flex' children={children} />
       </ConditionalBreakpointRendering>
-
-      <ActiveDelimiter />
     </SidebarStoreProvider>
   )
 }

--- a/src/tests/e2e/authentication/EmailAuthentication.cy.tsx
+++ b/src/tests/e2e/authentication/EmailAuthentication.cy.tsx
@@ -72,12 +72,12 @@ describe('Better Auth: Email Authentication - Error Handling', () => {
 
     cy.visit('/account/login?type=signup')
 
-    cy.get('[main-content="true"] * input[name="name"]').filter(':visible').type(USERNAME)
-    cy.get('[main-content="true"] * input[name="email"]').filter(':visible').type(EMAIL)
-    cy.get('[main-content="true"] * input[name="password"]').filter(':visible').type(Math.random().toString(36).slice(2, 10))
+    cy.get('input[name="name"]').filter(':visible').type(USERNAME)
+    cy.get('input[name="email"]').filter(':visible').type(EMAIL)
+    cy.get('input[name="password"]').filter(':visible').type(Math.random().toString(36).slice(2, 10))
 
     cy.intercept('POST', '/account/login?type=signup').as('signup-request')
-    cy.get('[main-content="true"] * button[type="submit"]').filter(':visible').click()
+    cy.get('button[type="submit"]').filter(':visible').click()
 
     cy.wait('@signup-request').then((interception) => {
       const response = interception.response
@@ -89,8 +89,8 @@ describe('Better Auth: Email Authentication - Error Handling', () => {
       expect(body.success).to.equal(false)
     })
 
-    cy.get('[main-content="true"] * main * #signup-form [aria-label="field-error-root"]').should('exist')
-    cy.get('[main-content="true"] * main * #signup-form [aria-label="field-error-root"]').contains('User already exists!')
+    cy.get('main * #signup-form [aria-label="field-error-root"]').should('exist')
+    cy.get('main * #signup-form [aria-label="field-error-root"]').contains('User already exists!')
   })
 
   it('Verify that sign-up client-side field errors are displayed on invalid input', () => {
@@ -99,16 +99,16 @@ describe('Better Auth: Email Authentication - Error Handling', () => {
 
     cy.visit('/account/login?type=signup')
 
-    cy.get('[main-content="true"] * input[name="name"]').filter(':visible').type('Some username')
-    cy.get('[main-content="true"] * input[name="name"]').filter(':visible').clear()
-    cy.get('[main-content="true"] * input[name="email"]').filter(':visible').type(EMAIL)
-    cy.get('[main-content="true"] * input[name="password"]').filter(':visible').type(PASSWORD)
+    cy.get('input[name="name"]').filter(':visible').type('Some username')
+    cy.get('input[name="name"]').filter(':visible').clear()
+    cy.get('input[name="email"]').filter(':visible').type(EMAIL)
+    cy.get('input[name="password"]').filter(':visible').type(PASSWORD)
 
-    cy.get('[main-content="true"] * button[type="submit"]').should('be.disabled')
+    cy.get('button[type="submit"]').should('be.disabled')
 
-    cy.get('[main-content="true"] * main * #signup-form [aria-label="field-error-name"]').should('exist')
-    cy.get('[main-content="true"] * main * #signup-form [aria-label="field-error-email"]').should('exist')
-    cy.get('[main-content="true"] * main * #signup-form [aria-label="field-error-password"]').should('exist')
+    cy.get('main * #signup-form [aria-label="field-error-name"]').should('exist')
+    cy.get('main * #signup-form [aria-label="field-error-email"]').should('exist')
+    cy.get('main * #signup-form [aria-label="field-error-password"]').should('exist')
   })
 
   it('Verify that login client-side field errors are displayed on invalid input', () => {
@@ -117,24 +117,24 @@ describe('Better Auth: Email Authentication - Error Handling', () => {
 
     cy.visit('/account/login?type=login')
 
-    cy.get('[main-content="true"] * input[name="email"]').filter(':visible').type(EMAIL)
-    cy.get('[main-content="true"] * input[name="password"]').filter(':visible').type(PASSWORD)
+    cy.get('input[name="email"]').filter(':visible').type(EMAIL)
+    cy.get('input[name="password"]').filter(':visible').type(PASSWORD)
 
-    cy.get('[main-content="true"] * button[type="submit"]').should('be.disabled')
-    cy.get('[main-content="true"] * button[type="submit"]').click({ force: true })
+    cy.get('button[type="submit"]').should('be.disabled')
+    cy.get('button[type="submit"]').click({ force: true })
 
-    cy.get('[main-content="true"] * main * #login-form [aria-label="field-error-email"]').should('exist')
-    cy.get('[main-content="true"] * main * #login-form [aria-label="field-error-password"]').should('exist')
+    cy.get('main * #login-form [aria-label="field-error-email"]').should('exist')
+    cy.get('main * #login-form [aria-label="field-error-password"]').should('exist')
   })
 
   it('Verify that error is displayed when logging in with wrong credentials', () => {
     cy.visit('/account/login?type=signin')
 
-    cy.get('[main-content="true"] * input[name="email"]').filter(':visible').type('test@email.com')
-    cy.get('[main-content="true"] * input[name="password"]').filter(':visible').type('wrongpassword')
+    cy.get('input[name="email"]').filter(':visible').type('test@email.com')
+    cy.get('input[name="password"]').filter(':visible').type('wrongpassword')
 
     cy.intercept('POST', '/account/login?type=signin').as('login-request')
-    cy.get('[main-content="true"] * button[type="submit"]').filter(':visible').click()
+    cy.get('button[type="submit"]').filter(':visible').click()
     cy.wait('@login-request').then((interception) => {
       const response = interception.response
       const responseBody = response?.body.toString().split('1:').at(1)
@@ -145,7 +145,7 @@ describe('Better Auth: Email Authentication - Error Handling', () => {
       expect(body.success).to.equal(false)
     })
 
-    cy.get('[main-content="true"] * main * #login-form [aria-label="field-error-root"]').should('exist')
-    cy.get('[main-content="true"] * main * #login-form [aria-label="field-error-root"]').contains('Wrong e-mail address or password.')
+    cy.get('main * #login-form [aria-label="field-error-root"]').should('exist')
+    cy.get('main * #login-form [aria-label="field-error-root"]').contains('Wrong e-mail address or password.')
   })
 })

--- a/src/tests/e2e/checks/[id]/CheckDetailPage.cy.tsx
+++ b/src/tests/e2e/checks/[id]/CheckDetailPage.cy.tsx
@@ -1,10 +1,6 @@
 it('Verify that the page is unaccessible for unauthenticated users', () => {
-  const baseUrl = Cypress.env('NEXT_PUBLIC_BASE_URL')
-  cy.intercept('GET', `${baseUrl}/checks/some-check-id`).as('intercept-page-response')
-
   cy.visit('/checks/some-check-id', { failOnStatusCode: false })
-
-  cy.wait('@intercept-page-response').its('response.statusCode').should('eq', 401)
+  cy.get('main').should('contain', "You're not authorized to access this page")
 })
 
 it('Verify that authenticated users cannot access non-existing check', () => {
@@ -14,5 +10,5 @@ it('Verify that authenticated users cannot access non-existing check', () => {
   cy.loginTestUser()
   cy.visit('/checks/some-check-id', { failOnStatusCode: false })
 
-  cy.wait('@intercept-page-response').its('response.statusCode').should('eq', 404)
+  cy.get('main').should('contain', 'This page could not be found')
 })

--- a/src/tests/e2e/checks/create/CreateChoiceQuestion.cy.tsx
+++ b/src/tests/e2e/checks/create/CreateChoiceQuestion.cy.tsx
@@ -5,8 +5,8 @@ describe('Check: Create Choice Question -', () => {
     cy.loginTestUser()
     cy.visit('/checks/create')
 
-    cy.get("[data-slot='dialog-trigger']").should('exist').contains('Create Question').click()
-    cy.get("[data-slot='dialog-trigger']").contains('Create Question').should('have.attr', 'data-state', 'open')
+    cy.get(".question-section * [data-slot='dialog-trigger']").should('exist').contains('Create Question').click()
+    cy.get(".question-section * [data-slot='dialog-trigger']").contains('Create Question').should('have.attr', 'data-state', 'open')
   })
 
   it('Verify that a choice question can be added when the inputs are valid', () => {

--- a/src/tests/e2e/checks/create/CreatePage.cy.tsx
+++ b/src/tests/e2e/checks/create/CreatePage.cy.tsx
@@ -1,12 +1,9 @@
 import { Any } from '@/types'
 
 it('Verify that the page is unaccessible for unauthenticated users', () => {
-  const baseUrl = Cypress.env('NEXT_PUBLIC_BASE_URL')
-  cy.intercept('GET', `${baseUrl}/checks/create`).as('intercept-page-response')
+  cy.visit('/checks/create')
 
-  cy.visit('/checks/create', { failOnStatusCode: false })
-
-  cy.wait('@intercept-page-response').its('response.statusCode').should('eq', 401)
+  cy.get('main').should('contain', "You're not authorized to access this page")
 })
 
 describe('/checks/create - Create Page ', () => {
@@ -26,7 +23,7 @@ describe('/checks/create - Create Page ', () => {
     cy.visit('/checks/create')
 
     cy.intercept('POST', `${baseUrl}/checks/create`).as('intercept-create-response')
-    cy.get("[main-content='true'] * [aria-label='save created knowledge check']").should('exist').click({ force: true })
+    cy.get("[aria-label='save created knowledge check']").should('exist').click({ force: true })
 
     cy.wait('@intercept-create-response').then((interception) => {
       const request = interception.request


### PR DESCRIPTION
This Pull request resolves a couple of issues that lead to failing test-cases that tied to the introduction of toast-messages and the changes made in that PR #102.

For example, by eliminating the duplicated rendering of the content due to the Sidebar variations the 'active-delimiter' `main-content="true"` is no longer need and did no longer work, which lead to tests failing. In addition some test-cases kept failing because of different statusCodes, which may be tied to the introduction of custom route-handlers for e.g. unauthorized handlers, which no longer returned a statusCode of 403 but instead 200, because the page rendered successfully.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved sidebar visibility and styling across different screen sizes.
  - Updated section styling on the question creation page.

- **Bug Fixes**
  - Adjusted toast notifications to better handle focus loss and allow multiple instances.

- **Tests**
  - Simplified and clarified end-to-end test selectors for authentication and question creation.
  - Updated test logic to verify UI messages instead of relying on network status codes.

- **Refactor**
  - Renamed internal interface for conditional rendering components for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->