### PR TITLE
Fix: Discarding cached store data when accessing different check

### DIFF
--- a/src/app/checks/edit/[id]/page.tsx
+++ b/src/app/checks/edit/[id]/page.tsx
@@ -20,7 +20,7 @@ export default async function CheckPage({ params }: { params: Promise<{ id: stri
   }
 
   return (
-    <CreateCheckStoreProvider initialStoreProps={check}>
+    <CreateCheckStoreProvider initialStoreProps={check} options={{ disableCache: true }}>
       <PageHeading title={check.name} />
       <div className='grid grid-cols-1 gap-8 lg:grid-cols-[repeat(auto-fill,minmax(680px,1fr))]'>
         <GeneralSection />

--- a/src/components/check/create/CreateCheckProvider.tsx
+++ b/src/components/check/create/CreateCheckProvider.tsx
@@ -16,8 +16,11 @@ export interface CreateCheckStoreProviderProps {
 }
 
 export function CreateCheckStoreProvider({ children, initialStoreProps }: CreateCheckStoreProviderProps) {
-  //? discard cache when cached check-id differs from the initialStore-id (because ids are constants)
-  const props = useCacheCreateStore<CreateCheckState>('create-check-store', createCheckCreateStore, initialStoreProps, { discardCache: (cache) => cache?.id !== initialStoreProps?.id })
+  const props = useCacheCreateStore<CreateCheckState>('create-check-store', createCheckCreateStore, initialStoreProps, {
+    //? discard cache when cached check-id truly differs from the initialStore-id (because ids are constants)
+    //? drafted checks may not be discarded when they were either not yet cached or when no initialProps were provided (thus indicating that a new check is being created)
+    discardCache: (cache) => cache?.id !== undefined && initialStoreProps?.id !== undefined && cache?.id !== initialStoreProps?.id,
+  })
 
   return (
     <CreateCheckStoreContext.Provider value={props}>

--- a/src/components/check/create/CreateCheckProvider.tsx
+++ b/src/components/check/create/CreateCheckProvider.tsx
@@ -21,7 +21,9 @@ export function CreateCheckStoreProvider({ children, initialStoreProps }: Create
   const { getStoredValue } = useSessionStorageContext()
 
   if (!storeRef.current) {
-    storeRef.current = createCheckCreateStore(getStoredValue<CreateCheckState>('create-check-store', { validation: validateKnowledgeCheck }) ?? initialStoreProps)
+    //? Discard cached value when cached check-id differs from the initialStore-id (because ids are constants)
+    const cached = getStoredValue<CreateCheckState>('create-check-store', { validation: validateKnowledgeCheck })
+    storeRef.current = createCheckCreateStore(cached ? (cached.id === initialStoreProps?.id ? cached : initialStoreProps) : initialStoreProps)
   }
 
   return (

--- a/src/components/check/create/CreateCheckProvider.tsx
+++ b/src/components/check/create/CreateCheckProvider.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { createCheckCreateStore, CreateCheckState, type CreateCheckStore } from '@/hooks/checks/create/CreateCheckStore'
+import { createCheckCreateStore, CreateCheckState, CreateCheckStore } from '@/hooks/checks/create/CreateCheckStore'
 import UnsavedCheckChangesAlert from '@/src/components/check/create/UnsavedCheckChangesAlert'
-import useCacheCreateStore from '@/src/hooks/Shared/useCacheCreateStore'
+import useCacheCreateStore, { useCacheCreateStoreOptions } from '@/src/hooks/Shared/useCacheCreateStore'
 import { createContext, type ReactNode, useContext } from 'react'
 import { useStore } from 'zustand'
 
@@ -13,13 +13,15 @@ const CreateCheckStoreContext = createContext<CreateCheckStoreApi | undefined>(u
 export interface CreateCheckStoreProviderProps {
   children: ReactNode
   initialStoreProps?: CreateCheckState
+  options?: useCacheCreateStoreOptions<CreateCheckState>
 }
 
-export function CreateCheckStoreProvider({ children, initialStoreProps }: CreateCheckStoreProviderProps) {
+export function CreateCheckStoreProvider({ children, initialStoreProps, options }: CreateCheckStoreProviderProps) {
   const props = useCacheCreateStore<CreateCheckState>('create-check-store', createCheckCreateStore, initialStoreProps, {
     //? discard cache when cached check-id truly differs from the initialStore-id (because ids are constants)
     //? drafted checks may not be discarded when they were either not yet cached or when no initialProps were provided (thus indicating that a new check is being created)
     discardCache: (cache) => cache?.id !== undefined && initialStoreProps?.id !== undefined && cache?.id !== initialStoreProps?.id,
+    ...options,
   })
 
   return (

--- a/src/components/checks/[share_token]/ExaminationStoreProvider.tsx
+++ b/src/components/checks/[share_token]/ExaminationStoreProvider.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { createExaminationStore, ExaminationState, type ExaminationStore } from '@/hooks/checks/[share_token]/ExaminationStore'
-import useCacheCreateStore from '@/src/hooks/Shared/useCacheCreateStore'
+import { createExaminationStore, ExaminationState, ExaminationStore } from '@/hooks/checks/[share_token]/ExaminationStore'
+import useCacheCreateStore, { useCacheCreateStoreOptions } from '@/src/hooks/Shared/useCacheCreateStore'
 import { createContext, type ReactNode, useContext } from 'react'
 import { useStore } from 'zustand'
 
@@ -12,13 +12,15 @@ export const ExaminationStoreContext = createContext<ExaminationStoreApi | undef
 export interface ExaminationStoreProviderProps {
   children: ReactNode
   initialStoreProps?: ExaminationState
+  options?: useCacheCreateStoreOptions<ExaminationState>
 }
 
-export function ExaminationStoreProvider({ children, initialStoreProps }: ExaminationStoreProviderProps) {
+export function ExaminationStoreProvider({ children, initialStoreProps, options }: ExaminationStoreProviderProps) {
   //todo consider switching to localStorage to ensure that users do not loose their progress e.g. when their browser / system crashes
   const props = useCacheCreateStore<ExaminationState>('examination-store', createExaminationStore, initialStoreProps, {
     expiresAfter: 10 * 60 * 1000,
     discardCache: (cache) => cache?.knowledgeCheck.id !== initialStoreProps?.knowledgeCheck.id,
+    ...options,
   }) //expire after 10 minutes of inactivity or when cached check-id differs from the initialStore-id (because ids are constants)
 
   return <ExaminationStoreContext.Provider value={props}>{children}</ExaminationStoreContext.Provider>

--- a/src/components/checks/[share_token]/ExaminationStoreProvider.tsx
+++ b/src/components/checks/[share_token]/ExaminationStoreProvider.tsx
@@ -16,7 +16,10 @@ export interface ExaminationStoreProviderProps {
 
 export function ExaminationStoreProvider({ children, initialStoreProps }: ExaminationStoreProviderProps) {
   //todo consider switching to localStorage to ensure that users do not loose their progress e.g. when their browser / system crashes
-  const props = useCacheCreateStore<ExaminationState>('examination-store', createExaminationStore, initialStoreProps, { expiresAfter: 10 * 60 * 1000 })
+  const props = useCacheCreateStore<ExaminationState>('examination-store', createExaminationStore, initialStoreProps, {
+    expiresAfter: 10 * 60 * 1000,
+    discardCache: (cache) => cache?.knowledgeCheck.id !== initialStoreProps?.knowledgeCheck.id,
+  }) //expire after 10 minutes of inactivity or when cached check-id differs from the initialStore-id (because ids are constants)
 
   return <ExaminationStoreContext.Provider value={props}>{children}</ExaminationStoreContext.Provider>
 }

--- a/src/hooks/Shared/useCacheCreateStore.ts
+++ b/src/hooks/Shared/useCacheCreateStore.ts
@@ -2,6 +2,11 @@ import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
 import { CreateStoreType } from '@/types/Shared/CreateStoreType'
 import { useRef } from 'react'
 
+export type useCacheCreateStoreOptions<T> = {
+  expiresAfter?: number
+  discardCache?: (cached: T | null) => boolean
+}
+
 /**
  * This hook implements the cache-restoration of a store's state
  * @param session_key The session-key under which the cached data is stored in the sessionStorage
@@ -12,7 +17,7 @@ export default function useCacheCreateStore<StoreState extends object>(
   session_key: string,
   createStoreFunc: CreateStoreType<StoreState>,
   initialStoreProps?: StoreState,
-  options?: { expiresAfter?: number; discardCache?: (cached: StoreState | null) => boolean },
+  options?: useCacheCreateStoreOptions<StoreState>,
 ): ReturnType<typeof createStoreFunc> {
   const { getStoredValue } = useSessionStorageContext()
   const storeRef = useRef<ReturnType<typeof createStoreFunc>>(null)

--- a/src/hooks/Shared/useCacheCreateStore.ts
+++ b/src/hooks/Shared/useCacheCreateStore.ts
@@ -1,5 +1,5 @@
 import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
-import { Any } from '@/types'
+import { CreateStoreType } from '@/types/Shared/CreateStoreType'
 import { useRef } from 'react'
 
 /**
@@ -10,7 +10,7 @@ import { useRef } from 'react'
  */
 export default function useCacheCreateStore<StoreState extends object>(
   session_key: string,
-  createStoreFunc: Any,
+  createStoreFunc: CreateStoreType<StoreState>,
   initialStoreProps?: StoreState,
   options?: { expiresAfter?: number; discardCache?: (cached: StoreState | null) => boolean },
 ): ReturnType<typeof createStoreFunc> {

--- a/src/hooks/Shared/useCacheCreateStore.ts
+++ b/src/hooks/Shared/useCacheCreateStore.ts
@@ -1,8 +1,8 @@
 import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
-import { CreateStoreType } from '@/types/Shared/CreateStoreType'
+import { CreateStoreOptions, CreateStoreType } from '@/types/Shared/CreateStoreType'
 import { useRef } from 'react'
 
-export type useCacheCreateStoreOptions<T> = {
+export type useCacheCreateStoreOptions<T> = CreateStoreOptions & {
   expiresAfter?: number
   discardCache?: (cached: T | null) => boolean
 }
@@ -30,7 +30,12 @@ export default function useCacheCreateStore<StoreState extends object>(
       console.debug(`Discarding cached store ('${session_key}') because discardCache() returned true`)
       props = initialStoreProps
     }
-    storeRef.current = createStoreFunc(props)
+
+    if (options?.disableCache) {
+      props = initialStoreProps
+    }
+
+    storeRef.current = createStoreFunc(props, options)
   }
 
   return storeRef.current

--- a/src/hooks/Shared/useCacheStoreUpdate.ts
+++ b/src/hooks/Shared/useCacheStoreUpdate.ts
@@ -8,8 +8,7 @@ import { CreateStoreOptions } from '@/types/Shared/CreateStoreType'
  */
 export default function useCacheStoreUpdate<StoreProps extends object>(
   set: (updater: (prev: StoreProps) => StoreProps | Partial<StoreProps>) => void,
-  debounceTime = 150,
-  options?: CreateStoreOptions,
+  { debounceTime = 150, options, cache_key }: { debounceTime?: number; options?: CreateStoreOptions; cache_key: string },
 ) {
   const { storeSessionValue } = useSessionStorageContext()
   let storeTimer: ReturnType<typeof setTimeout> | null = null
@@ -23,7 +22,7 @@ export default function useCacheStoreUpdate<StoreProps extends object>(
       const update = { ...prev, ...func(prev) }
 
       storeTimer = setTimeout(() => {
-        if (!options?.disableCache) storeSessionValue('examination-store', { ...update })
+        if (!options?.disableCache) storeSessionValue(cache_key, { ...update })
       }, debounceTime)
 
       return update

--- a/src/hooks/Shared/useCacheStoreUpdate.ts
+++ b/src/hooks/Shared/useCacheStoreUpdate.ts
@@ -1,11 +1,16 @@
 import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
+import { CreateStoreOptions } from '@/types/Shared/CreateStoreType'
 
 /**
  * This hook takes in the 'set' function that updates the state of a given store and exposes a 'modify' function that will update the store-state just like the set function, but will also cache the updated-state using the sessionStorage after a debounceTime [default: 150ms]
  * @param set The function used to update a given store's state
  * @param debounceTime The time after which a state-update will be cached - to eliminate rapid changes e.g. after each key-stroke
  */
-export default function useCacheStoreUpdate<StoreProps extends object>(set: (updater: (prev: StoreProps) => StoreProps | Partial<StoreProps>) => void, debounceTime = 150) {
+export default function useCacheStoreUpdate<StoreProps extends object>(
+  set: (updater: (prev: StoreProps) => StoreProps | Partial<StoreProps>) => void,
+  debounceTime = 150,
+  options?: CreateStoreOptions,
+) {
   const { storeSessionValue } = useSessionStorageContext()
   let storeTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -18,7 +23,7 @@ export default function useCacheStoreUpdate<StoreProps extends object>(set: (upd
       const update = { ...prev, ...func(prev) }
 
       storeTimer = setTimeout(() => {
-        storeSessionValue('examination-store', { ...update })
+        if (!options?.disableCache) storeSessionValue('examination-store', { ...update })
       }, debounceTime)
 
       return update

--- a/src/hooks/checks/[share_token]/ExaminationStore.ts
+++ b/src/hooks/checks/[share_token]/ExaminationStore.ts
@@ -2,6 +2,7 @@ import useCacheStoreUpdate from '@/src/hooks/Shared/useCacheStoreUpdate'
 import { initializeExaminationResults } from '@/src/lib/checks/[share_token]/Examination'
 import { ExaminationSchema, instantiateExaminationSchema } from '@/src/schemas/ExaminationSchema'
 import { instantiateKnowledgeCheck } from '@/src/schemas/KnowledgeCheck'
+import { CreateStoreType } from '@/types/Shared/CreateStoreType'
 import _ from 'lodash'
 import { createStore } from 'zustand/vanilla'
 
@@ -27,7 +28,7 @@ const defaultInitState: ExaminationState = {
   isLastQuestion: false,
 }
 
-export const createExaminationStore = (initialState: ExaminationState = defaultInitState) => {
+export const createExaminationStore: CreateStoreType<ExaminationState> = (initialState = defaultInitState, options) => {
   return createStore<ExaminationStore>()((set) => {
     const { modify: modifyState } = useCacheStoreUpdate(set)
 

--- a/src/hooks/checks/[share_token]/ExaminationStore.ts
+++ b/src/hooks/checks/[share_token]/ExaminationStore.ts
@@ -30,7 +30,7 @@ const defaultInitState: ExaminationState = {
 
 export const createExaminationStore: CreateStoreType<ExaminationState> = (initialState = defaultInitState, options) => {
   return createStore<ExaminationStore>()((set) => {
-    const { modify: modifyState } = useCacheStoreUpdate(set)
+    const { modify: modifyState } = useCacheStoreUpdate(set, { options, cache_key: 'examination-store' })
 
     return {
       ...initialState,

--- a/src/hooks/checks/create/CreateCheckStore.ts
+++ b/src/hooks/checks/create/CreateCheckStore.ts
@@ -1,6 +1,7 @@
 import { KnowledgeCheck } from '@/schemas/KnowledgeCheck'
 import { Question } from '@/schemas/QuestionSchema'
 import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
+import { CreateStoreType } from '@/types/Shared/CreateStoreType'
 import { isEqual } from 'lodash'
 import { v4 as uuid } from 'uuid'
 import { createStore } from 'zustand/vanilla'
@@ -39,7 +40,7 @@ const defaultInitState: CreateCheckState = {
   unsavedChanges: false,
 }
 
-export const createCheckCreateStore = (initialState: CreateCheckState = defaultInitState) => {
+export const createCheckCreateStore: CreateStoreType<CreateCheckState> = (initialState = defaultInitState, options) => {
   return createStore<CreateCheckStore>()((set) => {
     const { storeSessionValue } = useSessionStorageContext()
 

--- a/src/hooks/checks/create/CreateCheckStore.ts
+++ b/src/hooks/checks/create/CreateCheckStore.ts
@@ -42,7 +42,7 @@ const defaultInitState: CreateCheckState = {
 
 export const createCheckCreateStore: CreateStoreType<CreateCheckState> = (initialState = defaultInitState, options) => {
   return createStore<CreateCheckStore>()((set) => {
-    const { modify: modifyState } = useCacheStoreUpdate(set, { options, cache_key: 'create-check-store' })
+    const { modify: modifyState } = useCacheStoreUpdate(set, { options, debounceTime: 750, cache_key: 'create-check-store' })
 
     const removeQuestion: CreateCheckActions['removeQuestion'] = (questionId) =>
       modifyState((prev) => {

--- a/src/hooks/checks/create/CreateCheckStore.ts
+++ b/src/hooks/checks/create/CreateCheckStore.ts
@@ -56,7 +56,7 @@ export const createCheckCreateStore: CreateStoreType<CreateCheckState> = (initia
         const update = { ...prev, ...func(prev), unsavedChanges: true }
 
         storeTimer = setTimeout(() => {
-          storeSessionValue('create-check-store', update)
+          if (!options?.disableCache) storeSessionValue('create-check-store', update)
         }, sessionStorageDebounceTime)
 
         return update

--- a/src/hooks/checks/create/CreateCheckStore.ts
+++ b/src/hooks/checks/create/CreateCheckStore.ts
@@ -1,6 +1,6 @@
 import { KnowledgeCheck } from '@/schemas/KnowledgeCheck'
 import { Question } from '@/schemas/QuestionSchema'
-import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
+import useCacheStoreUpdate from '@/src/hooks/Shared/useCacheStoreUpdate'
 import { CreateStoreType } from '@/types/Shared/CreateStoreType'
 import { isEqual } from 'lodash'
 import { v4 as uuid } from 'uuid'
@@ -42,26 +42,7 @@ const defaultInitState: CreateCheckState = {
 
 export const createCheckCreateStore: CreateStoreType<CreateCheckState> = (initialState = defaultInitState, options) => {
   return createStore<CreateCheckStore>()((set) => {
-    const { storeSessionValue } = useSessionStorageContext()
-
-    const sessionStorageDebounceTime = 750
-    let storeTimer: ReturnType<typeof setTimeout> | null = null
-
-    function modifyState(func: (prev: CreateCheckStore) => CreateCheckStore | Partial<CreateCheckStore>) {
-      set((prev) => {
-        if (storeTimer) {
-          clearTimeout(storeTimer)
-        }
-
-        const update = { ...prev, ...func(prev), unsavedChanges: true }
-
-        storeTimer = setTimeout(() => {
-          if (!options?.disableCache) storeSessionValue('create-check-store', update)
-        }, sessionStorageDebounceTime)
-
-        return update
-      })
-    }
+    const { modify: modifyState } = useCacheStoreUpdate(set, { options, cache_key: 'create-check-store' })
 
     const removeQuestion: CreateCheckActions['removeQuestion'] = (questionId) =>
       modifyState((prev) => {
@@ -73,13 +54,14 @@ export const createCheckCreateStore: CreateStoreType<CreateCheckState> = (initia
         return {
           questions: prev.questions.filter((question) => question.id !== questionId),
           questionCategories: isCategoryUsed ? prev.questionCategories : prev.questionCategories.filter((cat) => cat.name !== category),
+          unsavedChanges: true,
         }
       })
 
     return {
       ...initialState,
-      setName: (name) => modifyState((prev) => ({ ...prev, name })),
-      setDescription: (description) => modifyState((prev) => ({ ...prev, description })),
+      setName: (name) => modifyState((prev) => ({ ...prev, name, unsavedChanges: true })),
+      setDescription: (description) => modifyState((prev) => ({ ...prev, description, unsavedChanges: true })),
       addQuestion: (question: Question) =>
         modifyState((prev) => {
           const { questionCategories } = prev
@@ -103,7 +85,7 @@ export const createCheckCreateStore: CreateStoreType<CreateCheckState> = (initia
             })
           }
 
-          return { questions: [...prev.questions.filter((q) => question.id !== q.id), question], questionCategories }
+          return { questions: [...prev.questions.filter((q) => question.id !== q.id), question], questionCategories, unsavedChanges: true }
         }),
       removeQuestion,
     }

--- a/types/Shared/CreateStoreType.ts
+++ b/types/Shared/CreateStoreType.ts
@@ -1,10 +1,11 @@
+import { Any } from '@/types'
 import type { StoreApi } from 'zustand/vanilla'
 
 /**
  * Defines how a `createStore` function should look like.
  * It takes an optional initial state and options, and returns a Zustand store API.
  */
-export type CreateStoreType<Store extends object> = (initialState?: Store, options?: CreateStoreOptions) => StoreApi<Store>
+export type CreateStoreType<State extends object, Store extends object = Any> = (initialState?: State, options?: CreateStoreOptions) => StoreApi<Store>
 
 /**
  * Defines what options should be available when creating a store.

--- a/types/Shared/CreateStoreType.ts
+++ b/types/Shared/CreateStoreType.ts
@@ -1,0 +1,12 @@
+import type { StoreApi } from 'zustand/vanilla'
+
+/**
+ * Defines how a `createStore` function should look like.
+ * It takes an optional initial state and options, and returns a Zustand store API.
+ */
+export type CreateStoreType<Store extends object> = (initialState?: Store, options?: CreateStoreOptions) => StoreApi<Store>
+
+/**
+ * Defines what options should be available when creating a store.
+ */
+export type CreateStoreOptions = { disableCache?: boolean }


### PR DESCRIPTION
## Summary 

- Bug Fix
  - Updated the caching of stores to automatically discard their cache when the actual data differs from the cache.
    e.g. in the context of the CreateCheckStore - when the user edits a check the cache will be discarded based on whether both ids match (cache vs. initialProps).

- Features
  - Added `discardCache` argument to `useCacheCreateStore` hook to specify when the cached data should be discarded.
  - Option to disable caching by setting `disableCache` to true, e.g. when re-using a store that would otherwise cache changes.

- Refactor
   - Applied updated `useCacheCreateStore` hook in `CreateCheckProvider` to discard cached data conditionally.
   - Declared `CreateStoreType` that defines how a `createStore` utility function should look like (initialProps, options).
   - Disabled caching of changes within `/edit/[id]` page as it does not require caching.
   - Applied `useCacheStoreUpdate` hook in `CreateCheckStore` to reduce code duplication.
