### PR TITLE
Ref: De-duplicate bodies of create and edit pages 

### DIFF
--- a/src/app/checks/create/GeneralSection.tsx
+++ b/src/app/checks/create/GeneralSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCreateCheckStore } from '@/src/components/check/create/CreateCheckProvider'
+import { useCheckStore } from '@/src/components/check/create/CreateCheckProvider'
 import Card from '@/src/components/Shared/Card'
 import Input from '@/src/components/Shared/form/Input'
 import { Textarea } from '@headlessui/react'
@@ -8,7 +8,7 @@ import { ComponentType, InputHTMLAttributes } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 export default function GeneralSection() {
-  const { setName, setDescription, name, description, closeDate } = useCreateCheckStore((state) => state)
+  const { setName, setDescription, name, description, closeDate } = useCheckStore((state) => state)
 
   return (
     <Card className='@container flex flex-col gap-8 p-3' disableHoverStyles>

--- a/src/app/checks/create/QuestionsSection.tsx
+++ b/src/app/checks/create/QuestionsSection.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useCreateCheckStore } from '@/components/check/create/CreateCheckProvider'
+import { useCheckStore } from '@/components/check/create/CreateCheckProvider'
 import Card from '@/components/Shared/Card'
 import { cn } from '@/lib/Shared/utils'
 import CreateQuestionDialog from '@/src/components/check/create/(create-question)/CreateQuestionDialog'
 import { Button } from '@/src/components/shadcn/button'
 import { Folder, Info, Pen, Plus, Trash2 } from 'lucide-react'
 export default function QuestionsSection() {
-  const { questions, removeQuestion } = useCreateCheckStore((state) => state)
+  const { questions, removeQuestion } = useCheckStore((state) => state)
 
   return (
     <Card disableHoverStyles className='question-section break-inside-avoid'>

--- a/src/app/checks/create/SaveCheckButton.tsx
+++ b/src/app/checks/create/SaveCheckButton.tsx
@@ -29,14 +29,15 @@ export function SaveCheckButton({ cacheKey }: { cacheKey?: string }) {
       formAction={() =>
         saveAction({ check }).catch((e) => {
           if (isRedirectError(e)) {
-            const hasCache = !!sessionStorage.getItem(cacheKey ?? 'check-store')
+            const key = cacheKey ?? 'check-store'
+            const hasCache = !!sessionStorage.getItem(key)
 
-            if (!hasCache) {
-              console.debug(`[SaveCheckButton]: No cached data was found for cacheKey: ${cacheKey}.`)
-              return
+            if (hasCache) {
+              sessionStorage.removeItem(key)
+            } else {
+              console.debug(`[SaveCheckButton]: No cached data was found for cacheKey: ${key}.`)
             }
 
-            sessionStorage.removeItem(cacheKey ?? 'check-store')
             clearNavigationAbort()
           }
         })

--- a/src/app/checks/create/SaveCheckButton.tsx
+++ b/src/app/checks/create/SaveCheckButton.tsx
@@ -1,14 +1,14 @@
 'use client'
 
 import { saveAction } from '@/src/app/checks/create/SaveAction'
-import { useCreateCheckStore } from '@/src/components/check/create/CreateCheckProvider'
+import { useCheckStore } from '@/src/components/check/create/CreateCheckProvider'
 import { useNavigationAbort } from '@/src/components/navigation-abortion/NavigationAbortProvider'
 import { Button } from '@/src/components/shadcn/button'
 import { KnowledgeCheck } from '@/src/schemas/KnowledgeCheck'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
 
 export function SaveCreateCheckButton() {
-  const store = useCreateCheckStore((store) => store)
+  const store = useCheckStore((store) => store)
   const { clearNavigationAbort } = useNavigationAbort()
   const check: KnowledgeCheck = {
     id: store.id,

--- a/src/app/checks/create/SaveCheckButton.tsx
+++ b/src/app/checks/create/SaveCheckButton.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/src/components/shadcn/button'
 import { KnowledgeCheck } from '@/src/schemas/KnowledgeCheck'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
 
-export function SaveCheckButton() {
+export function SaveCheckButton({ cacheKey }: { cacheKey?: string }) {
   const store = useCheckStore((store) => store)
   const { clearNavigationAbort } = useNavigationAbort()
   const check: KnowledgeCheck = {
@@ -29,7 +29,7 @@ export function SaveCheckButton() {
       formAction={() =>
         saveAction({ check }).catch((e) => {
           if (isRedirectError(e)) {
-            sessionStorage.removeItem('create-check-store')
+            sessionStorage.removeItem(cacheKey ?? 'check-store')
             clearNavigationAbort()
           }
         })

--- a/src/app/checks/create/SaveCheckButton.tsx
+++ b/src/app/checks/create/SaveCheckButton.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/src/components/shadcn/button'
 import { KnowledgeCheck } from '@/src/schemas/KnowledgeCheck'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
 
-export function SaveCreateCheckButton() {
+export function SaveCheckButton() {
   const store = useCheckStore((store) => store)
   const { clearNavigationAbort } = useNavigationAbort()
   const check: KnowledgeCheck = {
@@ -24,7 +24,7 @@ export function SaveCreateCheckButton() {
 
   return (
     <Button
-      aria-label='save created knowledge check'
+      aria-label='save knowledge check'
       type='submit'
       formAction={() =>
         saveAction({ check }).catch((e) => {

--- a/src/app/checks/create/SaveCheckButton.tsx
+++ b/src/app/checks/create/SaveCheckButton.tsx
@@ -29,6 +29,13 @@ export function SaveCheckButton({ cacheKey }: { cacheKey?: string }) {
       formAction={() =>
         saveAction({ check }).catch((e) => {
           if (isRedirectError(e)) {
+            const hasCache = !!sessionStorage.getItem(cacheKey ?? 'check-store')
+
+            if (!hasCache) {
+              console.debug(`[SaveCheckButton]: No cached data was found for cacheKey: ${cacheKey}.`)
+              return
+            }
+
             sessionStorage.removeItem(cacheKey ?? 'check-store')
             clearNavigationAbort()
           }

--- a/src/app/checks/create/SettingsSection.tsx
+++ b/src/app/checks/create/SettingsSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { InputGroup } from '@/src/app/checks/create/GeneralSection'
-import { useCreateCheckStore } from '@/src/components/check/create/CreateCheckProvider'
+import { useCheckStore } from '@/src/components/check/create/CreateCheckProvider'
 import Card from '@/src/components/Shared/Card'
 import { TabButton } from '@/src/components/Shared/tabs/TabButton'
 import { TabsContentPanel } from '@/src/components/Shared/tabs/TabsContentPanel'
@@ -17,7 +17,7 @@ const tabs = [
   { name: 'Sharing', icon: UsersIcon },
 ]
 export default function SettingsSection() {
-  const {} = useCreateCheckStore((state) => state)
+  const {} = useCheckStore((state) => state)
 
   return (
     <Card className='@container flex break-inside-avoid-column flex-col gap-8 p-3' disableHoverStyles>

--- a/src/app/checks/create/page.tsx
+++ b/src/app/checks/create/page.tsx
@@ -4,7 +4,7 @@ import Card from '@/components/Shared/Card'
 import PageHeading from '@/components/Shared/PageHeading'
 import insertKnowledgeCheck from '@/database/knowledgeCheck/insert'
 import GeneralSection from '@/src/app/checks/create/GeneralSection'
-import { SaveCreateCheckButton } from '@/src/app/checks/create/SaveCheckButton'
+import { SaveCheckButton } from '@/src/app/checks/create/SaveCheckButton'
 import SettingsSection from '@/src/app/checks/create/SettingsSection'
 import { Button } from '@/src/components/shadcn/button'
 import requireAuthentication from '@/src/lib/auth/requireAuthentication'
@@ -118,7 +118,7 @@ export default async function CreateCheckPage() {
         <Card className='h-60 break-inside-avoid' disableHoverStyles children={undefined} />
       </div>
       <form className='mt-4 flex justify-center gap-4'>
-        <SaveCreateCheckButton />
+        <SaveCheckButton />
         <Button variant='primary' className='' formAction={createDummyCheckAction}>
           Create Dummy Check
         </Button>

--- a/src/app/checks/create/page.tsx
+++ b/src/app/checks/create/page.tsx
@@ -1,5 +1,5 @@
 import QuestionsSection from '@/app/checks/create/QuestionsSection'
-import { CreateCheckStoreProvider } from '@/components/check/create/CreateCheckProvider'
+import { CheckStoreProvider } from '@/components/check/create/CreateCheckProvider'
 import Card from '@/components/Shared/Card'
 import PageHeading from '@/components/Shared/PageHeading'
 import insertKnowledgeCheck from '@/database/knowledgeCheck/insert'
@@ -82,8 +82,34 @@ export default async function CreateCheckPage() {
     redirect('/checks')
   }
 
+  /*
+   ...  function ({}: {mode: 'create' | 'edit' })
+  ...
+
   return (
-    <CreateCheckStoreProvider>
+    <CheckStoreProvider>
+      <PageHeading title={`${mode === 'create' ? "Create KnowledgeCheck" : check.title} `}/>
+
+      <div className='grid grid-cols-1 gap-8 lg:grid-cols-[repeat(auto-fill,minmax(680px,1fr))]'>
+        <GeneralSection />
+        <QuestionsSection />
+        <SettingsSection />
+        <Card className='h-60 break-inside-avoid' disableHoverStyles children={undefined} />
+      </div>
+      <form className='mt-4 flex justify-center gap-4'>
+        <SaveCreateCheckButton />
+        <Button variant='primary' className='' formAction={createDummyCheckAction}>
+          Create Dummy Check
+        </Button>
+      </form>
+      <div />
+    </CheckStoreProvider>
+  )
+
+*/
+
+  return (
+    <CheckStoreProvider>
       <PageHeading title='Create KnowledgeCheck' />
       <div className='grid grid-cols-1 gap-8 lg:grid-cols-[repeat(auto-fill,minmax(680px,1fr))]'>
         <GeneralSection />
@@ -98,6 +124,6 @@ export default async function CreateCheckPage() {
         </Button>
       </form>
       <div />
-    </CreateCheckStoreProvider>
+    </CheckStoreProvider>
   )
 }

--- a/src/app/checks/create/page.tsx
+++ b/src/app/checks/create/page.tsx
@@ -1,12 +1,5 @@
-import QuestionsSection from '@/app/checks/create/QuestionsSection'
-import { CheckStoreProvider } from '@/components/check/create/CreateCheckProvider'
-import Card from '@/components/Shared/Card'
-import PageHeading from '@/components/Shared/PageHeading'
 import insertKnowledgeCheck from '@/database/knowledgeCheck/insert'
-import GeneralSection from '@/src/app/checks/create/GeneralSection'
-import { SaveCheckButton } from '@/src/app/checks/create/SaveCheckButton'
-import SettingsSection from '@/src/app/checks/create/SettingsSection'
-import { Button } from '@/src/components/shadcn/button'
+import { ConfigureKnowledgeCheck } from '@/src/components/check/ConfigureKnowledgeCheck'
 import requireAuthentication from '@/src/lib/auth/requireAuthentication'
 import { getUUID } from '@/src/lib/Shared/getUUID'
 import { lorem } from 'next/dist/client/components/react-dev-overlay/ui/utils/lorem'
@@ -82,48 +75,5 @@ export default async function CreateCheckPage() {
     redirect('/checks')
   }
 
-  /*
-   ...  function ({}: {mode: 'create' | 'edit' })
-  ...
-
-  return (
-    <CheckStoreProvider>
-      <PageHeading title={`${mode === 'create' ? "Create KnowledgeCheck" : check.title} `}/>
-
-      <div className='grid grid-cols-1 gap-8 lg:grid-cols-[repeat(auto-fill,minmax(680px,1fr))]'>
-        <GeneralSection />
-        <QuestionsSection />
-        <SettingsSection />
-        <Card className='h-60 break-inside-avoid' disableHoverStyles children={undefined} />
-      </div>
-      <form className='mt-4 flex justify-center gap-4'>
-        <SaveCreateCheckButton />
-        <Button variant='primary' className='' formAction={createDummyCheckAction}>
-          Create Dummy Check
-        </Button>
-      </form>
-      <div />
-    </CheckStoreProvider>
-  )
-
-*/
-
-  return (
-    <CheckStoreProvider>
-      <PageHeading title='Create KnowledgeCheck' />
-      <div className='grid grid-cols-1 gap-8 lg:grid-cols-[repeat(auto-fill,minmax(680px,1fr))]'>
-        <GeneralSection />
-        <QuestionsSection />
-        <SettingsSection />
-        <Card className='h-60 break-inside-avoid' disableHoverStyles children={undefined} />
-      </div>
-      <form className='mt-4 flex justify-center gap-4'>
-        <SaveCheckButton />
-        <Button variant='primary' className='' formAction={createDummyCheckAction}>
-          Create Dummy Check
-        </Button>
-      </form>
-      <div />
-    </CheckStoreProvider>
-  )
+  return <ConfigureKnowledgeCheck mode='create' />
 }

--- a/src/app/checks/edit/[id]/page.tsx
+++ b/src/app/checks/edit/[id]/page.tsx
@@ -3,7 +3,7 @@ import GeneralSection from '@/src/app/checks/create/GeneralSection'
 import QuestionsSection from '@/src/app/checks/create/QuestionsSection'
 import { SaveCreateCheckButton } from '@/src/app/checks/create/SaveCheckButton'
 import SettingsSection from '@/src/app/checks/create/SettingsSection'
-import { CreateCheckStoreProvider } from '@/src/components/check/create/CreateCheckProvider'
+import { CheckStoreProvider } from '@/src/components/check/create/CreateCheckProvider'
 import Card from '@/src/components/Shared/Card'
 import PageHeading from '@/src/components/Shared/PageHeading'
 import requireAuthentication from '@/src/lib/auth/requireAuthentication'
@@ -20,7 +20,7 @@ export default async function CheckPage({ params }: { params: Promise<{ id: stri
   }
 
   return (
-    <CreateCheckStoreProvider initialStoreProps={check} options={{ disableCache: true }}>
+    <CheckStoreProvider initialStoreProps={check} options={{ disableCache: true }}>
       <PageHeading title={check.name} />
       <div className='grid grid-cols-1 gap-8 lg:grid-cols-[repeat(auto-fill,minmax(680px,1fr))]'>
         <GeneralSection />
@@ -32,6 +32,6 @@ export default async function CheckPage({ params }: { params: Promise<{ id: stri
         <SaveCreateCheckButton />
       </form>
       <div />
-    </CreateCheckStoreProvider>
+    </CheckStoreProvider>
   )
 }

--- a/src/app/checks/edit/[id]/page.tsx
+++ b/src/app/checks/edit/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { getKnowledgeCheckById } from '@/database/knowledgeCheck/select'
 import GeneralSection from '@/src/app/checks/create/GeneralSection'
 import QuestionsSection from '@/src/app/checks/create/QuestionsSection'
-import { SaveCreateCheckButton } from '@/src/app/checks/create/SaveCheckButton'
+import { SaveCheckButton } from '@/src/app/checks/create/SaveCheckButton'
 import SettingsSection from '@/src/app/checks/create/SettingsSection'
 import { CheckStoreProvider } from '@/src/components/check/create/CreateCheckProvider'
 import Card from '@/src/components/Shared/Card'
@@ -29,7 +29,7 @@ export default async function CheckPage({ params }: { params: Promise<{ id: stri
         <Card className='h-60 break-inside-avoid' children={<></>} disableHoverStyles></Card>
       </div>
       <form className='mt-4 flex justify-center gap-2'>
-        <SaveCreateCheckButton />
+        <SaveCheckButton />
       </form>
       <div />
     </CheckStoreProvider>

--- a/src/app/checks/edit/[id]/page.tsx
+++ b/src/app/checks/edit/[id]/page.tsx
@@ -1,11 +1,5 @@
 import { getKnowledgeCheckById } from '@/database/knowledgeCheck/select'
-import GeneralSection from '@/src/app/checks/create/GeneralSection'
-import QuestionsSection from '@/src/app/checks/create/QuestionsSection'
-import { SaveCheckButton } from '@/src/app/checks/create/SaveCheckButton'
-import SettingsSection from '@/src/app/checks/create/SettingsSection'
-import { CheckStoreProvider } from '@/src/components/check/create/CreateCheckProvider'
-import Card from '@/src/components/Shared/Card'
-import PageHeading from '@/src/components/Shared/PageHeading'
+import { ConfigureKnowledgeCheck } from '@/src/components/check/ConfigureKnowledgeCheck'
 import requireAuthentication from '@/src/lib/auth/requireAuthentication'
 import { notFound } from 'next/navigation'
 
@@ -19,19 +13,5 @@ export default async function CheckPage({ params }: { params: Promise<{ id: stri
     notFound()
   }
 
-  return (
-    <CheckStoreProvider initialStoreProps={check} options={{ disableCache: true }}>
-      <PageHeading title={check.name} />
-      <div className='grid grid-cols-1 gap-8 lg:grid-cols-[repeat(auto-fill,minmax(680px,1fr))]'>
-        <GeneralSection />
-        <QuestionsSection />
-        <SettingsSection />
-        <Card className='h-60 break-inside-avoid' children={<></>} disableHoverStyles></Card>
-      </div>
-      <form className='mt-4 flex justify-center gap-2'>
-        <SaveCheckButton />
-      </form>
-      <div />
-    </CheckStoreProvider>
-  )
+  return <ConfigureKnowledgeCheck mode='edit' initialStoreProps={check} options={{ disableCache: true }} />
 }

--- a/src/components/check/ConfigureKnowledgeCheck.tsx
+++ b/src/components/check/ConfigureKnowledgeCheck.tsx
@@ -2,8 +2,12 @@ import GeneralSection from '@/src/app/checks/create/GeneralSection'
 import QuestionsSection from '@/src/app/checks/create/QuestionsSection'
 import { SaveCheckButton } from '@/src/app/checks/create/SaveCheckButton'
 import SettingsSection from '@/src/app/checks/create/SettingsSection'
+import { OverviewSection } from '@/src/components/check/create/(sections)/OverviewSection'
 import { CheckStoreProvider, CheckStoreProviderProps } from '@/src/components/check/create/CreateCheckProvider'
-import Card from '@/src/components/Shared/Card'
+import { MultiStageBackButton, MultiStageNextButton } from '@/src/components/Shared/MultiStageProgress/MultiStageNavigationButtons'
+import { MultiStageProgressBar } from '@/src/components/Shared/MultiStageProgress/MultiStageProgressBar'
+import { MultiStageStoreProvider } from '@/src/components/Shared/MultiStageProgress/MultiStageStoreProvider'
+import { MutliStageRenderer } from '@/src/components/Shared/MultiStageProgress/MutliStageRenderer'
 import PageHeading from '@/src/components/Shared/PageHeading'
 
 type CreateProps = Pick<CheckStoreProviderProps, 'options' | 'initialStoreProps'> & {
@@ -18,17 +22,45 @@ type EditProps = Required<Pick<CheckStoreProviderProps, 'initialStoreProps'>> &
 export function ConfigureKnowledgeCheck({ mode, initialStoreProps, options }: CreateProps | EditProps = { mode: 'create' }) {
   return (
     <CheckStoreProvider initialStoreProps={initialStoreProps} options={options}>
-      <PageHeading title={`${mode === 'create' ? 'Create KnowledgeCheck' : initialStoreProps.name}`} />
-      <div className='grid grid-cols-1 gap-8 lg:grid-cols-[repeat(auto-fill,minmax(680px,1fr))]'>
-        <GeneralSection />
-        <QuestionsSection />
-        <SettingsSection />
-        <Card className='h-60 break-inside-avoid' disableHoverStyles children={undefined} />
-      </div>
-      <form className='mt-4 flex justify-center gap-4'>
-        <SaveCheckButton cacheKey={options?.cacheKey} />
-      </form>
-      <div />
+      <MultiStageStoreProvider
+        initialStoreProps={{
+          stages: [
+            { stage: 1, title: 'Basic Information' },
+            { stage: 2, title: 'Questions' },
+            { stage: 3, title: 'Settings' },
+            { stage: 4, title: 'Conclusion' },
+          ],
+        }}>
+        <PageHeading title={`${mode === 'create' ? 'Create KnowledgeCheck' : initialStoreProps.name}`} />
+        <MultiStageProgressBar className='-mt-2 mb-12' />
+
+        <div className='mx-[1.5%] grid grid-cols-1 gap-8'>
+          <MutliStageRenderer stage={1}>
+            <GeneralSection />
+          </MutliStageRenderer>
+          <MutliStageRenderer stage={2}>
+            <QuestionsSection />
+          </MutliStageRenderer>
+
+          <MutliStageRenderer stage={3}>
+            <SettingsSection />
+          </MutliStageRenderer>
+
+          <MutliStageRenderer stage={4}>
+            <OverviewSection />
+          </MutliStageRenderer>
+        </div>
+        <div className='mx-[1.5%] mt-4 flex justify-between'>
+          <MultiStageBackButton variant='outline' children='Back' />
+          <MultiStageNextButton variant='primary' children='Next' />
+        </div>
+        <MutliStageRenderer stage={4}>
+          <form className='mt-4 flex justify-center gap-4'>
+            <SaveCheckButton />
+          </form>
+        </MutliStageRenderer>
+        <div />
+      </MultiStageStoreProvider>
     </CheckStoreProvider>
   )
 }

--- a/src/components/check/ConfigureKnowledgeCheck.tsx
+++ b/src/components/check/ConfigureKnowledgeCheck.tsx
@@ -17,7 +17,7 @@ type EditProps = Required<Pick<CheckStoreProviderProps, 'initialStoreProps'>> &
 
 export function ConfigureKnowledgeCheck({ mode, initialStoreProps, options }: CreateProps | EditProps = { mode: 'create' }) {
   return (
-    <CheckStoreProvider>
+    <CheckStoreProvider initialStoreProps={initialStoreProps} options={options}>
       <PageHeading title={`${mode === 'create' ? 'Create KnowledgeCheck' : initialStoreProps.name}`} />
       <div className='grid grid-cols-1 gap-8 lg:grid-cols-[repeat(auto-fill,minmax(680px,1fr))]'>
         <GeneralSection />

--- a/src/components/check/ConfigureKnowledgeCheck.tsx
+++ b/src/components/check/ConfigureKnowledgeCheck.tsx
@@ -1,0 +1,34 @@
+import GeneralSection from '@/src/app/checks/create/GeneralSection'
+import QuestionsSection from '@/src/app/checks/create/QuestionsSection'
+import { SaveCheckButton } from '@/src/app/checks/create/SaveCheckButton'
+import SettingsSection from '@/src/app/checks/create/SettingsSection'
+import { CheckStoreProvider, CheckStoreProviderProps } from '@/src/components/check/create/CreateCheckProvider'
+import Card from '@/src/components/Shared/Card'
+import PageHeading from '@/src/components/Shared/PageHeading'
+
+type CreateProps = Pick<CheckStoreProviderProps, 'options' | 'initialStoreProps'> & {
+  mode: 'create'
+}
+
+type EditProps = Required<Pick<CheckStoreProviderProps, 'initialStoreProps'>> &
+  Pick<CheckStoreProviderProps, 'options'> & {
+    mode: 'edit'
+  }
+
+export function ConfigureKnowledgeCheck({ mode, initialStoreProps, options }: CreateProps | EditProps = { mode: 'create' }) {
+  return (
+    <CheckStoreProvider>
+      <PageHeading title={`${mode === 'create' ? 'Create KnowledgeCheck' : initialStoreProps.name}`} />
+      <div className='grid grid-cols-1 gap-8 lg:grid-cols-[repeat(auto-fill,minmax(680px,1fr))]'>
+        <GeneralSection />
+        <QuestionsSection />
+        <SettingsSection />
+        <Card className='h-60 break-inside-avoid' disableHoverStyles children={undefined} />
+      </div>
+      <form className='mt-4 flex justify-center gap-4'>
+        <SaveCheckButton cacheKey={options?.cacheKey} />
+      </form>
+      <div />
+    </CheckStoreProvider>
+  )
+}

--- a/src/components/check/create/(create-question)/CreateQuestionDialog.tsx
+++ b/src/components/check/create/(create-question)/CreateQuestionDialog.tsx
@@ -1,4 +1,4 @@
-import { useCreateCheckStore } from '@/components/check/create/CreateCheckProvider'
+import { useCheckStore } from '@/components/check/create/CreateCheckProvider'
 import { Button } from '@/src/components/shadcn/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/src/components/Shared/Dialog'
 import FieldError from '@/src/components/Shared/form/FormFieldError'
@@ -15,7 +15,7 @@ import { FormState, useFieldArray, UseFieldArrayReturn, useForm, UseFormReturn }
 import { twMerge } from 'tailwind-merge'
 export default function CreateQuestionDialog({ children, initialValues }: { children: ReactNode; initialValues?: Partial<Question> & Pick<Question, 'id'> }) {
   const [dialogOpenState, setDialogOpenState] = useState<boolean>(false)
-  const { addQuestion, questionCategories } = useCreateCheckStore((state) => state)
+  const { addQuestion, questionCategories } = useCheckStore((state) => state)
 
   const getDefaultValues = (type: Question['type']): Partial<Question> & Pick<Question, 'id'> => {
     const baseValues: Partial<Pick<Question, 'category' | 'points' | 'question'>> & Pick<Question, 'id'> = {

--- a/src/components/check/create/CreateCheckProvider.tsx
+++ b/src/components/check/create/CreateCheckProvider.tsx
@@ -1,23 +1,23 @@
 'use client'
 
-import { createCheckCreateStore, CreateCheckState, CreateCheckStore } from '@/hooks/checks/create/CreateCheckStore'
+import { CheckState, CheckStore, createCheckStore } from '@/hooks/checks/create/CreateCheckStore'
 import UnsavedCheckChangesAlert from '@/src/components/check/create/UnsavedCheckChangesAlert'
 import useCacheCreateStore, { useCacheCreateStoreOptions } from '@/src/hooks/Shared/useCacheCreateStore'
 import { createContext, type ReactNode, useContext } from 'react'
 import { useStore } from 'zustand'
 
-export type CreateCheckStoreApi = ReturnType<typeof createCheckCreateStore>
+export type CheckStoreApi = ReturnType<typeof createCheckStore>
 
-const CreateCheckStoreContext = createContext<CreateCheckStoreApi | undefined>(undefined)
+const CheckStoreContext = createContext<CheckStoreApi | undefined>(undefined)
 
-export interface CreateCheckStoreProviderProps {
+export interface CheckStoreProviderProps {
   children: ReactNode
-  initialStoreProps?: CreateCheckState
-  options?: useCacheCreateStoreOptions<CreateCheckState>
+  initialStoreProps?: CheckState
+  options?: useCacheCreateStoreOptions<CheckState>
 }
 
-export function CreateCheckStoreProvider({ children, initialStoreProps, options }: CreateCheckStoreProviderProps) {
-  const props = useCacheCreateStore<CreateCheckState>('create-check-store', createCheckCreateStore, initialStoreProps, {
+export function CheckStoreProvider({ children, initialStoreProps, options }: CheckStoreProviderProps) {
+  const props = useCacheCreateStore<CheckState>('check-store', createCheckStore, initialStoreProps, {
     //? discard cache when cached check-id truly differs from the initialStore-id (because ids are constants)
     //? drafted checks may not be discarded when they were either not yet cached or when no initialProps were provided (thus indicating that a new check is being created)
     discardCache: (cache) => cache?.id !== undefined && initialStoreProps?.id !== undefined && cache?.id !== initialStoreProps?.id,
@@ -25,18 +25,18 @@ export function CreateCheckStoreProvider({ children, initialStoreProps, options 
   })
 
   return (
-    <CreateCheckStoreContext.Provider value={props}>
+    <CheckStoreContext.Provider value={props}>
       <UnsavedCheckChangesAlert />
       {children}
-    </CreateCheckStoreContext.Provider>
+    </CheckStoreContext.Provider>
   )
 }
 
-export function useCreateCheckStore<T>(selector: (store: CreateCheckStore) => T): T {
-  const counterStoreContext = useContext(CreateCheckStoreContext)
+export function useCheckStore<T>(selector: (store: CheckStore) => T): T {
+  const counterStoreContext = useContext(CheckStoreContext)
 
   if (!counterStoreContext) {
-    throw new Error(`useCreateCheckStore must be used within CreateCheckStoreProvider`)
+    throw new Error(`useCheckStore must be used within CheckStoreProvider`)
   }
 
   return useStore(counterStoreContext, selector)

--- a/src/components/check/create/CreateCheckProvider.tsx
+++ b/src/components/check/create/CreateCheckProvider.tsx
@@ -17,7 +17,7 @@ export interface CheckStoreProviderProps {
 }
 
 export function CheckStoreProvider({ children, initialStoreProps, options }: CheckStoreProviderProps) {
-  const props = useCacheCreateStore<CheckState>('check-store', createCheckStore, initialStoreProps, {
+  const props = useCacheCreateStore<CheckState>(options?.cacheKey ?? 'check-store', createCheckStore, initialStoreProps, {
     //? discard cache when cached check-id truly differs from the initialStore-id (because ids are constants)
     //? drafted checks may not be discarded when they were either not yet cached or when no initialProps were provided (thus indicating that a new check is being created)
     discardCache: (cache) => cache?.id !== undefined && initialStoreProps?.id !== undefined && cache?.id !== initialStoreProps?.id,

--- a/src/components/check/create/UnsavedCheckChangesAlert.tsx
+++ b/src/components/check/create/UnsavedCheckChangesAlert.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useCreateCheckStore } from '@/src/components/check/create/CreateCheckProvider'
+import { useCheckStore } from '@/src/components/check/create/CreateCheckProvider'
 import { useNavigationAbort } from '@/src/components/navigation-abortion/NavigationAbortProvider'
 import { useEffect } from 'react'
 
 export default function UnsavedCheckChangesAlert() {
-  const { unsavedChanges } = useCreateCheckStore((state) => state)
+  const { unsavedChanges } = useCheckStore((state) => state)
   const { enableNavigationAbort } = useNavigationAbort()
 
   useEffect(() => {

--- a/src/components/checks/[share_token]/ExaminationStoreProvider.tsx
+++ b/src/components/checks/[share_token]/ExaminationStoreProvider.tsx
@@ -17,7 +17,7 @@ export interface ExaminationStoreProviderProps {
 
 export function ExaminationStoreProvider({ children, initialStoreProps, options }: ExaminationStoreProviderProps) {
   //todo consider switching to localStorage to ensure that users do not loose their progress e.g. when their browser / system crashes
-  const props = useCacheCreateStore<ExaminationState>('examination-store', createExaminationStore, initialStoreProps, {
+  const props = useCacheCreateStore<ExaminationState>(options?.cacheKey ?? 'examination-store', createExaminationStore, initialStoreProps, {
     expiresAfter: 10 * 60 * 1000,
     discardCache: (cache) => cache?.knowledgeCheck.id !== initialStoreProps?.knowledgeCheck.id,
     ...options,

--- a/src/hooks/checks/[share_token]/ExaminationStore.ts
+++ b/src/hooks/checks/[share_token]/ExaminationStore.ts
@@ -30,7 +30,7 @@ const defaultInitState: ExaminationState = {
 
 export const createExaminationStore: CreateStoreType<ExaminationState> = (initialState = defaultInitState, options) => {
   return createStore<ExaminationStore>()((set) => {
-    const { modify: modifyState } = useCacheStoreUpdate(set, { options, cache_key: 'examination-store' })
+    const { modify: modifyState } = useCacheStoreUpdate(set, { options, cache_key: options?.cacheKey ?? 'examination-store' })
 
     return {
       ...initialState,

--- a/src/hooks/checks/create/CreateCheckStore.ts
+++ b/src/hooks/checks/create/CreateCheckStore.ts
@@ -6,20 +6,20 @@ import { isEqual } from 'lodash'
 import { v4 as uuid } from 'uuid'
 import { createStore } from 'zustand/vanilla'
 
-export type CreateCheckState = KnowledgeCheck & {
+export type CheckState = KnowledgeCheck & {
   unsavedChanges?: boolean
 }
 
-export type CreateCheckActions = {
+export type CheckActions = {
   setName: (name: string) => void
   setDescription: (description: string) => void
   addQuestion: (question: Question) => void
   removeQuestion: (questionId: Question['id']) => void
 }
 
-export type CreateCheckStore = CreateCheckState & CreateCheckActions
+export type CheckStore = CheckState & CheckActions
 
-const defaultInitState: CreateCheckState = {
+const defaultInitState: CheckState = {
   id: uuid(),
   name: '',
   questions: [],
@@ -40,11 +40,11 @@ const defaultInitState: CreateCheckState = {
   unsavedChanges: false,
 }
 
-export const createCheckCreateStore: CreateStoreType<CreateCheckState> = (initialState = defaultInitState, options) => {
-  return createStore<CreateCheckStore>()((set) => {
-    const { modify: modifyState } = useCacheStoreUpdate(set, { options, debounceTime: 750, cache_key: 'create-check-store' })
+export const createCheckStore: CreateStoreType<CheckState> = (initialState = defaultInitState, options) => {
+  return createStore<CheckStore>()((set) => {
+    const { modify: modifyState } = useCacheStoreUpdate(set, { options, debounceTime: 750, cache_key: 'check-store' })
 
-    const removeQuestion: CreateCheckActions['removeQuestion'] = (questionId) =>
+    const removeQuestion: CheckActions['removeQuestion'] = (questionId) =>
       modifyState((prev) => {
         const toRemoveQuestion = prev.questions.find((question) => question.id === questionId)
 

--- a/src/hooks/checks/create/CreateCheckStore.ts
+++ b/src/hooks/checks/create/CreateCheckStore.ts
@@ -42,7 +42,7 @@ const defaultInitState: CheckState = {
 
 export const createCheckStore: CreateStoreType<CheckState> = (initialState = defaultInitState, options) => {
   return createStore<CheckStore>()((set) => {
-    const { modify: modifyState } = useCacheStoreUpdate(set, { options, debounceTime: 750, cache_key: 'check-store' })
+    const { modify: modifyState } = useCacheStoreUpdate(set, { options, debounceTime: 750, cache_key: options?.cacheKey ?? 'check-store' })
 
     const removeQuestion: CheckActions['removeQuestion'] = (questionId) =>
       modifyState((prev) => {

--- a/src/tests/components/checks/create/CreateQuestionDialog.cy.tsx
+++ b/src/tests/components/checks/create/CreateQuestionDialog.cy.tsx
@@ -1,5 +1,5 @@
 import CreateQuestionDialog from '@/src/components/check/create/(create-question)/CreateQuestionDialog'
-import { CreateCheckStoreProvider } from '@/src/components/check/create/CreateCheckProvider'
+import { CheckStoreProvider } from '@/src/components/check/create/CreateCheckProvider'
 import RootProviders from '@/src/components/root/RootProviders'
 
 describe('<CreateQuestionDialog />', () => {
@@ -7,11 +7,11 @@ describe('<CreateQuestionDialog />', () => {
     cy.viewport(800, 980)
     cy.mount(
       <RootProviders>
-        <CreateCheckStoreProvider>
+        <CheckStoreProvider>
           <CreateQuestionDialog>
             <div className='trigger'>Trigger</div>
           </CreateQuestionDialog>
-        </CreateCheckStoreProvider>
+        </CheckStoreProvider>
       </RootProviders>,
     )
 
@@ -27,11 +27,11 @@ describe('<CreateQuestionDialog />', () => {
     cy.viewport(800, 980)
     cy.mount(
       <RootProviders>
-        <CreateCheckStoreProvider>
+        <CheckStoreProvider>
           <CreateQuestionDialog>
             <div className='trigger'>Trigger</div>
           </CreateQuestionDialog>
-        </CreateCheckStoreProvider>
+        </CheckStoreProvider>
       </RootProviders>,
     )
 
@@ -53,11 +53,11 @@ describe('<CreateQuestionDialog />', () => {
     cy.viewport(800, 980)
     cy.mount(
       <RootProviders>
-        <CreateCheckStoreProvider>
+        <CheckStoreProvider>
           <CreateQuestionDialog>
             <div className='trigger'>Trigger</div>
           </CreateQuestionDialog>
-        </CreateCheckStoreProvider>
+        </CheckStoreProvider>
       </RootProviders>,
     )
 
@@ -75,11 +75,11 @@ describe('<CreateQuestionDialog />', () => {
     cy.viewport(800, 980)
     cy.mount(
       <RootProviders>
-        <CreateCheckStoreProvider>
+        <CheckStoreProvider>
           <CreateQuestionDialog>
             <div className='trigger'>Trigger</div>
           </CreateQuestionDialog>
-        </CreateCheckStoreProvider>
+        </CheckStoreProvider>
       </RootProviders>,
     )
 

--- a/src/tests/e2e/checks/create/CreatePage.cy.tsx
+++ b/src/tests/e2e/checks/create/CreatePage.cy.tsx
@@ -23,7 +23,7 @@ describe('/checks/create - Create Page ', () => {
     cy.visit('/checks/create')
 
     cy.intercept('POST', `${baseUrl}/checks/create`).as('intercept-create-response')
-    cy.get("[aria-label='save created knowledge check']").should('exist').click({ force: true })
+    cy.get("[aria-label='save knowledge check']").should('exist').click({ force: true })
 
     cy.wait('@intercept-create-response').then((interception) => {
       const request = interception.request

--- a/src/tests/e2e/checks/create/SessionStorageCache.cy.tsx
+++ b/src/tests/e2e/checks/create/SessionStorageCache.cy.tsx
@@ -11,14 +11,14 @@ describe('SessionStorageCache', () => {
     const baseUrl = Cypress.env('NEXT_PUBLIC_BASE_URL')
     const DUMMY_NAME = 'Test Check'
 
-    cy.getAllSessionStorage().its(baseUrl).should('not.have.a.property', 'create-check-store', 'Verify that create-check-store is not cached at the beginning')
+    cy.getAllSessionStorage().its(baseUrl).should('not.have.a.property', 'check-store', 'Verify that check-store is not cached at the beginning')
 
     cy.get("input[name='check-name']").type(DUMMY_NAME)
 
     cy.wait(1000) // wait - debounce time before values are cached
     cy.getAllSessionStorage()
       .its(baseUrl)
-      .should('have.property', 'create-check-store')
+      .should('have.property', 'check-store')
       .then((sessionCache) => {
         const cachedCheck: KnowledgeCheck = JSON.parse(sessionCache.toString())
 
@@ -36,13 +36,13 @@ describe('SessionStorageCache', () => {
     const DUMMY_NAME = 'Test Check'
     const CACHE_DURATION = 4 * 3600 * 1000
 
-    cy.getAllSessionStorage().its(baseUrl).should('not.have.a.property', 'create-check-store', 'Verify that create-check-store is not cached at the beginning')
+    cy.getAllSessionStorage().its(baseUrl).should('not.have.a.property', 'check-store', 'Verify that check-store is not cached at the beginning')
     cy.get("input[name='check-name']").type(DUMMY_NAME)
 
     cy.wait(1000) // wait - debounce time before values are cached
     cy.getAllSessionStorage()
       .its(baseUrl)
-      .should('have.property', 'create-check-store')
+      .should('have.property', 'check-store')
       .then((sessionCache) => {
         const cachedCheck: KnowledgeCheck = JSON.parse(sessionCache.toString())
 
@@ -55,6 +55,6 @@ describe('SessionStorageCache', () => {
     cy.clock(new Date(Date.now() + CACHE_DURATION))
 
     cy.reload()
-    cy.getAllSessionStorage().should('not.have.property', 'create-check-store', 'Verify that sessionStorage cache is invalidated after cacheDuration')
+    cy.getAllSessionStorage().should('not.have.property', 'check-store', 'Verify that sessionStorage cache is invalidated after cacheDuration')
   })
 })

--- a/types/Shared/CreateStoreType.ts
+++ b/types/Shared/CreateStoreType.ts
@@ -10,4 +10,4 @@ export type CreateStoreType<State extends object, Store extends object = Any> = 
 /**
  * Defines what options should be available when creating a store.
  */
-export type CreateStoreOptions = { disableCache?: boolean }
+export type CreateStoreOptions = { disableCache?: boolean; cacheKey?: string }


### PR DESCRIPTION
## Summary 

- New Features
  - Introduced new `ConfigureKnowledgeCheck` component which externalizes the bodies of the /create and /edit pages.
  - Introduced customizable caching keys in store providers to override default cache-keys

- Refactorings
  - Renamed `CreateCheck[ Store, Provider, ... ]` components to `Check[ Store, Provider ]` to make it more abstract as its used for both editing and creating checks.
  - Introduced debug log statements in `SaveCheckButton` when no cached entry was found (indicating that custom cacheKey is used).
  - Added property to `SaveCheckButon` to provide a custom cacheKey. This cacheKey prop is the used to override the default-static cacheKey to clean-up cached data after it was successfully saved.
