### PR TITLE
Ref: Update sort-order for /checks and display last update date

### DIFF
--- a/database/knowledgeCheck/select.ts
+++ b/database/knowledgeCheck/select.ts
@@ -68,5 +68,9 @@ function parseKnowledgeCheck(knowledgeCheck: DbKnowledgeCheck, questions: Questi
     closeDate: knowledgeCheck.closeDate ? new Date(Date.parse(knowledgeCheck.closeDate)) : null,
     openDate: new Date(Date.parse(knowledgeCheck.openDate)),
     questionCategories: [],
+
+    createdAt: new Date(Date.parse(knowledgeCheck.createdAt)),
+    updatedAt: new Date(Date.parse(knowledgeCheck.updatedAt)),
+    owner_id: knowledgeCheck.owner_id,
   }
 }

--- a/database/knowledgeCheck/select.ts
+++ b/database/knowledgeCheck/select.ts
@@ -14,7 +14,10 @@ export async function getKnowledgeChecksByOwner(user_id: User['id'], { limit = 1
   const db = await getDatabase()
   const checks: KnowledgeCheck[] = []
 
-  const knowledgeChecks = await db.exec<DbKnowledgeCheck[]>(`SELECT * FROM KnowledgeCheck WHERE owner_id = ? Limit ${limit > 100 ? 100 : limit} OFFSET ?`, [user_id, (offset ?? '0').toString()])
+  const knowledgeChecks = await db.exec<DbKnowledgeCheck[]>(`SELECT * FROM KnowledgeCheck WHERE owner_id = ? Order By updatedAt DESC Limit ${limit > 100 ? 100 : limit} OFFSET ?`, [
+    user_id,
+    (offset ?? '0').toString(),
+  ])
   for (const knowledgeCheck of knowledgeChecks) {
     const questions = await getKnowledgeCheckQuestions(db, knowledgeCheck.id)
     const parsedKnowledgeCheck = parseKnowledgeCheck(knowledgeCheck, questions)

--- a/src/app/checks/create/GeneralSection.tsx
+++ b/src/app/checks/create/GeneralSection.tsx
@@ -32,15 +32,12 @@ export default function GeneralSection() {
           label='Deadline'
           type='date'
           name='check-close-date'
-          defaultValue={
-            closeDate?.toDateString() ||
-            new Date(Date.now())
-              .toLocaleDateString('de')
-              .split('.')
-              .reverse()
-              .map((el) => (el.length < 2 ? '0' + el : el))
-              .join('-')
-          }
+          defaultValue={new Date(closeDate ?? Date.now())
+            .toLocaleDateString('de')
+            .split('.')
+            .reverse()
+            .map((el) => (el.length < 2 ? '0' + el : el))
+            .join('-')}
           className='text-sm text-neutral-500 dark:text-neutral-400 [&::-webkit-calendar-picker-indicator]:brightness-50'
         />
         <InputGroup label='Administrators' name='check-contributors' />

--- a/src/components/check/KnowledgeCheckCard.tsx
+++ b/src/components/check/KnowledgeCheckCard.tsx
@@ -87,7 +87,7 @@ export function KnowledgeCheckCard(check: KnowledgeCheck) {
           </dd>
         </div>
       </div>
-
+      <Footer updatedAt={check.updatedAt} />
       {/* <motion.div className='absolute inset-x-0 bottom-0 z-10 flex justify-center gap-12 rounded-md border-0 bg-white/90 py-3 ring-0 outline-none dark:bg-neutral-900' variants={actionVariants}>
         <Button variant='primary' disabled>
           Exercise
@@ -97,5 +97,13 @@ export function KnowledgeCheckCard(check: KnowledgeCheck) {
         </Button>
       </motion.div> */}
     </motion.a>
+  )
+}
+
+function Footer({ updatedAt }: { updatedAt?: Date }) {
+  return (
+    <div className='-mt-6 -mb-1 flex flex-row-reverse justify-between border-t border-neutral-700 px-4 pt-3 text-xs dark:text-neutral-400/70'>
+      <div>last modified: {updatedAt ? new Date(updatedAt).toLocaleDateString('de', { year: '2-digit', month: '2-digit', day: '2-digit' }) : 'N/A'}</div>
+    </div>
   )
 }

--- a/src/schemas/KnowledgeCheck.ts
+++ b/src/schemas/KnowledgeCheck.ts
@@ -1,5 +1,6 @@
 import { schemaUtilities } from '@/schemas/utils/schemaUtilities'
 import { CategorySchema } from '@/src/schemas/CategorySchema'
+import { StringDate } from '@/src/schemas/CustomZodTypes'
 import { QuestionSchema } from '@/src/schemas/QuestionSchema'
 import { lorem } from 'next/dist/client/components/react-dev-overlay/ui/utils/lorem'
 import { z } from 'zod'
@@ -43,6 +44,10 @@ export const KnowledgeCheckSchema = z
       .transform((date) => (typeof date === 'string' ? new Date(date) : date))
       .refine((check) => !isNaN(check.getTime()), 'Invalid date value provided')
       .nullable(),
+
+    createdAt: StringDate.default(new Date(Date.now())).optional(),
+    updatedAt: StringDate.default(new Date(Date.now())).optional(),
+    owner_id: z.string().optional(),
 
     /* todo:
       - question-order: 'shuffle, static, ...'


### PR DESCRIPTION
## Summary 

* New Features
  * Added a “Last modified” footer on knowledge check cards, showing the most recent update date.
  * Knowledge checks are now listed with the most recently updated first for easier access to recent work.

* Refactor
  * Updated the `KnowledgeCheck` schema to include the `createdAt`, `updatedAt`and `owner_id` properties.
  * Fixed an issue when rendering the closeDate property, when the date was converted to a string internally the previous implementation caused a Runtime error. 
