### PR TITLE
Style: Change height styles in Desktop-, Mobile sidebars

### DIFF
--- a/src/components/root/Navigation/desktop/DesktopSideBar.tsx
+++ b/src/components/root/Navigation/desktop/DesktopSideBar.tsx
@@ -10,7 +10,7 @@ import { twMerge as tw } from 'tailwind-merge'
 
 export const DesktopSidebar = ({ className, children }: { children: React.ReactNode; className?: string }) => {
   return (
-    <div className={tw('h-screen flex-col', className)}>
+    <div className={tw('min-h-screen flex-col', className)}>
       <MenuBar />
 
       <div id='desktop-sidebar-container' className='mx-auto flex w-full flex-1 flex-col overflow-hidden bg-gray-100 md:flex-row dark:bg-neutral-800'>

--- a/src/components/root/Navigation/desktop/DesktopSidebarDialog.tsx
+++ b/src/components/root/Navigation/desktop/DesktopSidebarDialog.tsx
@@ -9,7 +9,7 @@ export default function DesktopSidebarDialog({ children, visibilityBreakpoints }
 
   return (
     <motion.div
-      className={tw('flex h-full max-w-[300px] flex-shrink-0 bg-neutral-100 px-2 py-2 md:flex-col dark:bg-neutral-800', visibilityBreakpoints)}
+      className={tw('flex min-h-full max-w-[300px] flex-shrink-0 bg-neutral-100 px-2 py-2 md:flex-col dark:bg-neutral-800', visibilityBreakpoints)}
       initial={{ width: isAnimationEnabled ? '60px' : '300px' }}
       animate={{
         width: isAnimationEnabled ? (isOpen ? '300px' : '60px') : '300px',

--- a/src/components/root/Navigation/mobile/MobileSideBar.tsx
+++ b/src/components/root/Navigation/mobile/MobileSideBar.tsx
@@ -8,7 +8,7 @@ import { ArrowDownNarrowWide } from 'lucide-react'
 export default function MobileSideBar({ children, visibilityBreakpoints }: { visibilityBreakpoints?: string; children?: React.ReactNode }) {
   return (
     <>
-      <div className='flex h-screen flex-col md:hidden dark:bg-neutral-800'>
+      <div className='flex min-h-full flex-col md:hidden dark:bg-neutral-800'>
         <MobileMenubar />
         <main className='flex-1 bg-gray-100 p-4 dark:bg-neutral-900/60'>{children}</main>
       </div>

--- a/src/components/root/Navigation/mobile/MobileSidebarComponents.tsx
+++ b/src/components/root/Navigation/mobile/MobileSidebarComponents.tsx
@@ -14,7 +14,7 @@ export function MobileMenubar() {
   return (
     <div
       id='mobile-sidebar-menubar'
-      className='flex w-full flex-row items-center justify-between bg-white px-4 py-3 text-neutral-600 shadow shadow-neutral-300 dark:bg-neutral-900 dark:text-neutral-200 dark:shadow-neutral-600'>
+      className='sticky inset-x-0 top-0 z-50 flex w-full flex-row items-center justify-between bg-white px-4 py-3 text-neutral-600 shadow shadow-neutral-300 dark:bg-neutral-900 dark:text-neutral-200 dark:shadow-neutral-600'>
       <OpenButton />
       <span className='tracking-widest'>{title}</span>
       <ThemeSwitcher />


### PR DESCRIPTION
This pull request makes changes to the visual appearance of both the Desktop- and Mobile- sidebar. The reason for this is that when the content displayed on any page, given that its passed and rendered within each Sidebar, leads to background discrepancies. Additionally, it makes the mobile sidebar sticky to the top.  

The reason for said background discrepancies is that previously the height of both the Desktop- and Mobile- sidebar were previously set to `h-screen`, which is fine if the content requires less height but causes problems when the max-height exceeds this restriction. In other words, when the content's height exceeds the screen-size, thus requires scrolling the `h-screen` class becomes a limiting factor as its prevents the container height to increase dynamically. 

By changing the height classes in both sidebars to `min-h-screen` instead these issues should be resolved. This way the height is increased the to screen height in case the content requires less space and does not prevent `>>` heights when the content's height exceeds the screen-height.


Figure 1: Shows the background discrepancies beforehand:
![CleanShot 2025-06-20 at 06 41 33](https://github.com/user-attachments/assets/cd8e80b4-b336-4f48-9038-a0dbb29a8d5a)

Figure 2: Shows the desired behavior:
![CleanShot 2025-06-20 at 06 43 31](https://github.com/user-attachments/assets/2ba9ae3e-ef50-4384-a8c0-5743d90c328b)
