### PR TITLE
Ref: Persist sidebar-store to track sidebar state e.g. on reload

### DIFF
--- a/src/components/root/Navigation/SidebarStoreProvider.tsx
+++ b/src/components/root/Navigation/SidebarStoreProvider.tsx
@@ -3,6 +3,7 @@
 import { createContext, type ReactNode, useContext, useRef } from 'react'
 import { useStore } from 'zustand'
 import { createSidebarStore, SidebarState, type SidebarStore } from '@/hooks/root/SidebarStore'
+import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
 
 export type SidebarStoreApi = ReturnType<typeof createSidebarStore>
 
@@ -15,8 +16,10 @@ export interface SidebarStoreProviderProps {
 
 export function SidebarStoreProvider({ children, initialStoreProps }: SidebarStoreProviderProps) {
   const storeRef = useRef<SidebarStoreApi>(null)
+  const { getStoredValue } = useSessionStorageContext()
+
   if (!storeRef.current) {
-    storeRef.current = createSidebarStore(initialStoreProps)
+    storeRef.current = createSidebarStore(getStoredValue<SidebarState>('sidebar-store') ?? initialStoreProps)
   }
 
   return <SidebarStoreContext.Provider value={storeRef.current}>{children}</SidebarStoreContext.Provider>

--- a/src/components/root/Navigation/desktop/SidebarHoverabilityDetection.tsx
+++ b/src/components/root/Navigation/desktop/SidebarHoverabilityDetection.tsx
@@ -4,8 +4,11 @@ import { useSidebarStore } from '@/components/root/Navigation/SidebarStoreProvid
 import { useEffect } from 'react'
 import { usePrimaryPointerQuery } from '@/hooks/root/Navigation/usePrimaryPointerQuery'
 import useStylusPointerQuery from '@/hooks/root/Navigation/useStylusPointerQuery'
+import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
+import { SidebarState } from '@/src/hooks/root/SidebarStore'
 
 export default function SidebarHoverabilityDetection() {
+  const { getStoredValue } = useSessionStorageContext()
   const { setDeviceHoverable } = useSidebarStore((state) => state)
   const primaryPointer = usePrimaryPointerQuery()
   const hasStylus = useStylusPointerQuery()
@@ -16,13 +19,18 @@ export default function SidebarHoverabilityDetection() {
     const isDesktop = desktop_variant?.checkVisibility() === true
 
     if (!isDesktop) return
+    const sidebarStore = getStoredValue<SidebarState>('sidebar-store')
 
     if (primaryPointer === 'fine' && !hasStylus) {
+      // Prevent re-rendering if the state is already set
+      if (sidebarStore && sidebarStore.canDeviceHover) return
       setDeviceHoverable(true)
       console.info(`Your device does support hovering -> hover animations are enabled.`)
     } else {
-      console.info(`Your device does not support hovering ${primaryPointer} -> hover animations are disabled.`)
+      // Prevent re-rendering if the state is already set
+      if (sidebarStore && !sidebarStore.canDeviceHover) return
       setDeviceHoverable(false)
+      console.info(`Your device does not support hovering ${primaryPointer} -> hover animations are disabled.`)
     }
   }, [primaryPointer])
 

--- a/src/hooks/root/SessionStorage.tsx
+++ b/src/hooks/root/SessionStorage.tsx
@@ -14,7 +14,10 @@ const Context = createContext<SessionStorageContext | undefined>(undefined)
 
 export function SessionStorageProvider({ children, cacheDuration = 4 * 3600 * 1000 }: { children: React.ReactNode; cacheDuration?: number }) {
   function getStoredValue<T extends object = Any>(key: string, validation?: (value: T | null) => T | never): T | null {
-    const item = JSON.parse(sessionStorage.getItem(key) || 'null')
+    //! Check if window is defined to avoid SSR issues
+    if (typeof window === 'undefined') return null
+
+    const item = JSON.parse(sessionStorage.getItem(key) ?? 'null')
     if (!item) return null
 
     if (!item?.session_savedAt || item.session_savedAt + cacheDuration < Date.now()) {

--- a/src/hooks/root/SidebarStore.ts
+++ b/src/hooks/root/SidebarStore.ts
@@ -1,6 +1,7 @@
 import { createStore } from 'zustand/vanilla'
 import { SideBarProps } from '@/components/root/Navigation/SideBar'
 import { sideBarConfiguration } from '@/components/root/Navigation/SideBarConfiguration'
+import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
 
 export type SidebarState = {
   isOpen: boolean
@@ -29,15 +30,35 @@ export const defaultInitState: SidebarState = {
 
 export const createSidebarStore = ({ ...initState }: SidebarState = defaultInitState) => {
   return createStore<SidebarStore>()((set) => {
+    const { storeSessionValue } = useSessionStorageContext()
+    const sessionStorageDebounceTime = 150
+    let storeTimer: ReturnType<typeof setTimeout> | null = null
+
     const clousureDebounceTime = 500
     let closeTimer: ReturnType<typeof setTimeout> | null = null
 
+    function modifyState(func: (prev: SidebarState) => SidebarStore | Partial<SidebarState>) {
+      set((prev) => {
+        if (storeTimer) {
+          clearTimeout(storeTimer)
+        }
+
+        const update = { ...prev, ...func(prev) }
+
+        storeTimer = setTimeout(() => {
+          storeSessionValue('sidebar-store', update)
+        }, sessionStorageDebounceTime)
+
+        return update
+      })
+    }
+
     return {
       ...initState,
-      toggleSidebar: () => set((state) => ({ isOpen: !state.isOpen })),
-      toggleAnimation: () => set((state) => ({ isAnimationEnabled: state.canDeviceHover ? !state.isAnimationEnabled : state.isAnimationEnabled })),
-      setOpen: (open_state) => set(() => ({ isOpen: open_state })),
-      setAnimation: (animation_state) => set(() => ({ isAnimationEnabled: animation_state })),
+      toggleSidebar: () => modifyState((state) => (!state.isAnimationEnabled ? state : { isOpen: !state.isOpen })),
+      toggleAnimation: () => modifyState((state) => ({ isAnimationEnabled: state.canDeviceHover ? !state.isAnimationEnabled : state.isAnimationEnabled })),
+      setOpen: (open_state) => modifyState(() => ({ isOpen: open_state })),
+      setAnimation: (animation_state) => modifyState(() => ({ isAnimationEnabled: animation_state })),
       debounceClosure: (new_open_state) => {
         if (new_open_state) {
           // When opening, cancel any pending close timer and update state immediately.
@@ -45,18 +66,18 @@ export const createSidebarStore = ({ ...initState }: SidebarState = defaultInitS
             clearTimeout(closeTimer)
             closeTimer = null
           }
-          set(() => ({ isOpen: true }))
+          modifyState(() => ({ isOpen: true }))
         } else {
           // When closing, debounce the state change by 500ms.
           if (closeTimer) {
             clearTimeout(closeTimer)
           }
           closeTimer = setTimeout(() => {
-            set((state) => ({ isOpen: state.isAnimationEnabled ? false : state.isOpen }))
+            modifyState((state) => ({ isOpen: state.isAnimationEnabled ? false : state.isOpen }))
           }, clousureDebounceTime)
         }
       },
-      setDeviceHoverable: (hoverable) => set(() => ({ isAnimationEnabled: hoverable, canDeviceHover: hoverable })),
+      setDeviceHoverable: (hoverable) => modifyState(() => ({ isAnimationEnabled: hoverable, canDeviceHover: hoverable })),
     }
   })
 }

--- a/src/tests/e2e/checks/create/SessionStorageCache.cy.tsx
+++ b/src/tests/e2e/checks/create/SessionStorageCache.cy.tsx
@@ -11,7 +11,7 @@ describe('SessionStorageCache', () => {
     const baseUrl = Cypress.env('NEXT_PUBLIC_BASE_URL')
     const DUMMY_NAME = 'Test Check'
 
-    cy.getAllSessionStorage().should('deep.equal', {}, 'Verify that sessionStorage is empty at the beginning')
+    cy.getAllSessionStorage().its(baseUrl).should('not.have.a.property', 'create-check-store', 'Verify that create-check-store is not cached at the beginning')
 
     cy.get("input[name='check-name']").type(DUMMY_NAME)
 
@@ -36,7 +36,7 @@ describe('SessionStorageCache', () => {
     const DUMMY_NAME = 'Test Check'
     const CACHE_DURATION = 4 * 3600 * 1000
 
-    cy.getAllSessionStorage().should('deep.equal', {}, 'Verify that sessionStorage is empty at the beginning')
+    cy.getAllSessionStorage().its(baseUrl).should('not.have.a.property', 'create-check-store', 'Verify that create-check-store is not cached at the beginning')
     cy.get("input[name='check-name']").type(DUMMY_NAME)
 
     cy.wait(1000) // wait - debounce time before values are cached


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar state is now persisted in session storage, allowing sidebar preferences to be retained across page reloads.

* **Bug Fixes**
  * Improved handling of session storage to prevent errors during server-side rendering.
  * Sidebar hoverability detection avoids unnecessary state updates, improving performance.

* **Tests**
  * Updated end-to-end tests to more precisely verify session storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->