### PR TITLE
Ref: Introduce missing exam results translations

### DIFF
--- a/src/app/[locale]/checks/[share_token]/results/[attemptId]/page.tsx
+++ b/src/app/[locale]/checks/[share_token]/results/[attemptId]/page.tsx
@@ -3,12 +3,14 @@ import { getExaminationAttemptById } from '@/database/examination/select'
 import { getKnowledgeCheckByShareToken } from '@/database/knowledgeCheck/select'
 import { QuestionScoresLineChart } from '@/src/components/charts/QuestionScoresLineChart'
 import PageHeading from '@/src/components/Shared/PageHeading'
+import { getScopedI18n } from '@/src/i18n/server-localization'
 import requireAuthentication from '@/src/lib/auth/requireAuthentication'
 import hasCollaborativePermissions from '@/src/lib/checks/hasCollaborativePermissions'
 import getDummyExamAttempts from '@/src/lib/dummy/getDummyExamAttempts'
 import ExamQuestionResultTable from '../../../../../../components/checks/[share_token]/results/ExamQuestionResultTable'
 
 export default async function ExamAttemptResultPage({ params }: { params: Promise<{ share_token: string; attemptId: string }> }) {
+  const t = await getScopedI18n('Checks.ExaminatonResults.ExamAttemptResultPage')
   const { share_token, attemptId } = await params
   const { user } = await requireAuthentication()
 
@@ -22,7 +24,7 @@ export default async function ExamAttemptResultPage({ params }: { params: Promis
 
   return (
     <>
-      <PageHeading title='Examination Attempt Results' description={`Shows all the details of the a given examination attempt of ${attempt.user.name}`} />
+      <PageHeading title={t('title')} description={t('description', { name: attempt.user.name })} />
 
       <div className='flex flex-col gap-14'>
         <QuestionScoresLineChart />

--- a/src/app/[locale]/checks/[share_token]/results/page.tsx
+++ b/src/app/[locale]/checks/[share_token]/results/page.tsx
@@ -11,6 +11,7 @@ import { UserTypePieChart } from '@/src/components/charts/UserTypePieChart'
 import { ExaminationAttemptTable } from '@/src/components/checks/[share_token]/ExaminationAttemptTable'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/src/components/shadcn/card'
 import PageHeading from '@/src/components/Shared/PageHeading'
+import { getScopedI18n } from '@/src/i18n/server-localization'
 import requireAuthentication from '@/src/lib/auth/requireAuthentication'
 import hasCollaborativePermissions from '@/src/lib/checks/hasCollaborativePermissions'
 import getDummyExamAttempts from '@/src/lib/dummy/getDummyExamAttempts'
@@ -35,29 +36,30 @@ export default async function ExaminationResultsPage({ params }: { params: Promi
   if (!hasCollaborativePermissions(check, user.id)) forbidden()
 
   const dummyAttempts = await getDummyExamAttempts(50)
+  const t = await getScopedI18n('Checks.ExaminatonResults')
 
   return (
     <>
-      <PageHeading title='Examination Results' description='Look at the examination attempts of users.' />
+      <PageHeading title={t('title')} description={t('description')} />
 
       <div className='mx-6 mt-2 flex flex-col gap-16'>
         <div className='mx-0 flex flex-col gap-16'>
           <div className='grid-container [--grid-column-count:3] [--grid-desired-gap:70px] [--grid-item-min-width:280px] @[360px]:[--grid-item-min-width:340px]'>
-            <UserTypePieChart title='Examinations by User types' description='Shows examination attempts by user type' />
-            <ExamQuestionDurationChart title='Average Question time differences' description='Shows the variance in actual and estimated answer-time ' />
-            <ExaminationSuccessPieChart title='Examinations Success Rate' description='Shows how many users have passed / failed.' />
+            <UserTypePieChart title={t('Charts.UserTypePieChart.title')} description={t('Charts.UserTypePieChart.description')} />
+            <ExamQuestionDurationChart title={t('Charts.ExamQuestionDurationChart.title')} description={t('Charts.ExamQuestionDurationChart.description')} />
+            <ExaminationSuccessPieChart title={t('Charts.ExaminationSuccessPieChart.title')} description={t('Charts.ExaminationSuccessPieChart.description')} />
           </div>
 
           <div className='grid-container [--grid-column-count:2] [--grid-desired-gap:70px] [--grid-item-min-width:280px] @[550px]:[--grid-item-min-width:500px]'>
-            <QuestionScoresLineChartCard title='Average question score by question' description='Shows the variance between average question score and max-score by question' />
+            <QuestionScoresLineChartCard title={t('Charts.QuestionScoresLineChartCard.title')} description={t('Charts.QuestionScoresLineChartCard.description')} />
           </div>
         </div>
 
         <Card>
-          <CardHeader className='bg-card -mt-6 flex flex-col items-stretch border-b pt-6 sm:flex-row'>
+          <CardHeader className='-mt-6 flex flex-col items-stretch border-b bg-card pt-6 sm:flex-row'>
             <div className='flex flex-1 flex-col justify-center gap-1 pb-3 sm:pb-0'>
-              <CardTitle>Examation Attempts</CardTitle>
-              <CardDescription>Shows a detailed list of all examination attempts for this check</CardDescription>
+              <CardTitle>{t('ExaminationAttemptTable.title')}</CardTitle>
+              <CardDescription>{t('ExaminationAttemptTable.description')}</CardDescription>
             </div>
           </CardHeader>
           <CardContent className='mt-auto px-0'>
@@ -67,9 +69,9 @@ export default async function ExaminationResultsPage({ params }: { params: Promi
                 score: attempt.score,
                 startedAt: new Date(Date.parse(attempt.startedAt)),
                 finishedAt: new Date(Date.parse(attempt.finishedAt)),
-                status: i % 4 !== 0 ? 'Done' : 'in-progress',
+                status: i % 4 !== 0 ? t('ExaminationAttemptTable.status_done') : t('ExaminationAttemptTable.status_in_progress'),
                 totalCheckScore: 100,
-                type: i % 5 !== 0 ? 'normal' : 'anonymous',
+                type: i % 5 !== 0 ? t('ExaminationAttemptTable.user_type_normal') : t('ExaminationAttemptTable.user_type_anonynmous'),
                 username: attempt.user.name,
               }))}
             />
@@ -102,9 +104,9 @@ function StatisticElement({ label, value, title, className }: { label: string; v
   title ||= label
 
   return (
-    <div className={cn('ring-ring-subtle flex flex-col justify-center gap-2 rounded-md ring-1 dark:bg-neutral-800/70', className)}>
+    <div className={cn('flex flex-col justify-center gap-2 rounded-md ring-1 ring-ring-subtle dark:bg-neutral-800/70', className)}>
       {title && (
-        <h3 className='bg-input border-b-input-ring flex justify-between rounded-t-md border-b px-3 py-1.5 text-sm font-medium dark:text-neutral-300/80'>
+        <h3 className='flex justify-between rounded-t-md border-b border-b-input-ring bg-input px-3 py-1.5 text-sm font-medium dark:text-neutral-300/80'>
           {title}
 
           <EllipsisIcon className='' />

--- a/src/components/Shared/Table/DataTable.tsx
+++ b/src/components/Shared/Table/DataTable.tsx
@@ -29,6 +29,7 @@ import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMe
 import { Label } from '@/components/shadcn/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/shadcn/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/shadcn/table'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 import getKeys from '@/src/lib/Shared/Keys'
 import { cn } from '@/src/lib/Shared/utils'
 
@@ -70,6 +71,7 @@ function DraggableRow<I extends { id: string | number }>({ row }: { row: Row<I> 
 }
 
 export function DataTable<T extends I[], I extends { id: string | number }>({ data: initialData, columns, columnHideOrder }: { data: T; columns: ColumnDef<I>[]; columnHideOrder?: string[] }) {
+  const t = useScopedI18n('Components.DataTable')
   const [data, setData] = React.useState<I[]>(() => initialData)
   const [rowSelection, setRowSelection] = React.useState({})
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({})
@@ -180,7 +182,7 @@ export function DataTable<T extends I[], I extends { id: string | number }>({ da
       <div className='-mb-2 flex items-center justify-between'>
         <div className='ml-2 hidden items-center gap-2 @sm/table:flex'>
           <Label htmlFor='rows-per-page' className='text-sm font-medium'>
-            Rows per page
+            {t('page_size_label')}
           </Label>
           <Select
             value={`${table.getState().pagination.pageSize}`}
@@ -189,7 +191,7 @@ export function DataTable<T extends I[], I extends { id: string | number }>({ da
             }}>
             <SelectTrigger
               size='sm'
-              className='dark:border-ring-subtle border-ring-subtle !h-7 w-fit bg-neutral-200/70 hover:cursor-pointer hover:bg-neutral-200 dark:bg-neutral-700 dark:hover:bg-neutral-600/80'
+              className='dark:border-ring-subtle border-ring-subtle h-7! w-fit bg-neutral-200/70 hover:cursor-pointer hover:bg-neutral-200 dark:bg-neutral-700 dark:hover:bg-neutral-600/80'
               id='rows-per-page'>
               <SelectValue placeholder={table.getState().pagination.pageSize} />
             </SelectTrigger>
@@ -207,8 +209,8 @@ export function DataTable<T extends I[], I extends { id: string | number }>({ da
             <DropdownMenuTrigger asChild>
               <Button variant='outline' size='sm'>
                 <IconLayoutColumns />
-                <span className='hidden lg:inline'>Customize Columns</span>
-                <span className='lg:hidden'>Columns</span>
+                <span className='hidden lg:inline'>{t('customize_columns_label_long')}</span>
+                <span className='lg:hidden'>{t('customize_columns_label_short')}</span>
                 <IconChevronDown />
               </Button>
             </DropdownMenuTrigger>
@@ -262,7 +264,7 @@ export function DataTable<T extends I[], I extends { id: string | number }>({ da
                 ) : (
                   <TableRow>
                     <TableCell colSpan={columns.length} className='h-24 text-center'>
-                      No results.
+                      {t('no_results_label')}
                     </TableCell>
                   </TableRow>
                 )}
@@ -277,30 +279,30 @@ export function DataTable<T extends I[], I extends { id: string | number }>({ da
 }
 
 function TableFooter<I extends { id: string | number }>({ table }: { table: TableType<I> }) {
+  const t = useScopedI18n('Components.DataTable.Pagination')
+
   return (
     <div className='flex items-center justify-between px-4'>
       <div className={cn('text-muted-foreground hidden flex-1 text-sm transition-opacity lg:flex', table.getFilteredSelectedRowModel().rows.length === 0 && 'opacity-0')}>
-        {table.getFilteredSelectedRowModel().rows.length > 0 && `${table.getFilteredSelectedRowModel().rows.length} of ${table.getFilteredRowModel().rows.length} row(s) selected.`}
+        {table.getFilteredSelectedRowModel().rows.length > 0 && t('selection_label', { selected: table.getFilteredSelectedRowModel().rows.length, total: table.getFilteredRowModel().rows.length })}
       </div>
       <div className='mb-0.25 flex w-full items-center gap-8 lg:w-fit'>
-        <div className='flex w-fit items-center justify-center text-sm font-medium'>
-          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
-        </div>
+        <div className='flex w-fit items-center justify-center text-sm font-medium'>{t('current_page_label', { page: table.getState().pagination.pageIndex + 1, total: table.getPageCount() })}</div>
         <div className='ml-auto flex items-center gap-2 lg:ml-0'>
           <Button variant='outline' className='hidden h-8 w-8 p-0 lg:flex' onClick={() => table.setPageIndex(0)} disabled={!table.getCanPreviousPage()}>
-            <span className='sr-only'>Go to first page</span>
+            <span className='sr-only'>{t('sr_only.go_first_page')}</span>
             <IconChevronsLeft />
           </Button>
           <Button variant='outline' className='size-8' size='icon' onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
-            <span className='sr-only'>Go to previous page</span>
+            <span className='sr-only'>{t('sr_only.go_previous_page')}</span>
             <IconChevronLeft />
           </Button>
           <Button variant='outline' className='size-8' size='icon' onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
-            <span className='sr-only'>Go to next page</span>
+            <span className='sr-only'>{t('sr_only.go_next_page')}</span>
             <IconChevronRight />
           </Button>
           <Button variant='outline' className='mb-0 hidden size-8 lg:flex' size='icon' onClick={() => table.setPageIndex(table.getPageCount() - 1)} disabled={!table.getCanNextPage()}>
-            <span className='sr-only'>Go to last page</span>
+            <span className='sr-only'>{t('sr_only.go_last_page')}</span>
             <IconChevronsRight />
           </Button>
         </div>

--- a/src/components/charts/ExaminationSuccessPieChart.tsx
+++ b/src/components/charts/ExaminationSuccessPieChart.tsx
@@ -5,8 +5,10 @@ import React from 'react'
 import { Label, Pie, PieChart } from 'recharts'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/src/components/shadcn/card'
 import { ChartConfig, ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent } from '@/src/components/shadcn/chart'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 
 export function ExaminationSuccessPieChart({ title, description }: { title: string; description?: string }) {
+  const t = useScopedI18n('Checks.ExaminatonResults.Charts.ExaminationSuccessPieChart')
   const total = Math.max(Math.round(Math.random() * 150), Math.round(Math.max(48, Math.random() * 120)))
   const passedRate = Math.min(0.95, Math.max(0.6, Math.random()))
 
@@ -24,12 +26,12 @@ export function ExaminationSuccessPieChart({ title, description }: { title: stri
     (): ChartConfig => ({
       pass: {
         // label: 'Passed Examination',
-        label: 'Passed',
+        label: t('passed_label'),
         color: 'var(--chart-2)',
       },
       fail: {
         // label: 'Failed Examination',
-        label: 'Failed',
+        label: t('failed_label'),
         color: 'var(--chart-5)',
       },
     }),
@@ -61,7 +63,7 @@ export function ExaminationSuccessPieChart({ title, description }: { title: stri
                           <div className='flex items-center justify-between gap-4'>
                             <div className='flex items-center gap-2'>
                               <div
-                                className='h-2.5 w-2.5 shrink-0 rounded-[2px] bg-(--color-bg)'
+                                className='size-2.5 shrink-0 rounded-[2px] bg-(--color-bg)'
                                 style={
                                   {
                                     '--color-bg': `var(--color-${name})`,
@@ -72,7 +74,7 @@ export function ExaminationSuccessPieChart({ title, description }: { title: stri
                             </div>
                             <div className='text-foreground flex flex-1 items-baseline justify-end gap-1 text-right font-mono font-medium tabular-nums'>
                               {value}
-                              <span className='text-muted-foreground font-normal'>attempts</span>
+                              <span className='text-muted-foreground font-normal lowercase'>{t('inner_label', { count: +value })}</span>
                             </div>
                           </div>
                         </div>
@@ -91,8 +93,8 @@ export function ExaminationSuccessPieChart({ title, description }: { title: stri
                         <tspan x={viewBox.cx} y={viewBox.cy} className='fill-foreground text-3xl font-bold'>
                           {totalUsers.toLocaleString()}
                         </tspan>
-                        <tspan x={viewBox.cx} y={(viewBox.cy || 0) + 24} className='fill-muted-foreground'>
-                          Attempts
+                        <tspan x={viewBox.cx} y={(viewBox.cy || 0) + 24} className='fill-muted-foreground capitalize'>
+                          {t('inner_label', { count: totalUsers })}
                         </tspan>
                       </text>
                     )

--- a/src/components/charts/QuestionDurationChart.tsx
+++ b/src/components/charts/QuestionDurationChart.tsx
@@ -4,12 +4,15 @@ import React from 'react'
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/src/components/shadcn/card'
 import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@/src/components/shadcn/chart'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 import randomRange from '@/src/lib/Shared/randomRange'
 import { cn } from '@/src/lib/Shared/utils'
 import { instantiateQuestion, Question } from '@/src/schemas/QuestionSchema'
 import { Any } from '@/types'
 
 export function ExamQuestionDurationChart({ title, description, questions }: { title: string; description?: string; questions?: Question[] }) {
+  const tShared = useScopedI18n('Shared.Timestamp')
+  const t = useScopedI18n('Checks.ExaminatonResults.Charts.ExamQuestionDurationChart')
   if (!questions || questions.length === 0) questions = Array.from({ length: 15 }, () => instantiateQuestion())
 
   const dataQuestions = React.useMemo(() => {
@@ -65,50 +68,47 @@ export function ExamQuestionDurationChart({ title, description, questions }: { t
               cursor={false}
               content={
                 <ChartTooltipContent
-                  label='Time Difference'
                   formatter={(value, name, item, index) => {
                     return (
                       <div className='mt-2 flex flex-col gap-1'>
                         <div className='flex flex-col gap-1.5'>
                           <div className='flex items-center justify-between gap-4'>
                             <div className='flex items-center gap-2'>
-                              <div className={cn('h-2.5 w-2.5 shrink-0 rounded-[2px]', 'bg-chart-2')} />
-                              Estimated Time
+                              <div className={cn('size-2.5 shrink-0 rounded-[2px]', 'bg-chart-2')} />
+                              {t('tooltip.estimated_time_label')}
                             </div>
                             <div className='text-foreground flex flex-1 items-baseline justify-end gap-1 text-right font-mono font-medium tabular-nums'>
                               {item.payload.estimated}
-                              <span className='text-muted-foreground font-normal'>minutes</span>
+                              <span className='text-muted-foreground font-normal'>{tShared('minute_label', { count: item.payload.estimated })}</span>
                             </div>
                           </div>
                           <div className='flex items-center justify-between gap-4'>
                             <div className='flex items-center gap-2'>
-                              <div className={cn('h-2.5 w-2.5 shrink-0 rounded-[2px]', 'bg-chart-3')} />
-                              Time needed
+                              <div className={cn('size-2.5 shrink-0 rounded-[2px]', 'bg-chart-3')} />
+                              {t('tooltip.actual_time_label')}
                             </div>
                             <div className='text-foreground flex flex-1 items-baseline justify-end gap-1 text-right font-mono font-medium tabular-nums'>
                               {item.payload.actualTime}
-                              <span className='text-muted-foreground font-normal'>minutes</span>
+                              <span className='text-muted-foreground font-normal'>{tShared('minute_label', { count: item.payload.actualTime })}</span>
                             </div>
                           </div>
                         </div>
 
                         <div className='text-foreground mt-1.5 flex items-center border-t pt-1.5 text-xs font-medium'>
                           {item.payload.difference > 0 ? (
-                            <span className='text-[oklch(59.2%_0.309_151.711)] dark:text-[oklch(79.2%_0.209_151.711)]'>Faster by</span>
+                            <span className='text-[oklch(59.2%_0.309_151.711)] dark:text-green-400'>{t('tooltip.total_faster_label')}</span>
                           ) : (
                             // eslint-disable-next-line require-color-modes/require-color-mode-styles
-                            <span className='text-red-400'>Slower by</span>
+                            <span className='text-red-400'>{t('tooltip.total_slower_label')}</span>
                           )}
                           <div className='text-foreground ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums'>
-                            <span className={cn(item.payload.difference > 0 ? 'text-[oklch(59.2%_0.309_151.711)] dark:text-[oklch(79.2%_0.209_151.711)]' : 'text-red-400')}>
-                              {Math.abs(item.payload.difference)}
-                            </span>
+                            <span className={cn(item.payload.difference > 0 ? 'text-[oklch(59.2%_0.309_151.711)] dark:text-green-400' : 'text-red-400')}>{Math.abs(item.payload.difference)}</span>
                             <span
                               className={cn(
                                 'font-normal',
                                 item.payload.difference > 0 ? 'text-[oklch(59.2%_0.309_151.711)]/50 dark:text-[oklch(79.2%_0.07_151.711)]' : 'text-[oklch(70.4%_0.07_22.216)]',
                               )}>
-                              minutes
+                              {tShared('minute_label', { count: Math.abs(item.payload.difference) })}
                             </span>
                           </div>
                         </div>
@@ -117,7 +117,7 @@ export function ExamQuestionDurationChart({ title, description, questions }: { t
                   }}
                 />
               }
-              labelFormatter={(_, payload) => `Question ${payload[0].payload.name}`}
+              labelFormatter={(_, payload) => t('tooltip.title', { count: payload[0].payload.name })}
             />
             <defs>
               <linearGradient id='splitColor' x1='0' y1='0' x2='0' y2='1'>
@@ -140,7 +140,7 @@ export function ExamQuestionDurationChart({ title, description, questions }: { t
               }}
               label={({ viewBox: { x, y, width, height } }: Any) => (
                 <text x={x + width / 2 - 20} y={y + height + 3} className='' fill='gray'>
-                  Questions
+                  {t('x_axis_label')}
                 </text>
               )}
             />
@@ -151,7 +151,7 @@ export function ExamQuestionDurationChart({ title, description, questions }: { t
                 // console.log('Normalized domain', ...updatedDomain, 'min: ', dataMin, 'max: ', dataMax)
                 return updatedDomain
               }}
-              label={<AxisLabel>Time spent</AxisLabel>}
+              label={<AxisLabel>{t('y_axis_label')}</AxisLabel>}
             />
             <Area type='monotone' dataKey='difference' className='text-neutral-400 dark:text-neutral-500' stroke='currentColor' fill='url(#splitColor)' />
           </AreaChart>

--- a/src/components/charts/QuestionScoresLineChart.tsx
+++ b/src/components/charts/QuestionScoresLineChart.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shadcn/card'
 import { type ChartConfig, ChartContainer, ChartLegend, ChartTooltip, ChartTooltipContent } from '@/shadcn/chart'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 import { cn } from '@/src/lib/Shared/utils'
 import { Any } from '@/types'
 
@@ -31,8 +32,6 @@ const data: ChartData[] = [
   { questionIndex: 14, score: 10, maxScore: 14 },
 ]
 
-const chartConfig = {} satisfies ChartConfig
-
 export function QuestionScoresLineChartCard({ title, description }: { title: string; description?: string }) {
   return (
     <Card>
@@ -50,6 +49,19 @@ export function QuestionScoresLineChartCard({ title, description }: { title: str
 }
 
 export function QuestionScoresLineChart({ data: initialData = data, className }: { data?: ChartData[]; className?: string }) {
+  const t = useScopedI18n('Checks.ExaminatonResults.Charts.QuestionScoresLineChartCard')
+
+  const chartConfig = React.useMemo(
+    (): ChartConfig => ({
+      maxScore: {
+        label: t('maxScore_label'),
+      },
+      score: {
+        label: t('score_label'),
+      },
+    }),
+    [t],
+  )
   return (
     <ChartContainer config={chartConfig} className={cn('aspect-auto h-[250px] w-full', className)}>
       <AreaChart
@@ -74,7 +86,7 @@ export function QuestionScoresLineChart({ data: initialData = data, className }:
           }}
           label={({ viewBox: { x, y, width, height } }: Any) => (
             <text x={x + width / 2 - 20} y={y + height + 3} className='' fill='gray'>
-              Questions
+              {t('x_axis_label')}
             </text>
           )}
           dataKey='questionIndex'
@@ -91,10 +103,10 @@ export function QuestionScoresLineChart({ data: initialData = data, className }:
           </linearGradient>
         </defs>
 
-        <ChartTooltip content={<ChartTooltipContent className='w-[150px]' nameKey='score' />} />
+        <ChartTooltip content={<ChartTooltipContent hideLabel className='w-[150px]' />} />
         <Area type='bumpX' dataKey={'score'} stroke={`var(--chart-2)`} strokeWidth={3} stackId='a' dot={true} fill='url(#fillScore)' />
         <Area type='bumpX' label={'Question Points'} dataKey={'maxScore'} stroke={`var(--chart-3)`} strokeWidth={3} stackId='a' dot={true} fill='url(#fillMaxScore)' />
-        <ChartLegend wrapperStyle={{ bottom: '-10px', left: '25px', margin: '0px 15px 0px 25px', width: 'stretch' }} />
+        <ChartLegend formatter={(val: 'score' | 'maxScore') => t(`${val}_label`)} wrapperStyle={{ bottom: '-10px', left: '25px', margin: '0px 15px 0px 25px', width: 'stretch' }} />
       </AreaChart>
     </ChartContainer>
   )

--- a/src/components/charts/UserTypePieChart.tsx
+++ b/src/components/charts/UserTypePieChart.tsx
@@ -5,9 +5,11 @@ import React from 'react'
 import { Label, Pie, PieChart } from 'recharts'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/src/components/shadcn/card'
 import { ChartConfig, ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent } from '@/src/components/shadcn/chart'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 import { BetterAuthUser } from '@/src/lib/auth/server'
 
 export function UserTypePieChart({ title, description, users }: { title: string; description?: string; users?: BetterAuthUser[] }) {
+  const t = useScopedI18n('Checks.ExaminatonResults.Charts.UserTypePieChart')
   const total = Math.max(Math.round(Math.random() * 150), Math.round(Math.max(48, Math.random() * 120)))
   const normalRate = Math.min(0.95, Math.max(0.6, Math.random()))
 
@@ -27,11 +29,11 @@ export function UserTypePieChart({ title, description, users }: { title: string;
   const chartConfig = React.useMemo(
     (): ChartConfig => ({
       normal: {
-        label: 'Normal',
+        label: t('user_type_normal'),
         color: 'var(--chart-3)',
       },
       anonymous: {
-        label: 'Anonymous',
+        label: t('user_type_anonynmous'),
         color: 'var(--chart-1)',
       },
     }),
@@ -62,7 +64,7 @@ export function UserTypePieChart({ title, description, users }: { title: string;
                           {totalUsers.toLocaleString()}
                         </tspan>
                         <tspan x={viewBox.cx} y={(viewBox.cy || 0) + 24} className='fill-muted-foreground'>
-                          Users
+                          {t('inner_label')}
                         </tspan>
                       </text>
                     )

--- a/src/components/checks/[share_token]/ExaminationAttemptTable.tsx
+++ b/src/components/checks/[share_token]/ExaminationAttemptTable.tsx
@@ -40,7 +40,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/shadcn/table'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { QuestionScoresLineChart } from '@/src/components/charts/QuestionScoresLineChart'
-import { useCurrentLocale } from '@/src/i18n/client-localization'
+import { useCurrentLocale, useScopedI18n } from '@/src/i18n/client-localization'
 import getKeys from '@/src/lib/Shared/Keys'
 import { cn } from '@/src/lib/Shared/utils'
 
@@ -83,7 +83,7 @@ const columns: ColumnDef<ExamAttemptItem>[] = [
     cell: ({ row }) => {
       return (
         <DrawerActionTableCell item={row.original}>
-          <Button variant='link' className='text-foreground w-fit px-0 text-left'>
+          <Button variant='link' className='w-fit px-0 text-left text-foreground'>
             {row.original.username}
           </Button>
         </DrawerActionTableCell>
@@ -96,8 +96,8 @@ const columns: ColumnDef<ExamAttemptItem>[] = [
     accessorKey: 'status',
     header: 'Status',
     cell: ({ row }) => (
-      <Badge variant='outline' className='text-muted-foreground px-1.5'>
-        {row.original.status === 'Done' ? <IconCircleCheckFilled className='fill-green-500 dark:fill-green-400/70' /> : <IconLoader />}
+      <Badge variant='outline' className='px-1.5 text-muted-foreground'>
+        {row.original.status === 'Done' || row.original.status === 'Erledigt' ? <IconCircleCheckFilled className='fill-green-500 dark:fill-green-400/70' /> : <IconLoader />}
         {row.original.status}
       </Badge>
     ),
@@ -116,7 +116,7 @@ const columns: ColumnDef<ExamAttemptItem>[] = [
     header: 'User Type',
     cell: ({ row }) => (
       <div className='w-fit'>
-        <Badge variant='outline' className='text-muted-foreground px-1.5'>
+        <Badge variant='outline' className='px-1.5 text-muted-foreground'>
           {row.original.type}
         </Badge>
       </div>
@@ -126,7 +126,7 @@ const columns: ColumnDef<ExamAttemptItem>[] = [
     accessorKey: 'score',
     header: () => <div className='w-full text-center'>Score</div>,
     cell: ({ row }) => (
-      <div className='text-foreground text-center text-xs' id={`${row.original.id}-score`}>
+      <div className='text-center text-xs text-foreground' id={`${row.original.id}-score`}>
         {row.original.score}
       </div>
     ),
@@ -161,7 +161,7 @@ const columns: ColumnDef<ExamAttemptItem>[] = [
     cell: ({ row }) => (
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant='ghost' className='data-[state=open]:bg-muted text-muted-foreground flex size-8' size='icon'>
+          <Button variant='ghost' className='flex size-8 text-muted-foreground data-[state=open]:bg-muted' size='icon'>
             <IconDotsVertical />
             <span className='sr-only'>Open menu</span>
           </Button>
@@ -216,6 +216,7 @@ function DraggableRow({ row }: { row: Row<ExamAttemptItem> }) {
 }
 
 export function ExaminationAttemptTable({ data: initialData }: { data: ExamAttemptItem[] }) {
+  const t = useScopedI18n('Components.DataTable')
   const [data, setData] = React.useState(() => initialData)
   const [rowSelection, setRowSelection] = React.useState({})
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({})
@@ -325,7 +326,7 @@ export function ExaminationAttemptTable({ data: initialData }: { data: ExamAttem
       <div className='-mb-2 flex items-center justify-between px-4 lg:px-6'>
         <div className='ml-2 hidden items-center gap-2 @sm/table:flex'>
           <Label htmlFor='rows-per-page' className='text-sm font-medium'>
-            Rows per page
+            {t('page_size_label')}
           </Label>
           <Select
             value={`${table.getState().pagination.pageSize}`}
@@ -334,7 +335,7 @@ export function ExaminationAttemptTable({ data: initialData }: { data: ExamAttem
             }}>
             <SelectTrigger
               size='sm'
-              className='dark:border-ring-subtle border-ring-subtle !h-7 w-fit bg-neutral-200/70 hover:cursor-pointer hover:bg-neutral-200 dark:bg-neutral-700 dark:hover:bg-neutral-600/80'
+              className='h-7! w-fit border-ring-subtle bg-neutral-200/70 hover:cursor-pointer hover:bg-neutral-200 dark:border-ring-subtle dark:bg-neutral-700 dark:hover:bg-neutral-600/80'
               id='rows-per-page'>
               <SelectValue placeholder={table.getState().pagination.pageSize} />
             </SelectTrigger>
@@ -352,8 +353,8 @@ export function ExaminationAttemptTable({ data: initialData }: { data: ExamAttem
             <DropdownMenuTrigger asChild>
               <Button variant='outline' size='sm'>
                 <IconLayoutColumns />
-                <span className='hidden lg:inline'>Customize Columns</span>
-                <span className='lg:hidden'>Columns</span>
+                <span className='hidden lg:inline'>{t('customize_columns_label_long')}</span>
+                <span className='lg:hidden'>{t('customize_columns_label_short')}</span>
                 <IconChevronDown />
               </Button>
             </DropdownMenuTrigger>
@@ -406,7 +407,7 @@ export function ExaminationAttemptTable({ data: initialData }: { data: ExamAttem
                 ) : (
                   <TableRow>
                     <TableCell colSpan={columns.length} className='h-24 text-center'>
-                      No results.
+                      {t('no_results_label')}
                     </TableCell>
                   </TableRow>
                 )}
@@ -421,30 +422,29 @@ export function ExaminationAttemptTable({ data: initialData }: { data: ExamAttem
 }
 
 function TableFooter({ table }: { table: TableType<ExamAttemptItem> }) {
+  const t = useScopedI18n('Components.DataTable.Pagination')
   return (
     <div className='flex items-center justify-between px-4'>
-      <div className='text-muted-foreground hidden flex-1 text-sm lg:flex'>
-        {table.getFilteredSelectedRowModel().rows.length > 0 && `${table.getFilteredSelectedRowModel().rows.length} of ${table.getFilteredRowModel().rows.length} row(s) selected.`}
+      <div className='hidden flex-1 text-sm text-muted-foreground lg:flex'>
+        {table.getFilteredSelectedRowModel().rows.length > 0 && t('selection_label', { selected: table.getFilteredSelectedRowModel().rows.length, total: table.getFilteredRowModel().rows.length })}
       </div>
       <div className='mb-0.25 flex w-full items-center gap-8 lg:w-fit'>
-        <div className='flex w-fit items-center justify-center text-sm font-medium'>
-          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
-        </div>
+        <div className='flex w-fit items-center justify-center text-sm font-medium'>{t('current_page_label', { page: table.getState().pagination.pageIndex + 1, total: table.getPageCount() })}</div>
         <div className='ml-auto flex items-center gap-2 lg:ml-0'>
           <Button variant='outline' className='hidden h-8 w-8 p-0 lg:flex' onClick={() => table.setPageIndex(0)} disabled={!table.getCanPreviousPage()}>
-            <span className='sr-only'>Go to first page</span>
+            <span className='sr-only'>{t('sr_only.go_first_page')}</span>
             <IconChevronsLeft />
           </Button>
           <Button variant='outline' className='size-8' size='icon' onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
-            <span className='sr-only'>Go to previous page</span>
+            <span className='sr-only'>{t('sr_only.go_previous_page')}</span>
             <IconChevronLeft />
           </Button>
           <Button variant='outline' className='size-8' size='icon' onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
-            <span className='sr-only'>Go to next page</span>
+            <span className='sr-only'>{t('sr_only.go_next_page')}</span>
             <IconChevronRight />
           </Button>
           <Button variant='outline' className='mb-0 hidden size-8 lg:flex' size='icon' onClick={() => table.setPageIndex(table.getPageCount() - 1)} disabled={!table.getCanNextPage()}>
-            <span className='sr-only'>Go to last page</span>
+            <span className='sr-only'>{t('sr_only.go_last_page')}</span>
             <IconChevronsRight />
           </Button>
         </div>
@@ -454,6 +454,7 @@ function TableFooter({ table }: { table: TableType<ExamAttemptItem> }) {
 }
 
 function DrawerActionTableCell({ item, children }: { item: ExamAttemptItem; children: React.ReactNode }) {
+  const t = useScopedI18n('Checks.ExaminatonResults.ExaminationAttemptTable.Drawer')
   const isMobile = useIsMobile()
   const currentLocale = useCurrentLocale()
 
@@ -463,38 +464,38 @@ function DrawerActionTableCell({ item, children }: { item: ExamAttemptItem; chil
       <DrawerContent className='data-[vaul-drawer-direction=right]:*:data-close:flex'>
         <div data-close className='absolute top-0 bottom-0 -left-2.5 hidden items-center'>
           <DrawerClose asChild>
-            <Button variant='ghost' size='icon' className='bg-background size-4 text-neutral-600 hover:scale-115 dark:text-neutral-300'>
+            <Button variant='ghost' size='icon' className='size-4 bg-background text-neutral-600 hover:scale-115 dark:text-neutral-300'>
               <ChevronRightIcon className='' />
             </Button>
           </DrawerClose>
         </div>
         <DrawerHeader className='mb-6 gap-1 border-b'>
-          <DrawerTitle>Examination Attempt - {item.username}</DrawerTitle>
-          <DrawerDescription>Showing basics about {item.username}&apos;s examaination attempt.</DrawerDescription>
+          <DrawerTitle>{t('title', { username: item.username })}</DrawerTitle>
+          <DrawerDescription>{t('description', { username: item.username })}</DrawerDescription>
         </DrawerHeader>
         <div className='flex flex-1 flex-col gap-4 overflow-y-auto px-4 text-sm'>
           <QuestionScoresLineChart />
           <form className='mt-4 flex flex-col gap-6'>
             <div className='grid-container [--grid-column-count:2] [--grid-desired-gap-x:48px] [--grid-desired-gap:24px] [--grid-item-min-width:80px]'>
               <div className='col-span-2 flex flex-2 flex-col gap-3'>
-                <Label htmlFor='username'>Username</Label>
+                <Label htmlFor='username'>{t('username_label')}</Label>
                 <Input id='username' readOnly defaultValue={item.username} />
               </div>
 
               <div className='flex flex-1 flex-col gap-3'>
-                <Label htmlFor='score'>User Score</Label>
+                <Label htmlFor='score'>{t('user_score_label')}</Label>
                 <Input id='score' type='number' defaultValue={item.score} />
               </div>
               <div className='flex flex-1 flex-col gap-3'>
-                <Label htmlFor='startedAt'>Start Time</Label>
+                <Label htmlFor='startedAt'>{t('start_time_label')}</Label>
                 <Input id='startedAt' readOnly defaultValue={format(item.startedAt, 'P pp', { locale: currentLocale === 'en' ? enUS : deAT })} />
               </div>
               <div className='flex flex-col gap-3'>
-                <Label htmlFor='duration'>Duration</Label>
+                <Label htmlFor='duration'>{t('duration_label')}</Label>
                 <Input id='duration' readOnly defaultValue={differenceInMinutes(item.finishedAt, item.startedAt) + ' minutes'} />
               </div>
               <div className='flex flex-1 flex-col gap-3'>
-                <Label htmlFor='finishedAt'>End Time</Label>
+                <Label htmlFor='finishedAt'>{t('end_time_label')}</Label>
                 <Input id='finishedAt' readOnly defaultValue={format(item.startedAt, 'P pp', { locale: currentLocale === 'en' ? enUS : deAT })} />
               </div>
             </div>
@@ -503,12 +504,12 @@ function DrawerActionTableCell({ item, children }: { item: ExamAttemptItem; chil
         <DrawerFooter className='grid grid-cols-2 gap-12'>
           <DrawerClose asChild>
             <Button className='' variant='outline'>
-              Close
+              {t('close_button_label')}
             </Button>
           </DrawerClose>
 
           <DrawerClose asChild>
-            <Button className=''>Save Changes</Button>
+            <Button className=''>{t('submit_button_label')}</Button>
           </DrawerClose>
         </DrawerFooter>
       </DrawerContent>

--- a/src/components/checks/[share_token]/ExaminationAttemptTable.tsx
+++ b/src/components/checks/[share_token]/ExaminationAttemptTable.tsx
@@ -91,6 +91,7 @@ function DraggableRow({ row }: { row: Row<ExamAttemptItem> }) {
 export function ExaminationAttemptTable({ data: initialData }: { data: ExamAttemptItem[] }) {
   const currentLocale = useCurrentLocale()
   const tDataTable = useScopedI18n('Components.DataTable')
+  const tShared = useScopedI18n('Shared.Timestamp')
   const t = useScopedI18n('Checks.ExaminatonResults.ExaminationAttemptTable')
   const [data, setData] = React.useState(() => initialData)
   const [rowSelection, setRowSelection] = React.useState({})
@@ -160,7 +161,7 @@ export function ExaminationAttemptTable({ data: initialData }: { data: ExamAttem
         header: () => <div className=''>{t('columns.duration_header')}</div>,
         cell: ({ row }) => (
           <div className='text-foreground' id={`${row.original.id}-duration`}>
-            {differenceInMinutes(row.original.finishedAt, row.original.startedAt)} minutes
+            {tShared('minute', { count: differenceInMinutes(row.original.finishedAt, row.original.startedAt) })}
           </div>
         ),
       },
@@ -240,7 +241,7 @@ export function ExaminationAttemptTable({ data: initialData }: { data: ExamAttem
       },
     ]
     return columns
-  }, [t, tDataTable, currentLocale])
+  }, [t, tDataTable, tShared, currentLocale])
 
   const table = useReactTable({
     data,
@@ -466,6 +467,7 @@ function TableFooter({ table }: { table: TableType<ExamAttemptItem> }) {
 }
 
 function DrawerActionTableCell({ item, children }: { item: ExamAttemptItem; children: React.ReactNode }) {
+  const tShared = useScopedI18n('Shared.Timestamp')
   const t = useScopedI18n('Checks.ExaminatonResults.ExaminationAttemptTable.Drawer')
   const isMobile = useIsMobile()
   const currentLocale = useCurrentLocale()
@@ -504,7 +506,7 @@ function DrawerActionTableCell({ item, children }: { item: ExamAttemptItem; chil
               </div>
               <div className='flex flex-col gap-3'>
                 <Label htmlFor='duration'>{t('duration_label')}</Label>
-                <Input id='duration' readOnly defaultValue={differenceInMinutes(item.finishedAt, item.startedAt) + ' minutes'} />
+                <Input id='duration' readOnly defaultValue={tShared('minute', { count: differenceInMinutes(item.finishedAt, item.startedAt) })} />
               </div>
               <div className='flex flex-1 flex-col gap-3'>
                 <Label htmlFor='finishedAt'>{t('end_time_label')}</Label>

--- a/src/components/checks/[share_token]/results/ExamQuestionResultTable.tsx
+++ b/src/components/checks/[share_token]/results/ExamQuestionResultTable.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/src/components/shadcn/button'
 import { Checkbox } from '@/src/components/shadcn/checkbox'
 import { Input } from '@/src/components/shadcn/input'
 import { DataTable } from '@/src/components/Shared/Table/DataTable'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 import createDummyQuestionInput from '@/src/lib/dummy/createDummyUserInput'
 import { instantiateQuestion, Question } from '@/src/schemas/QuestionSchema'
 import { QuestionInput } from '@/src/schemas/UserQuestionInputSchema'
@@ -28,6 +29,9 @@ export type PreviewQuestionResult_QuestionItem = {
 }
 
 export default function ExamQuestionResultTable() {
+  const tShared = useScopedI18n('Shared.Question')
+  const t = useScopedI18n('Checks.ExaminatonResults.ExaminationQuestionTable')
+
   const columns: ColumnDef<PreviewQuestionResult_QuestionItem>[] = [
     {
       id: 'select',
@@ -59,8 +63,8 @@ export default function ExamQuestionResultTable() {
     },
     {
       id: 'primary',
-      accessorKey: 'question',
-      header: 'Question',
+      accessorKey: t('columns.question_accessorKey'),
+      header: t('columns.question_accessorKey'),
       cell: ({ row }) => {
         return <div className='text-left text-foreground'>{row.original.questionText}</div>
       },
@@ -68,8 +72,9 @@ export default function ExamQuestionResultTable() {
     },
 
     {
-      accessorKey: 'category',
-      header: () => <div className='text-center'>Category</div>,
+      id: 'category',
+      accessorKey: t('columns.category_accessorKey'),
+      header: () => <div className='text-center'>{t('columns.category_accessorKey')}</div>,
       cell: ({ row }) => (
         <Badge variant='outline' className='px-1.5 text-muted-foreground'>
           {row.original.category}
@@ -78,36 +83,39 @@ export default function ExamQuestionResultTable() {
     },
 
     {
-      accessorKey: 'answer status',
-      header: () => <div className='text-center'>Answer Status</div>,
+      id: 'answer status',
+      accessorKey: t('columns.answer_status_accessorKey'),
+      header: () => <div className='text-center'>{t('columns.answer_status_accessorKey')}</div>,
       cell: () => (
         <Badge variant='outline' className='px-1.5 text-muted-foreground'>
           {Math.random() > 0.25 ? (
             <>
               <IconCircleCheckFilled className='fill-green-500 dark:fill-green-400/70' />
-              Answered
+              {t('columns.answer_status_cell_answered')}
             </>
           ) : (
             <>
               <XIcon className='stroke-red-500 dark:stroke-red-400' />
-              not Answered
+              {t('columns.answer_status_cell_unanswered')}
             </>
           )}
         </Badge>
       ),
     },
     {
-      accessorKey: 'type',
-      header: () => <div className='text-center'>Type</div>,
+      id: 'type',
+      accessorKey: t('columns.type_accessorKey'),
+      header: () => <div className='text-center'>{t('columns.type_accessorKey')}</div>,
       cell: ({ row }) => (
-        <Badge variant='outline' className='px-1.5 text-muted-foreground'>
-          {row.original.type}
+        <Badge variant='outline' className='px-1.5 text-muted-foreground lowercase'>
+          {tShared(`type.${row.original.type}`)}
         </Badge>
       ),
     },
     {
-      accessorKey: 'score',
-      header: () => <div className='text-center'>Score</div>,
+      id: 'score',
+      accessorKey: t('columns.score_accessorKey'),
+      header: () => <div className='text-center'>{t('columns.score_accessorKey')}</div>,
       cell: ({ row }) => (
         <div className='text-center text-xs text-foreground' id={`${row.original.id}-score`}>
           {row.original.score}
@@ -115,13 +123,15 @@ export default function ExamQuestionResultTable() {
       ),
     },
     {
-      accessorKey: 'points',
-      header: 'Points',
+      id: 'points',
+      accessorKey: t('columns.points_accessorKey'),
+      header: t('columns.points_accessorKey'),
       cell: ({ row }) => <div className='flex justify-center'>{row.original.points}</div>,
     },
     {
-      accessorKey: 'grade',
-      header: 'Grade',
+      id: 'grade',
+      accessorKey: t('columns.grade_accessorKey'),
+      header: () => <div className='text-center'>{t('columns.grade_accessorKey')}</div>,
       cell: ({ row }) => (
         <div className='flex justify-center'>
           <Input
@@ -141,7 +151,7 @@ export default function ExamQuestionResultTable() {
             <ShowAnswerDrawer_TableCell item={row.original}>
               <Button variant='link' size='sm' className='text-foreground/50'>
                 <EyeIcon />
-                Show Answers
+                {t('columns.preview_action_cell')}
               </Button>
             </ShowAnswerDrawer_TableCell>
           </div>

--- a/src/components/checks/[share_token]/results/ExamQuestionTable_ActionMenu.tsx
+++ b/src/components/checks/[share_token]/results/ExamQuestionTable_ActionMenu.tsx
@@ -6,8 +6,12 @@ import { PreviewQuestionResult_QuestionItem } from '@/src/components/checks/[sha
 import ShowAnswerDrawer_TableCell from '@/src/components/checks/[share_token]/results/PreviewQuestionResultDrawer'
 import { Button } from '@/src/components/shadcn/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/src/components/shadcn/dropdown-menu'
+import { useCurrentLocale, useScopedI18n } from '@/src/i18n/client-localization'
+import { cn } from '@/src/lib/Shared/utils'
 
 export default function ExamQuestionTable_ActionMenu({ row }: { row: Row<PreviewQuestionResult_QuestionItem> }) {
+  const t = useScopedI18n('Checks.ExaminatonResults.ExaminationQuestionTable.ActionMenu')
+  const currentLocale = useCurrentLocale()
   const [drawerOpenState, setDrawerOpenState] = useState(false)
 
   return (
@@ -18,17 +22,17 @@ export default function ExamQuestionTable_ActionMenu({ row }: { row: Row<Preview
         <DropdownMenuTrigger asChild>
           <Button variant='ghost' className='flex size-8 text-muted-foreground data-[state=open]:bg-muted' size='icon'>
             <IconDotsVertical />
-            <span className='sr-only'>Open menu</span>
+            <span className='sr-only'>{t('sr_only_trigger')}</span>
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align='end' className='w-40'>
+        <DropdownMenuContent align='end' className={cn('w-40', currentLocale === 'de' && 'w-48')}>
           <DropdownMenuItem className='justify-between' onSelect={() => requestAnimationFrame(() => setDrawerOpenState(true))}>
-            Show Answers
+            {t('show_answers_label')}
             <ChartColumnIcon className='size-3.5' />
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem variant='destructive' className='justify-between'>
-            Delete Answer
+            {t('delete_answer_label')}
             <TrashIcon className='size-3.5' />
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/components/checks/[share_token]/results/PreviewQuestionResultDrawer.tsx
+++ b/src/components/checks/[share_token]/results/PreviewQuestionResultDrawer.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/src/components/shadcn/label'
 import { Slider } from '@/src/components/shadcn/slider'
 import { Textarea } from '@/src/components/shadcn/textarea'
 import { useIsMobile } from '@/src/hooks/use-mobile'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 import { cn } from '@/src/lib/Shared/utils'
 import { ChoiceQuestion, DragDropQuestion, OpenQuestion } from '@/src/schemas/QuestionSchema'
 import { QuestionInput } from '@/src/schemas/UserQuestionInputSchema'
@@ -26,6 +27,8 @@ export default function ShowAnswerDrawer_TableCell({
   open?: boolean
   setOpenAction?: Dispatch<SetStateAction<boolean>>
 }) {
+  const tShared = useScopedI18n('Shared.Question')
+  const t = useScopedI18n('Checks.ExaminatonResults.ShowAnswerDrawer_TableCell')
   const isMobile = useIsMobile()
   const [slideValue, setSliderValue] = useState([item.score])
 
@@ -41,15 +44,15 @@ export default function ShowAnswerDrawer_TableCell({
           </DrawerClose>
         </div>
         <DrawerHeader className='mb-6 gap-1 border-b'>
-          <DrawerTitle className='capitalize'>Preview user question answer</DrawerTitle>
-          <DrawerDescription>Shows details about a given question and its results.</DrawerDescription>
+          <DrawerTitle className=''>{t('title')}</DrawerTitle>
+          <DrawerDescription>{t('description')}</DrawerDescription>
         </DrawerHeader>
         <div className='flex flex-1 flex-col gap-4 overflow-y-auto px-4 text-sm'>
           <QuestionScoresLineChart className='h-[175px] min-h-[175px]' />
           <form className='mt-4 flex flex-col gap-10 pb-8'>
             <div className='col-span-2 flex flex-2 flex-col gap-2'>
               <Label htmlFor='question' className='text-xs text-muted-foreground capitalize'>
-                {item.type.replace('-', ' ')} Question
+                {tShared(`type.${item.type}`).replace('-', ' ')} {tShared('question_label')}
               </Label>
               <h2 className='text-base/6 font-medium tracking-wide'>{item.questionText}</h2>
             </div>
@@ -57,18 +60,18 @@ export default function ShowAnswerDrawer_TableCell({
             <div className='flex justify-center gap-10 px-2'>
               <div className='flex flex-1 flex-col gap-3'>
                 <div className='flex items-center justify-between'>
-                  <Label htmlFor='slider'>Question Score</Label>
-                  <span className='text-sm text-muted-foreground'>{slideValue[0]} points</span>
+                  <Label htmlFor='slider'>{t('score_slider_label')}</Label>
+                  <span className='text-sm text-muted-foreground'>{tShared('points', { count: slideValue[0] })}</span>
                 </div>
                 <Slider id='slider' max={item.points} min={0} onValueChange={setSliderValue} onPointerDown={(e) => e.stopPropagation()} value={slideValue} />
                 <div className='flex items-center justify-between text-xs text-muted-foreground'>
-                  <span>0 points</span>
-                  <span>{item.points} points</span>
+                  <span>{tShared('points', { count: 0 })}</span>
+                  <span>{tShared('points', { count: item.points })}</span>
                 </div>
               </div>
 
               <div className='flex flex-col gap-3'>
-                <Label>Grade</Label>
+                <Label>{t('grade_label')}</Label>
                 <Input
                   defaultValue={item.grade}
                   placeholder='N/A'
@@ -78,7 +81,7 @@ export default function ShowAnswerDrawer_TableCell({
             </div>
 
             <div className='flex flex-col gap-3'>
-              <Label>{item.type !== 'open-question' ? 'Answers' : 'Answer'}</Label>
+              <Label>{item.type !== 'open-question' ? t('answers_array_label') : t('answer_open_question_label')}</Label>
               <ShowQuestionAnswerResults item={item} />
             </div>
           </form>
@@ -86,12 +89,12 @@ export default function ShowAnswerDrawer_TableCell({
         <DrawerFooter className='grid grid-cols-2 gap-12'>
           <DrawerClose asChild>
             <Button className='' variant='outline'>
-              Close
+              {t('drawer_close_button_label')}
             </Button>
           </DrawerClose>
 
           <DrawerClose asChild>
-            <Button className=''>Save Changes</Button>
+            <Button className=''>{t('drawer_submit_button_label')}</Button>
           </DrawerClose>
         </DrawerFooter>
       </DrawerContent>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -19,7 +19,11 @@
         "exam-only": "Prüfungs Frage"
       },
       "category_label": "Kategorie",
-      "answers_label": "Antworten"
+      "answers_label": "Antworten",
+      "points#one": "{count} Punkt",
+      "points#zero": "{count} Punkte",
+      "points#other": "{count} Punkte",
+      "points": "{count} Punkte"
     },
     "Timestamp": {
       "hour#one": "{count} stunde",
@@ -235,6 +239,16 @@
       "ExamAttemptResultPage": {
         "description": "Zeigt alle Details zum jeweiligen Prüfungsversuch von {name}",
         "title": "Ergebnisse des Prüfungsversuchs"
+      },
+      "ShowAnswerDrawer_TableCell": {
+        "answer_open_question_label": "Antwort",
+        "answers_array_label": "Antworten",
+        "description": "Zeigt Details zu einer bestimmten Frage und ihren Ergebnissen an.",
+        "drawer_close_button_label": "Schließen",
+        "drawer_submit_button_label": "Änderungen speichern",
+        "grade_label": "Note",
+        "score_slider_label": "Fragenergebnis",
+        "title": "Details zur Antwort auf die Prüfungsfrage"
       }
     }
   },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -176,7 +176,10 @@
         },
         "UserTypePieChart": {
           "description": "Zeigt Prüfungsversuche nach Benutzertyp",
-          "title": "Prüfungen nach Benutzertypen"
+          "title": "Prüfungen nach Benutzertypen",
+          "user_type_normal": "Normal",
+          "user_type_anonynmous": "Anonym",
+          "inner_label": "Benutzer"
         }
       },
       "ExaminationAttemptTable": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -212,7 +212,21 @@
         "user_type_normal": "normal"
       },
       "description": "Schauen Sie sich die Prüfungsversuche der Nutzer an.",
-      "title": "Prüfungsergebnisse"
+      "title": "Prüfungsergebnisse",
+      "ExaminationQuestionTable": {
+        "columns": {
+          "answer_status_accessorKey": "Antwortstatus",
+          "answer_status_cell_answered": "Beantwortet",
+          "answer_status_cell_unanswered": "nicht beantwortet",
+          "category_accessorKey": "Kategorie",
+          "grade_accessorKey": "Note",
+          "points_accessorKey": "Punkte",
+          "preview_action_cell": "Antworten anzeigen",
+          "question_accessorKey": "Frage",
+          "score_accessorKey": "Punktzahl",
+          "type_accessorKey": "Typ"
+        }
+      }
     }
   },
   "Examination": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -226,6 +226,10 @@
           "score_accessorKey": "Punktzahl",
           "type_accessorKey": "Typ"
         }
+      },
+      "ExamAttemptResultPage": {
+        "description": "Zeigt alle Details zum jeweiligen Prüfungsversuch von {name}",
+        "title": "Ergebnisse des Prüfungsversuchs"
       }
     }
   },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -181,7 +181,12 @@
         },
         "ExaminationSuccessPieChart": {
           "description": "Zeigt an, wie viele Benutzer bestanden/fehlgeschlagen sind.",
-          "title": "Erfolgsquote der Prüfungen"
+          "title": "Erfolgsquote der Prüfungen",
+          "inner_label#one": "Antritt",
+          "inner_label#other": "Antritte",
+          "inner_label": "Antritte",
+          "passed_label": "Positiv",
+          "failed_label": "Negativ"
         },
         "QuestionScoresLineChartCard": {
           "description": "Zeigt die Varianz zwischen der durchschnittlichen Fragepunktzahl und der Höchstpunktzahl pro Frage an",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -224,6 +224,20 @@
           "title": "Prüfungsversuch – {username}",
           "user_score_label": "Benutzerbewertung",
           "username_label": "Benutzername"
+        },
+        "columns": {
+          "username_header": "Benutzername",
+          "status_header": "Status",
+          "duration_header": "Dauer",
+          "user_type_header": "Benutzertyp",
+          "score_header": "Punktzahl",
+          "totalScore_header": "Maximale Punktzahl",
+          "preview_action_cell": "Vorschau",
+          "actions_menu": {
+            "delete_attempt_label": "Versuch löschen",
+            "show_results_label": "Ergebnisse anzeigen",
+            "sr_only_trigger": "Menü öffnen"
+          }
         }
       },
       "description": "Schauen Sie sich die Prüfungsversuche der Nutzer an.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -28,7 +28,11 @@
       "minute#other": "{count} minuten",
       "join_word": "und",
       "hour": "{count} stunden",
-      "minute": "{count} minuten"
+      "minute": "{count} minuten",
+      "minute_label#one": "minute",
+      "minute_label#zero": "minuten",
+      "minute_label#other": "minuten",
+      "minute_label": "minuten"
     },
     "jump_back_button_label": "Bearbeiten"
   },
@@ -164,7 +168,16 @@
       "Charts": {
         "ExamQuestionDurationChart": {
           "description": "Zeigt die Abweichung zwischen tatsächlicher und geschätzter Antwortzeit an",
-          "title": "Durchschnittlicher Zeitunterschied bei Fragen"
+          "title": "Durchschnittlicher Zeitunterschied bei Fragen",
+          "tooltip": {
+            "title": "Frage {count}",
+            "actual_time_label": "tatsächliche Zeit",
+            "estimated_time_label": "geschätzte Zeit",
+            "total_faster_label": "Schneller um",
+            "total_slower_label": "Langsamer um"
+          },
+          "x_axis_label": "Fragen",
+          "y_axis_label": "Zeitaufwand"
         },
         "ExaminationSuccessPieChart": {
           "description": "Zeigt an, wie viele Benutzer bestanden/fehlgeschlagen sind.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -213,7 +213,18 @@
         "status_in_progress": "läuft",
         "title": "Prüfungsversuche",
         "user_type_anonynmous": "anonym",
-        "user_type_normal": "normal"
+        "user_type_normal": "normal",
+        "Drawer": {
+          "close_button_label": "Schließen",
+          "description": "Zeigt Informationen zum Prüfungsversuch von {username}.",
+          "duration_label": "Dauer",
+          "end_time_label": "Endzeit",
+          "start_time_label": "Startzeit",
+          "submit_button_label": "Änderungen speichern",
+          "title": "Prüfungsversuch – {username}",
+          "user_score_label": "Benutzerbewertung",
+          "username_label": "Benutzername"
+        }
       },
       "description": "Schauen Sie sich die Prüfungsversuche der Nutzer an.",
       "title": "Prüfungsergebnisse",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -190,7 +190,10 @@
         },
         "QuestionScoresLineChartCard": {
           "description": "Zeigt die Varianz zwischen der durchschnittlichen Fragepunktzahl und der Höchstpunktzahl pro Frage an",
-          "title": "Durchschnittliche Fragepunktzahl pro Frage"
+          "title": "Durchschnittliche Fragepunktzahl pro Frage",
+          "x_axis_label": "Fragen",
+          "score_label": "Punkte",
+          "maxScore_label": "max Punkte"
         },
         "UserTypePieChart": {
           "description": "Zeigt Prüfungsversuche nach Benutzertyp",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -94,7 +94,6 @@
           "startDate_label": "Start Datum",
           "endDate_label": "Abschluss Datum"
         },
-
         "ShareSettings": {
           "title": "Freigabe Einstellungen",
           "shareAccessibility": "Öffentlich auffindbar"
@@ -160,6 +159,36 @@
           "eq_filter_operand": "Gleich"
         }
       }
+    },
+    "ExaminatonResults": {
+      "Charts": {
+        "ExamQuestionDurationChart": {
+          "description": "Zeigt die Abweichung zwischen tatsächlicher und geschätzter Antwortzeit an",
+          "title": "Durchschnittlicher Zeitunterschied bei Fragen"
+        },
+        "ExaminationSuccessPieChart": {
+          "description": "Zeigt an, wie viele Benutzer bestanden/fehlgeschlagen sind.",
+          "title": "Erfolgsquote der Prüfungen"
+        },
+        "QuestionScoresLineChartCard": {
+          "description": "Zeigt die Varianz zwischen der durchschnittlichen Fragepunktzahl und der Höchstpunktzahl pro Frage an",
+          "title": "Durchschnittliche Fragepunktzahl pro Frage"
+        },
+        "UserTypePieChart": {
+          "description": "Zeigt Prüfungsversuche nach Benutzertyp",
+          "title": "Prüfungen nach Benutzertypen"
+        }
+      },
+      "ExaminationAttemptTable": {
+        "description": "Zeigt eine detaillierte Liste aller Prüfungsversuche für diese Prüfung",
+        "status_done": "Erledigt",
+        "status_in_progress": "läuft",
+        "title": "Prüfungsversuche",
+        "user_type_anonynmous": "anonym",
+        "user_type_normal": "normal"
+      },
+      "description": "Schauen Sie sich die Prüfungsversuche der Nutzer an.",
+      "title": "Prüfungsergebnisse"
     }
   },
   "Examination": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -306,6 +306,22 @@
       "default_body": "Diese Aktion kann nicht rückgängig gemacht werden. \nDadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.",
       "default_cancel_label": "Abbrechen",
       "default_confirm_label": "Weiter"
+    },
+    "DataTable": {
+      "Pagination": {
+        "current_page_label": "Seite {page} von {total}",
+        "selection_label": "{selected} von {total} Zeilen ausgewählt.",
+        "sr_only": {
+          "go_first_page": "Gehe zur ersten Seite",
+          "go_last_page": "Gehe zur letzten Seite",
+          "go_next_page": "Gehe zur nächsten Seite",
+          "go_previous_page": "Gehe zur vorherigen Seite"
+        }
+      },
+      "customize_columns_label_long": "Spalten anpassen",
+      "customize_columns_label_short": "Spalten",
+      "no_results_label": "Keine Ergebnisse.",
+      "page_size_label": "Zeilen pro Seite"
     }
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -225,6 +225,11 @@
           "question_accessorKey": "Frage",
           "score_accessorKey": "Punktzahl",
           "type_accessorKey": "Typ"
+        },
+        "ActionMenu": {
+          "delete_answer_label": "Antwort löschen",
+          "show_answers_label": "Antworten anzeigen",
+          "sr_only_trigger": "Menü öffnen"
         }
       },
       "ExamAttemptResultPage": {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -29,7 +29,11 @@ export default {
       'minute#other': '{count} minuten',
       join_word: 'und',
       hour: '{count} stunden',
-      minute: '{count} minuten'
+      minute: '{count} minuten',
+      'minute_label#one': 'minute',
+      'minute_label#zero': 'minuten',
+      'minute_label#other': 'minuten',
+      minute_label: 'minuten'
     },
     jump_back_button_label: 'Bearbeiten'
   },
@@ -166,7 +170,16 @@ export default {
       Charts: {
         ExamQuestionDurationChart: {
           description: 'Zeigt die Abweichung zwischen tatsächlicher und geschätzter Antwortzeit an',
-          title: 'Durchschnittlicher Zeitunterschied bei Fragen'
+          title: 'Durchschnittlicher Zeitunterschied bei Fragen',
+          tooltip: {
+            title: 'Frage {count}',
+            actual_time_label: 'tatsächliche Zeit',
+            estimated_time_label: 'geschätzte Zeit',
+            total_faster_label: 'Schneller um',
+            total_slower_label: 'Langsamer um'
+          },
+          x_axis_label: 'Fragen',
+          y_axis_label: 'Zeitaufwand'
         },
         ExaminationSuccessPieChart: {
           description: 'Zeigt an, wie viele Benutzer bestanden/fehlgeschlagen sind.',

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -227,6 +227,10 @@ export default {
           score_accessorKey: 'Punktzahl',
           type_accessorKey: 'Typ'
         }
+      },
+      ExamAttemptResultPage: {
+        description: 'Zeigt alle Details zum jeweiligen Prüfungsversuch von {name}',
+        title: 'Ergebnisse des Prüfungsversuchs'
       }
     }
   },

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -311,6 +311,22 @@ export default {
         'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
       default_cancel_label: 'Abbrechen',
       default_confirm_label: 'Weiter'
+    },
+    DataTable: {
+      Pagination: {
+        current_page_label: 'Seite {page} von {total}',
+        selection_label: '{selected} von {total} Zeilen ausgewählt.',
+        sr_only: {
+          go_first_page: 'Gehe zur ersten Seite',
+          go_last_page: 'Gehe zur letzten Seite',
+          go_next_page: 'Gehe zur nächsten Seite',
+          go_previous_page: 'Gehe zur vorherigen Seite'
+        }
+      },
+      customize_columns_label_long: 'Spalten anpassen',
+      customize_columns_label_short: 'Spalten',
+      no_results_label: 'Keine Ergebnisse.',
+      page_size_label: 'Zeilen pro Seite'
     }
   }
 } as const

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -143,7 +143,8 @@ export default {
     },
     Discover: {
       title: 'Entdecken Sie neue Wissenschecks',
-      no_checks_found_base: 'Keine Wissensüberprüfungen gefunden. \n' + 'Erstellen Sie Ihren eigenen KnowledgeCheck',
+      no_checks_found_base: 'Keine Wissensüberprüfungen gefunden. \n' +
+        'Erstellen Sie Ihren eigenen KnowledgeCheck',
       no_checks_found_link: 'hier',
       FilterFields: {
         filter_operand_menu_label: 'Filter Operatoren',
@@ -160,6 +161,36 @@ export default {
           eq_filter_operand: 'Gleich'
         }
       }
+    },
+    ExaminatonResults: {
+      Charts: {
+        ExamQuestionDurationChart: {
+          description: 'Zeigt die Abweichung zwischen tatsächlicher und geschätzter Antwortzeit an',
+          title: 'Durchschnittlicher Zeitunterschied bei Fragen'
+        },
+        ExaminationSuccessPieChart: {
+          description: 'Zeigt an, wie viele Benutzer bestanden/fehlgeschlagen sind.',
+          title: 'Erfolgsquote der Prüfungen'
+        },
+        QuestionScoresLineChartCard: {
+          description: 'Zeigt die Varianz zwischen der durchschnittlichen Fragepunktzahl und der Höchstpunktzahl pro Frage an',
+          title: 'Durchschnittliche Fragepunktzahl pro Frage'
+        },
+        UserTypePieChart: {
+          description: 'Zeigt Prüfungsversuche nach Benutzertyp',
+          title: 'Prüfungen nach Benutzertypen'
+        }
+      },
+      ExaminationAttemptTable: {
+        description: 'Zeigt eine detaillierte Liste aller Prüfungsversuche für diese Prüfung',
+        status_done: 'Erledigt',
+        status_in_progress: 'läuft',
+        title: 'Prüfungsversuche',
+        user_type_anonynmous: 'anonym',
+        user_type_normal: 'normal'
+      },
+      description: 'Schauen Sie sich die Prüfungsversuche der Nutzer an.',
+      title: 'Prüfungsergebnisse'
     }
   },
   Examination: {
@@ -233,14 +264,15 @@ export default {
       },
       remove_share_token: {
         tooltip: 'Dieser Check hat keinen Freigabe schlüssel.',
-        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird das Share-Token dauerhaft aus diesem KnowledgeCheck gelöscht.',
+        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
+          'Dadurch wird das Share-Token dauerhaft aus diesem KnowledgeCheck gelöscht.',
         toast_deletion_successful: 'Freigabe token erfolgreich gelöscht',
         toast_deletion_failure: 'Löschen des freigabge tokens fehlgeschlagen!'
       },
       delete_knowledgeCheck: {
         label: 'Check löschen',
-        confirmation_dialog_body:
-          'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird dieser KnowledCheck dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
+        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
+          'Dadurch wird dieser KnowledCheck dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
         toast_deletion_successful: 'KnowledgeCheck erfolgreich gelöscht',
         toast_deletion_failure: 'Löschen des KnowledgeChecks fehlgeschlagen!'
       },
@@ -251,7 +283,8 @@ export default {
     },
     ConfirmationDialog: {
       default_title: 'Bist du absolut sicher?',
-      default_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
+      default_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
+        'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
       default_cancel_label: 'Abbrechen',
       default_confirm_label: 'Weiter'
     }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -178,7 +178,10 @@ export default {
         },
         UserTypePieChart: {
           description: 'Zeigt Prüfungsversuche nach Benutzertyp',
-          title: 'Prüfungen nach Benutzertypen'
+          title: 'Prüfungen nach Benutzertypen',
+          user_type_normal: 'Normal',
+          user_type_anonynmous: 'Anonym',
+          inner_label: 'Benutzer'
         }
       },
       ExaminationAttemptTable: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -214,7 +214,18 @@ export default {
         status_in_progress: 'läuft',
         title: 'Prüfungsversuche',
         user_type_anonynmous: 'anonym',
-        user_type_normal: 'normal'
+        user_type_normal: 'normal',
+        Drawer: {
+          close_button_label: 'Schließen',
+          description: 'Zeigt Informationen zum Prüfungsversuch von {username}.',
+          duration_label: 'Dauer',
+          end_time_label: 'Endzeit',
+          start_time_label: 'Startzeit',
+          submit_button_label: 'Änderungen speichern',
+          title: 'Prüfungsversuch – {username}',
+          user_score_label: 'Benutzerbewertung',
+          username_label: 'Benutzername'
+        }
       },
       description: 'Schauen Sie sich die Prüfungsversuche der Nutzer an.',
       title: 'Prüfungsergebnisse',

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -226,6 +226,11 @@ export default {
           question_accessorKey: 'Frage',
           score_accessorKey: 'Punktzahl',
           type_accessorKey: 'Typ'
+        },
+        ActionMenu: {
+          delete_answer_label: 'Antwort löschen',
+          show_answers_label: 'Antworten anzeigen',
+          sr_only_trigger: 'Menü öffnen'
         }
       },
       ExamAttemptResultPage: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -225,6 +225,20 @@ export default {
           title: 'Prüfungsversuch – {username}',
           user_score_label: 'Benutzerbewertung',
           username_label: 'Benutzername'
+        },
+        columns: {
+          actions_menu: {
+            delete_attempt_label: 'Versuch löschen',
+            show_results_label: 'Ergebnisse anzeigen',
+            sr_only_trigger: 'Menü öffnen'
+          },
+          duration_header: 'Dauer',
+          preview_action_cell: 'Vorschau',
+          score_header: 'Punktzahl',
+          status_header: 'Status',
+          totalScore_header: 'Maximale Punktzahl',
+          user_type_header: 'Benutzertyp',
+          username_header: 'Benutzername'
         }
       },
       description: 'Schauen Sie sich die Prüfungsversuche der Nutzer an.',

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -147,8 +147,7 @@ export default {
     },
     Discover: {
       title: 'Entdecken Sie neue Wissenschecks',
-      no_checks_found_base: 'Keine Wissensüberprüfungen gefunden. \n' +
-        'Erstellen Sie Ihren eigenen KnowledgeCheck',
+      no_checks_found_base: 'Keine Wissensüberprüfungen gefunden. \n' + 'Erstellen Sie Ihren eigenen KnowledgeCheck',
       no_checks_found_link: 'hier',
       FilterFields: {
         filter_operand_menu_label: 'Filter Operatoren',
@@ -214,7 +213,21 @@ export default {
         user_type_normal: 'normal'
       },
       description: 'Schauen Sie sich die Prüfungsversuche der Nutzer an.',
-      title: 'Prüfungsergebnisse'
+      title: 'Prüfungsergebnisse',
+      ExaminationQuestionTable: {
+        columns: {
+          answer_status_accessorKey: 'Antwortstatus',
+          answer_status_cell_answered: 'Beantwortet',
+          answer_status_cell_unanswered: 'nicht beantwortet',
+          category_accessorKey: 'Kategorie',
+          grade_accessorKey: 'Note',
+          points_accessorKey: 'Punkte',
+          preview_action_cell: 'Antworten anzeigen',
+          question_accessorKey: 'Frage',
+          score_accessorKey: 'Punktzahl',
+          type_accessorKey: 'Typ'
+        }
+      }
     }
   },
   Examination: {
@@ -288,15 +301,14 @@ export default {
       },
       remove_share_token: {
         tooltip: 'Dieser Check hat keinen Freigabe schlüssel.',
-        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
-          'Dadurch wird das Share-Token dauerhaft aus diesem KnowledgeCheck gelöscht.',
+        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird das Share-Token dauerhaft aus diesem KnowledgeCheck gelöscht.',
         toast_deletion_successful: 'Freigabe token erfolgreich gelöscht',
         toast_deletion_failure: 'Löschen des freigabge tokens fehlgeschlagen!'
       },
       delete_knowledgeCheck: {
         label: 'Check löschen',
-        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
-          'Dadurch wird dieser KnowledCheck dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
+        confirmation_dialog_body:
+          'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird dieser KnowledCheck dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
         toast_deletion_successful: 'KnowledgeCheck erfolgreich gelöscht',
         toast_deletion_failure: 'Löschen des KnowledgeChecks fehlgeschlagen!'
       },
@@ -307,8 +319,7 @@ export default {
     },
     ConfirmationDialog: {
       default_title: 'Bist du absolut sicher?',
-      default_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
-        'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
+      default_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
       default_cancel_label: 'Abbrechen',
       default_confirm_label: 'Weiter'
     },

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -183,7 +183,12 @@ export default {
         },
         ExaminationSuccessPieChart: {
           description: 'Zeigt an, wie viele Benutzer bestanden/fehlgeschlagen sind.',
-          title: 'Erfolgsquote der Prüfungen'
+          title: 'Erfolgsquote der Prüfungen',
+          'inner_label#one': 'Antritt',
+          'inner_label#other': 'Antritte',
+          inner_label: 'Antritte',
+          passed_label: 'Positiv',
+          failed_label: 'Negativ'
         },
         QuestionScoresLineChartCard: {
           description: 'Zeigt die Varianz zwischen der durchschnittlichen Fragepunktzahl und der Höchstpunktzahl pro Frage an',

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -20,7 +20,11 @@ export default {
         'exam-only': 'Prüfungs Frage'
       },
       category_label: 'Kategorie',
-      answers_label: 'Antworten'
+      answers_label: 'Antworten',
+      'points#one': '{count} Punkt',
+      'points#zero': '{count} Punkte',
+      'points#other': '{count} Punkte',
+      points: '{count} Punkte'
     },
     Timestamp: {
       'hour#one': '{count} stunde',
@@ -236,6 +240,16 @@ export default {
       ExamAttemptResultPage: {
         description: 'Zeigt alle Details zum jeweiligen Prüfungsversuch von {name}',
         title: 'Ergebnisse des Prüfungsversuchs'
+      },
+      ShowAnswerDrawer_TableCell: {
+        answer_open_question_label: 'Antwort',
+        answers_array_label: 'Antworten',
+        description: 'Zeigt Details zu einer bestimmten Frage und ihren Ergebnissen an.',
+        drawer_close_button_label: 'Schließen',
+        drawer_submit_button_label: 'Änderungen speichern',
+        grade_label: 'Note',
+        score_slider_label: 'Fragenergebnis',
+        title: 'Details zur Antwort auf die Prüfungsfrage'
       }
     }
   },

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -192,7 +192,10 @@ export default {
         },
         QuestionScoresLineChartCard: {
           description: 'Zeigt die Varianz zwischen der durchschnittlichen Fragepunktzahl und der Höchstpunktzahl pro Frage an',
-          title: 'Durchschnittliche Fragepunktzahl pro Frage'
+          title: 'Durchschnittliche Fragepunktzahl pro Frage',
+          x_axis_label: 'Fragen',
+          score_label: 'Punkte',
+          maxScore_label: 'max Punkte'
         },
         UserTypePieChart: {
           description: 'Zeigt Prüfungsversuche nach Benutzertyp',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -177,6 +177,21 @@
         "user_type_anonynmous": "anonymous"
       },
 
+      "ExaminationQuestionTable": {
+        "columns": {
+          "question_accessorKey": "Question",
+          "category_accessorKey": "Category",
+          "answer_status_accessorKey": "Answer Status",
+          "type_accessorKey": "Type",
+          "score_accessorKey": "Score",
+          "points_accessorKey": "Points",
+          "grade_accessorKey": "Grade",
+          "answer_status_cell_answered": "Answered",
+          "answer_status_cell_unanswered": "not Answered",
+          "preview_action_cell": "Show Answers"
+        }
+      },
+
       "Charts": {
         "UserTypePieChart": {
           "title": "Examinations by User types",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -200,7 +200,12 @@
         },
         "ExaminationSuccessPieChart": {
           "title": "Examinations Success Rate",
-          "description": "Shows how many users have passd / failed."
+          "description": "Shows how many users have passd / failed.",
+          "inner_label#one": "Attempt",
+          "inner_label#other": "Attempts",
+          "inner_label": "Attempts",
+          "passed_label": "Passed",
+          "failed_label": "Failed"
         },
         "QuestionScoresLineChartCard": {
           "title": "Average question score by question",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -172,6 +172,20 @@
       "title": "Examination Results",
       "description": "Look at the examination attempts of users.",
       "ExaminationAttemptTable": {
+        "columns": {
+          "username_header": "Username",
+          "status_header": "Status",
+          "duration_header": "Duration",
+          "user_type_header": "User Type",
+          "score_header": "Score",
+          "totalScore_header": "Max Score",
+          "preview_action_cell": "Preview",
+          "actions_menu": {
+            "sr_only_trigger": "Open menu",
+            "show_results_label": "Show Results",
+            "delete_attempt_label": "Delete Attempt"
+          }
+        },
         "title": "Examination Attempts",
         "description": "Shows a detailed list of all examination attempts for this check",
         "status_done": "Done",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -209,7 +209,10 @@
         },
         "QuestionScoresLineChartCard": {
           "title": "Average question score by question",
-          "description": "Shows the variance between average question score and max-score by question"
+          "description": "Shows the variance between average question score and max-score by question",
+          "x_axis_label": "Questions",
+          "score_label": "Score",
+          "maxScore_label": "max Score"
         }
       }
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -229,6 +229,10 @@
           "score_label": "Score",
           "maxScore_label": "max Score"
         }
+      },
+      "ExamAttemptResultPage": {
+        "title": "Examination Attempt Results",
+        "description": "Shows all the details of the respective examination attempt of {name}"
       }
     }
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -12,6 +12,10 @@
         "drag-drop": "Drag-Drop"
       },
       "points_label": "Points",
+      "points#one": "{count} point",
+      "points#zero": "{count} points",
+      "points#other": "{count} points",
+      "points": "{count} points",
       "accessibility_label": "Accessibility",
       "accessibility": {
         "all": "Universal",
@@ -167,7 +171,6 @@
     "ExaminatonResults": {
       "title": "Examination Results",
       "description": "Look at the examination attempts of users.",
-
       "ExaminationAttemptTable": {
         "title": "Examination Attempts",
         "description": "Shows a detailed list of all examination attempts for this check",
@@ -176,7 +179,6 @@
         "user_type_normal": "normal",
         "user_type_anonynmous": "anonymous"
       },
-
       "ExaminationQuestionTable": {
         "columns": {
           "question_accessorKey": "Question",
@@ -196,7 +198,16 @@
           "delete_answer_label": "Delete Answer"
         }
       },
-
+      "ShowAnswerDrawer_TableCell": {
+        "title": "Preview User Question Answer",
+        "description": "Shows details about a given question and its results.",
+        "score_slider_label": "Question Score",
+        "grade_label": "Grade",
+        "answers_array_label": "Answers",
+        "answer_open_question_label": "Answer",
+        "drawer_close_button_label": "Close",
+        "drawer_submit_button_label": "Save Changes"
+      },
       "Charts": {
         "UserTypePieChart": {
           "title": "Examinations by User types",
@@ -280,7 +291,6 @@
     "KnowledgeCheckCardMenu": {
       "menu_label": "Actions",
       "invite_to_submenu_label": "Invite users to",
-
       "copy_practice": {
         "label": "Copy Practice Link",
         "toast_success": "Successfully saved practice url to clipboard.",
@@ -301,12 +311,10 @@
         "tooltip": "This check has no questions, examination disabled.",
         "toast": "Unable to start Practice"
       },
-
       "edit_check": {
         "label": "Edit KnowledgeCheck",
         "tooltip": "You are not allowed to edit this check!"
       },
-
       "clone_check": {
         "label": "Clone KnowledgeCheck"
       },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -159,6 +159,38 @@
           "eq_filter_operand": "Equals"
         }
       }
+    },
+    "ExaminatonResults": {
+      "title": "Examination Results",
+      "description": "Look at the examination attempts of users.",
+
+      "ExaminationAttemptTable": {
+        "title": "Examination Attempts",
+        "description": "Shows a detailed list of all examination attempts for this check",
+        "status_done": "Done",
+        "status_in_progress": "in-progress",
+        "user_type_normal": "normal",
+        "user_type_anonynmous": "anonymous"
+      },
+
+      "Charts": {
+        "UserTypePieChart": {
+          "title": "Examinations by User types",
+          "description": "Shows examination attempts by user type"
+        },
+        "ExamQuestionDurationChart": {
+          "title": "Average Question time difference",
+          "description": "Shows the variance in actual and estimated answer-time"
+        },
+        "ExaminationSuccessPieChart": {
+          "title": "Examinations Success Rate",
+          "description": "Shows how many users have passd / failed."
+        },
+        "QuestionScoresLineChartCard": {
+          "title": "Average question score by question",
+          "description": "Shows the variance between average question score and max-score by question"
+        }
+      }
     }
   },
   "Examination": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -256,7 +256,7 @@
         },
         "ExaminationSuccessPieChart": {
           "title": "Examinations Success Rate",
-          "description": "Shows how many users have passd / failed.",
+          "description": "Shows how many users have passed / failed.",
           "inner_label#one": "Attempt",
           "inner_label#other": "Attempts",
           "inner_label": "Attempts",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -189,6 +189,11 @@
           "answer_status_cell_answered": "Answered",
           "answer_status_cell_unanswered": "not Answered",
           "preview_action_cell": "Show Answers"
+        },
+        "ActionMenu": {
+          "sr_only_trigger": "Open Menu",
+          "show_answers_label": "Show Answers",
+          "delete_answer_label": "Delete Answer"
         }
       },
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -176,7 +176,10 @@
       "Charts": {
         "UserTypePieChart": {
           "title": "Examinations by User types",
-          "description": "Shows examination attempts by user type"
+          "description": "Shows examination attempts by user type",
+          "user_type_normal": "Normal",
+          "user_type_anonynmous": "Anonymous",
+          "inner_label": "Users"
         },
         "ExamQuestionDurationChart": {
           "title": "Average Question time difference",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -311,6 +311,22 @@
       "default_body": "This action cannot be undone. This will permanently delete this element from your account and remove its data from our servers.",
       "default_cancel_label": "Cancel",
       "default_confirm_label": "Continue"
+    },
+    "DataTable": {
+      "page_size_label": "Rows per page",
+      "customize_columns_label_long": "Customize Columns",
+      "customize_columns_label_short": "Columns",
+      "no_results_label": "No results.",
+      "Pagination": {
+        "selection_label": "{selected} of {total} rows selected.",
+        "current_page_label": "Page {page} of {total}",
+        "sr_only": {
+          "go_first_page": "Go to first page",
+          "go_next_page": "Go to next page",
+          "go_previous_page": "Go to previous page",
+          "go_last_page": "Go to last page"
+        }
+      }
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -177,7 +177,18 @@
         "status_done": "Done",
         "status_in_progress": "in-progress",
         "user_type_normal": "normal",
-        "user_type_anonynmous": "anonymous"
+        "user_type_anonynmous": "anonymous",
+        "Drawer": {
+          "title": "Examination Attempt - {username}",
+          "description": "Showing basics about {username}'s examination attempt.",
+          "username_label": "Username",
+          "user_score_label": "User Score",
+          "start_time_label": "Start Time",
+          "duration_label": "Duration",
+          "end_time_label": "End Time",
+          "close_button_label": "Close",
+          "submit_button_label": "Save Changes"
+        }
       },
       "ExaminationQuestionTable": {
         "columns": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -28,7 +28,11 @@
       "minute#other": "{count} minutes",
       "join_word": "and",
       "hour": "{count} hours",
-      "minute": "{count} minutes"
+      "minute": "{count} minutes",
+      "minute_label#one": "minute",
+      "minute_label#zero": "minutes",
+      "minute_label#other": "minutes",
+      "minute_label": "minutes"
     },
     "jump_back_button_label": "Jump back"
   },
@@ -183,7 +187,16 @@
         },
         "ExamQuestionDurationChart": {
           "title": "Average Question time difference",
-          "description": "Shows the variance in actual and estimated answer-time"
+          "description": "Shows the variance in actual and estimated answer-time",
+          "x_axis_label": "Questions",
+          "y_axis_label": "Time spent",
+          "tooltip": {
+            "title": "Question {count}",
+            "estimated_time_label": "Estimated Time",
+            "actual_time_label": "Time needed",
+            "total_faster_label": "Faster by",
+            "total_slower_label": "Slower by"
+          }
         },
         "ExaminationSuccessPieChart": {
           "title": "Examinations Success Rate",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -173,6 +173,20 @@ export default {
       title: 'Examination Results',
       description: 'Look at the examination attempts of users.',
       ExaminationAttemptTable: {
+        columns: {
+          username_header: 'Username',
+          status_header: 'Status',
+          duration_header: 'Duration',
+          user_type_header: 'User Type',
+          score_header: 'Score',
+          totalScore_header: 'Max Score',
+          preview_action_cell: 'Preview',
+          actions_menu: {
+            sr_only_trigger: 'Open menu',
+            show_results_label: 'Show Results',
+            delete_attempt_label: 'Delete Attempt'
+          }
+        },
         title: 'Examination Attempts',
         description: 'Shows a detailed list of all examination attempts for this check',
         status_done: 'Done',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -160,6 +160,36 @@ export default {
           eq_filter_operand: 'Equals'
         }
       }
+    },
+    ExaminatonResults: {
+      title: 'Examination Results',
+      description: 'Look at the examination attempts of users.',
+      ExaminationAttemptTable: {
+        title: 'Examination Attempts',
+        description: 'Shows a detailed list of all examination attempts for this check',
+        status_done: 'Done',
+        status_in_progress: 'in-progress',
+        user_type_normal: 'normal',
+        user_type_anonynmous: 'anonymous'
+      },
+      Charts: {
+        UserTypePieChart: {
+          title: 'Examinations by User types',
+          description: 'Shows examination attempts by user type'
+        },
+        ExamQuestionDurationChart: {
+          title: 'Average Question time difference',
+          description: 'Shows the variance in actual and estimated answer-time'
+        },
+        ExaminationSuccessPieChart: {
+          title: 'Examinations Success Rate',
+          description: 'Shows how many users have passd / failed.'
+        },
+        QuestionScoresLineChartCard: {
+          title: 'Average question score by question',
+          description: 'Shows the variance between average question score and max-score by question'
+        }
+      }
     }
   },
   Examination: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -13,6 +13,10 @@ export default {
         'drag-drop': 'Drag-Drop'
       },
       points_label: 'Points',
+      'points#one': '{count} point',
+      'points#zero': '{count} points',
+      'points#other': '{count} points',
+      points: '{count} points',
       accessibility_label: 'Accessibility',
       accessibility: {
         all: 'Universal',
@@ -194,6 +198,16 @@ export default {
           show_answers_label: 'Show Answers',
           delete_answer_label: 'Delete Answer'
         }
+      },
+      ShowAnswerDrawer_TableCell: {
+        title: 'Preview User Question Answer',
+        description: 'Shows details about a given question and its results.',
+        score_slider_label: 'Question Score',
+        grade_label: 'Grade',
+        answers_array_label: 'Answers',
+        answer_open_question_label: 'Answer',
+        drawer_close_button_label: 'Close',
+        drawer_submit_button_label: 'Save Changes'
       },
       Charts: {
         UserTypePieChart: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -175,7 +175,10 @@ export default {
       Charts: {
         UserTypePieChart: {
           title: 'Examinations by User types',
-          description: 'Shows examination attempts by user type'
+          description: 'Shows examination attempts by user type',
+          user_type_normal: 'Normal',
+          user_type_anonynmous: 'Anonymous',
+          inner_label: 'Users'
         },
         ExamQuestionDurationChart: {
           title: 'Average Question time difference',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -178,7 +178,18 @@ export default {
         status_done: 'Done',
         status_in_progress: 'in-progress',
         user_type_normal: 'normal',
-        user_type_anonynmous: 'anonymous'
+        user_type_anonynmous: 'anonymous',
+        Drawer: {
+          title: 'Examination Attempt - {username}',
+          description: "Showing basics about {username}'s examination attempt.",
+          username_label: 'Username',
+          user_score_label: 'User Score',
+          start_time_label: 'Start Time',
+          duration_label: 'Duration',
+          end_time_label: 'End Time',
+          close_button_label: 'Close',
+          submit_button_label: 'Save Changes'
+        }
       },
       ExaminationQuestionTable: {
         columns: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -188,6 +188,11 @@ export default {
           answer_status_cell_answered: 'Answered',
           answer_status_cell_unanswered: 'not Answered',
           preview_action_cell: 'Show Answers'
+        },
+        ActionMenu: {
+          sr_only_trigger: 'Open Menu',
+          show_answers_label: 'Show Answers',
+          delete_answer_label: 'Delete Answer'
         }
       },
       Charts: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -227,6 +227,10 @@ export default {
           score_label: 'Score',
           maxScore_label: 'max Score'
         }
+      },
+      ExamAttemptResultPage: {
+        title: 'Examination Attempt Results',
+        description: 'Shows all the details of the respective examination attempt of {name}'
       }
     }
   },

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -176,6 +176,20 @@ export default {
         user_type_normal: 'normal',
         user_type_anonynmous: 'anonymous'
       },
+      ExaminationQuestionTable: {
+        columns: {
+          question_accessorKey: 'Question',
+          category_accessorKey: 'Category',
+          answer_status_accessorKey: 'Answer Status',
+          type_accessorKey: 'Type',
+          score_accessorKey: 'Score',
+          points_accessorKey: 'Points',
+          grade_accessorKey: 'Grade',
+          answer_status_cell_answered: 'Answered',
+          answer_status_cell_unanswered: 'not Answered',
+          preview_action_cell: 'Show Answers'
+        }
+      },
       Charts: {
         UserTypePieChart: {
           title: 'Examinations by User types',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -199,7 +199,10 @@ export default {
         },
         ExaminationSuccessPieChart: {
           title: 'Examinations Success Rate',
-          description: 'Shows how many users have passd / failed.'
+          description: 'Shows how many users have passd / failed.',
+          inner_label: 'Attempts',
+          passed_label: 'Passed',
+          failed_label: 'Failed'
         },
         QuestionScoresLineChartCard: {
           title: 'Average question score by question',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -307,6 +307,22 @@ export default {
       default_body: 'This action cannot be undone. This will permanently delete this element from your account and remove its data from our servers.',
       default_cancel_label: 'Cancel',
       default_confirm_label: 'Continue'
+    },
+    DataTable: {
+      page_size_label: 'Rows per page',
+      customize_columns_label_long: 'Customize Columns',
+      customize_columns_label_short: 'Columns',
+      no_results_label: 'No results.',
+      Pagination: {
+        selection_label: '{selected} of {total} rows selected.',
+        current_page_label: 'Page {page} of {total}',
+        sr_only: {
+          go_first_page: 'Go to first page',
+          go_next_page: 'Go to next page',
+          go_previous_page: 'Go to previous page',
+          go_last_page: 'Go to last page'
+        }
+      }
     }
   }
 } as const

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -257,7 +257,7 @@ export default {
         },
         ExaminationSuccessPieChart: {
           title: 'Examinations Success Rate',
-          description: 'Shows how many users have passd / failed.',
+          description: 'Shows how many users have passed / failed.',
           'inner_label#one': 'Attempt',
           'inner_label#other': 'Attempts',
           inner_label: 'Attempts',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -29,7 +29,11 @@ export default {
       'minute#other': '{count} minutes',
       join_word: 'and',
       hour: '{count} hours',
-      minute: '{count} minutes'
+      minute: '{count} minutes',
+      'minute_label#one': 'minute',
+      'minute_label#zero': 'minutes',
+      'minute_label#other': 'minutes',
+      minute_label: 'minutes'
     },
     jump_back_button_label: 'Jump back'
   },
@@ -182,7 +186,16 @@ export default {
         },
         ExamQuestionDurationChart: {
           title: 'Average Question time difference',
-          description: 'Shows the variance in actual and estimated answer-time'
+          description: 'Shows the variance in actual and estimated answer-time',
+          x_axis_label: 'Questions',
+          y_axis_label: 'Time spent',
+          tooltip: {
+            title: 'Question {count}',
+            estimated_time_label: 'Estimated Time',
+            actual_time_label: 'Time needed',
+            total_faster_label: 'Faster by',
+            total_slower_label: 'Slower by'
+          }
         },
         ExaminationSuccessPieChart: {
           title: 'Examinations Success Rate',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -200,13 +200,18 @@ export default {
         ExaminationSuccessPieChart: {
           title: 'Examinations Success Rate',
           description: 'Shows how many users have passd / failed.',
+          'inner_label#one': 'Attempt',
+          'inner_label#other': 'Attempts',
           inner_label: 'Attempts',
           passed_label: 'Passed',
           failed_label: 'Failed'
         },
         QuestionScoresLineChartCard: {
           title: 'Average question score by question',
-          description: 'Shows the variance between average question score and max-score by question'
+          description: 'Shows the variance between average question score and max-score by question',
+          x_axis_label: 'Questions',
+          score_label: 'Score',
+          maxScore_label: 'max Score'
         }
       }
     }


### PR DESCRIPTION
## Summary 

* **New Features**
  * Added localization to examination results: pages, charts, tables, drawers, tooltips and pagination (en/de).

* **Style / Accessibility**
  * Increased table action menu (dropdown) width when the `de` locale is selected because of longer labels. 


--- 
### Detailed Changelog 

<details>
<summary>Changelog</summary>

 [](https://google.com)

- **Refactors**:
  - Added translations to `/[share_token]/results` page ([`ef334994`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/ef334994))
  - Added translations to `UserTypePieChart` ([`8eb42df1`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/8eb42df1))
     Added translations for chart-axes and labels.
  - Added translations to `QuestionDurationChart` ([`6f4c253a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/6f4c253a))
  - Added translations to `ExamSuccessPieChart` ([`921819b1`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/921819b1))
  - Added translations to `QuestionScoresLineChart` ([`43fbb95a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/43fbb95a))
  - Added translations to `DataTable` ([`b4120886`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/b4120886))
  - Added translations to `ExamQuestionResultTable` ([`d3ec7324`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/d3ec7324))
  - Added translations to `ExamAttemptResultPage` ([`70298e81`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/70298e81))
  - Added translations to `ExamQTable_ActionMenu` ([`3a4c6b93`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/3a4c6b93))
  - Added translations to `PreviewQRDrawer` ([`bacda314`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/bacda314))
  - Added translations to `ExamAttemptTable` ([`af418428`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/af418428))
  - Added translations to `ExamATable` columns ([`b25338de`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/b25338de))
  - Added translation for duration in `ExamATable` ([`623c9e0e`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/623c9e0e))
  - Fixed typo in chart description translation ([`f1ac3e4f`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f1ac3e4f))

</details>