### PR TITLE
Fix: Resolve missing initial values when editing a question

### DIFF
--- a/src/components/check/create/(create-question)/CreateQuestionDialog.tsx
+++ b/src/components/check/create/(create-question)/CreateQuestionDialog.tsx
@@ -9,7 +9,7 @@ import { ChoiceQuestion, OpenQuestion, Question, QuestionSchema } from '@/src/sc
 import { Tooltip } from '@heroui/tooltip'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { ArrowDown, ArrowUp, Check, Plus, Trash2, X } from 'lucide-react'
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 import { FormState, useFieldArray, UseFieldArrayReturn, useForm, UseFormReturn } from 'react-hook-form'
 import { twMerge } from 'tailwind-merge'
 export default function CreateQuestionDialog({ children, initialValues }: { children: ReactNode; initialValues?: Partial<Question> }) {
@@ -74,6 +74,9 @@ export default function CreateQuestionDialog({ children, initialValues }: { chil
     }
   }
 
+  const defaultValues = initialValues ?? getDefaultValues('drag-drop')
+  const previousType = useRef(defaultValues.type)
+
   const {
     register,
     handleSubmit,
@@ -85,7 +88,7 @@ export default function CreateQuestionDialog({ children, initialValues }: { chil
     setValue,
   } = useForm<Question>({
     resolver: zodResolver(QuestionSchema),
-    defaultValues: initialValues || getDefaultValues('drag-drop'),
+    defaultValues: defaultValues,
   })
 
   const closeDialog = ({ reset = false }: { reset?: boolean } = {}) => {
@@ -97,9 +100,10 @@ export default function CreateQuestionDialog({ children, initialValues }: { chil
 
   useEffect(() => {
     const type = watch('type')
-    if (type) {
+    if (type !== previousType.current) {
       resetInputs({ ...getDefaultValues(type), question: watch('question'), points: watch('points'), category: watch('category') })
     }
+    previousType.current = type
   }, [watch('type')])
 
   const onSubmit = (data: Question) => {

--- a/src/components/check/create/(create-question)/CreateQuestionDialog.tsx
+++ b/src/components/check/create/(create-question)/CreateQuestionDialog.tsx
@@ -29,10 +29,10 @@ export default function CreateQuestionDialog({ children, initialValues }: { chil
           // question: 'Which of the following is a programming language?',
           type,
           answers: [
-            { answer: 'Python', correct: true },
-            { answer: 'ASCII', correct: false },
-            { answer: 'ByteCode', correct: false },
-            { answer: 'JavaScript', correct: true },
+            { answer: '', correct: true },
+            { answer: '', correct: true },
+            { answer: '', correct: false },
+            { answer: '', correct: false },
           ],
         }
       case 'single-choice':
@@ -41,10 +41,10 @@ export default function CreateQuestionDialog({ children, initialValues }: { chil
           // question: 'What does RGB stand for?',
           type,
           answers: [
-            { answer: 'Red, Green, Blue', correct: true },
-            { answer: 'Red, Green, Black', correct: false },
-            { answer: 'Red, Green, Yellow', correct: false },
-            { answer: 'Red, Green, White', correct: false },
+            { answer: '', correct: true },
+            { answer: '', correct: false },
+            { answer: '', correct: false },
+            { answer: '', correct: false },
           ],
         }
 
@@ -53,7 +53,7 @@ export default function CreateQuestionDialog({ children, initialValues }: { chil
           ...baseValues,
           // question: 'Describe the essential parts of a computer.',
           type,
-          expectation: 'A computer consists of hardware and software components that work together to perform tasks. This includes components like the CPU, memory, storage, and input/output devices.',
+          expectation: '',
         }
 
       case 'drag-drop':
@@ -62,10 +62,10 @@ export default function CreateQuestionDialog({ children, initialValues }: { chil
           // question: 'Move these activities based the order in which they should be performed',
           type,
           answers: [
-            { answer: 'Prepare the workspace', position: 1 },
-            { answer: 'Gather materials', position: 2 },
-            { answer: 'Follow the instructions', position: 3 },
-            { answer: 'Clean up', position: 4 },
+            { answer: '', position: 1 },
+            { answer: '', position: 2 },
+            { answer: '', position: 3 },
+            { answer: '', position: 4 },
           ],
         }
 
@@ -273,7 +273,7 @@ function ChoiceQuestionAnswers({ control, watch, register, errors }: AnswerOptio
                   <input type='checkbox' {...register(`answers.${index}.correct` as const)} title='Mark as correct' className='appearance-none' />
                 </label>
               </Tooltip>
-              <Input {...register(`answers.${index}.answer` as const)} placeholder={`Answer ${index + 1}`} className='-ml-0.5 flex-1 placeholder:text-[15px]' />
+              <Input {...register(`answers.${index}.answer` as const)} placeholder={`Answer ${index + 1} -  to your question`} className='-ml-0.5 flex-1 placeholder:text-[15px]' />
               <DeleteAnswerOptionButton index={index} remove={remove} />
             </div>
             {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
@@ -342,7 +342,7 @@ function DragDropQuestionAnswers({ register, errors, control, watch, setValue }:
                   />
                 </label>
               </Tooltip>
-              <Input {...register(`answers.${index}.answer` as const)} placeholder={`Answer ${index + 1}`} className='-ml-0.5 flex-1 placeholder:text-[15px]' />
+              <Input {...register(`answers.${index}.answer` as const)} placeholder={`Moveable exemplary Answer ${index + 1}`} className='-ml-0.5 flex-1 placeholder:text-[15px]' />
               <div className='flex gap-2'>
                 <button
                   aria-label='move answer up'


### PR DESCRIPTION
## Summary by CodeRabbit

**Refactor**
 * Improved input placeholders for answer fields in multiple-choice, single-choice, and drag-drop questions to provide clearer guidance.
  * Answer fields for all question types now start as empty, with example texts removed so that users must not clear / override answers when switching between types.
  * **Resolved form resets caused by initial render** that satisfied the question-type-change condition and in turn reset the answer fields to their default values. Thereby losing the initial values when editing a question.