### PR TITLE
Feat: Introduce column sorting to DataTable

### DIFF
--- a/src/components/Shared/Table/DataTable.tsx
+++ b/src/components/Shared/Table/DataTable.tsx
@@ -70,7 +70,17 @@ function DraggableRow<I extends { id: string | number }>({ row }: { row: Row<I> 
   )
 }
 
-export function DataTable<T extends I[], I extends { id: string | number }>({ data: initialData, columns, columnHideOrder }: { data: T; columns: ColumnDef<I>[]; columnHideOrder?: string[] }) {
+export function DataTable<T extends I[], I extends { id: string | number }>({
+  data: initialData,
+  columns,
+  columnHideOrder,
+  enableSorting = true,
+}: {
+  data: T
+  columns: ColumnDef<I>[]
+  columnHideOrder?: string[]
+  enableSorting?: boolean
+}) {
   const t = useScopedI18n('Components.DataTable')
   const [data, setData] = React.useState<I[]>(() => initialData)
   const [rowSelection, setRowSelection] = React.useState({})
@@ -98,7 +108,7 @@ export function DataTable<T extends I[], I extends { id: string | number }>({ da
     },
     getRowId: (row) => row.id.toString(),
     enableRowSelection: true,
-    enableSorting: true,
+    enableSorting: enableSorting,
     enableSortingRemoval: false,
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,

--- a/src/components/Shared/Table/DataTable.tsx
+++ b/src/components/Shared/Table/DataTable.tsx
@@ -29,7 +29,7 @@ import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMe
 import { Label } from '@/components/shadcn/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/shadcn/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/shadcn/table'
-import { useScopedI18n } from '@/src/i18n/client-localization'
+import { useCurrentLocale, useScopedI18n } from '@/src/i18n/client-localization'
 import getKeys from '@/src/lib/Shared/Keys'
 import { cn } from '@/src/lib/Shared/utils'
 
@@ -82,6 +82,7 @@ export function DataTable<T extends I[], I extends { id: string | number }>({
   enableSorting?: boolean
 }) {
   const t = useScopedI18n('Components.DataTable')
+  const currentLocale = useCurrentLocale()
   const [data, setData] = React.useState<I[]>(() => initialData)
   const [rowSelection, setRowSelection] = React.useState({})
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({})
@@ -274,13 +275,13 @@ export function DataTable<T extends I[], I extends { id: string | number }>({
                                 type='button'
                                 onClick={header.column.getToggleSortingHandler()}
                                 className='inline-flex flex-1 items-center justify-between gap-2 select-none hover:cursor-pointer'
-                                aria-label={`Sort by ${header.id}`}>
+                                aria-label={t('Sorting.column_sort_button_aria_label', { columnId: header.column.id })}>
                                 {flexRender(header.column.columnDef.header, header.getContext())}
 
                                 {header.column.getIsSorted() === 'asc' ? (
-                                  <IconSortAscending className='size-4 opacity-80' title='Sorting rows in ascending order' />
+                                  <IconSortAscending className='size-4 opacity-80' title={t('Sorting.ascending_order_title')} />
                                 ) : header.column.getIsSorted() === 'desc' ? (
-                                  <IconSortDescending className='size-4 opacity-80' title='Sorting rows in descending order' />
+                                  <IconSortDescending className='size-4 opacity-80' title={t('Sorting.descending_order_title')} />
                                 ) : (
                                   <></>
                                 )}
@@ -292,7 +293,7 @@ export function DataTable<T extends I[], I extends { id: string | number }>({
                                     variant='ghost'
                                     size='icon'
                                     className={cn('size-5 opacity-65', header.column.getIsSorted() && 'hidden')}
-                                    aria-label='Open sort menu'
+                                    aria-label={t('Sorting.dropdown_sr_only_trigger_label')}
                                     onClick={(e) => {
                                       // Prevent the header toggle click from firing when opening the menu.
                                       e.stopPropagation()
@@ -300,14 +301,14 @@ export function DataTable<T extends I[], I extends { id: string | number }>({
                                     <IconChevronDown className='size-4 opacity-60' />
                                   </Button>
                                 </DropdownMenuTrigger>
-                                <DropdownMenuContent align='start' className='w-44'>
+                                <DropdownMenuContent align='start' className={cn('w-44', currentLocale === 'de' && 'w-50')}>
                                   <DropdownMenuItem onClick={() => header.column.toggleSorting(false, false)}>
                                     <IconSortAscending className='mr-2 size-4' />
-                                    Sort ascending
+                                    {t('Sorting.ascending_order_label')}
                                   </DropdownMenuItem>
                                   <DropdownMenuItem onClick={() => header.column.toggleSorting(true, false)}>
                                     <IconSortDescending className='mr-2 size-4' />
-                                    Sort descending
+                                    {t('Sorting.descending_order_label')}
                                   </DropdownMenuItem>
                                 </DropdownMenuContent>
                               </DropdownMenu>

--- a/src/components/Shared/Table/DataTable.tsx
+++ b/src/components/Shared/Table/DataTable.tsx
@@ -24,6 +24,7 @@ import {
 } from '@tanstack/react-table'
 import { useOrientation, usePrevious, useWindowSize } from '@uidotdev/usehooks'
 import isEqual from 'lodash/isEqual'
+import { EraserIcon } from 'lucide-react'
 import { Button } from '@/components/shadcn/button'
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/shadcn/dropdown-menu'
 import { Label } from '@/components/shadcn/label'
@@ -314,6 +315,10 @@ export function DataTable<T extends I[], I extends { id: string | number }>({
                                   <DropdownMenuItem onClick={() => header.column.toggleSorting(true, false)}>
                                     <IconSortDescending className='mr-2 size-4' />
                                     {t('Sorting.descending_order_label')}
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem disabled={header.column.getIsSorted() === false} onClick={() => header.column.clearSorting()}>
+                                    <EraserIcon className='mr-2 size-4' />
+                                    {t('Sorting.reset_sorting_label')}
                                   </DropdownMenuItem>
                                 </DropdownMenuContent>
                               </DropdownMenu>

--- a/src/components/Shared/Table/DataTable.tsx
+++ b/src/components/Shared/Table/DataTable.tsx
@@ -292,7 +292,7 @@ export function DataTable<T extends I[], I extends { id: string | number }>({
                                   <Button
                                     variant='ghost'
                                     size='icon'
-                                    className={cn('size-5 opacity-65', header.column.getIsSorted() && 'hidden')}
+                                    className={cn('size-5 opacity-65')}
                                     aria-label={t('Sorting.dropdown_sr_only_trigger_label')}
                                     onClick={(e) => {
                                       // Prevent the header toggle click from firing when opening the menu.

--- a/src/components/Shared/Table/DataTable.tsx
+++ b/src/components/Shared/Table/DataTable.tsx
@@ -231,9 +231,12 @@ export function DataTable<T extends I[], I extends { id: string | number }>({ da
                         setColumnHidingPolicy('manual')
                       }}>
                       {/* renders the column-header instead of (id / accessorKey) to re-use the same localized value */}
-                      {typeof column.columnDef.header === 'function'
-                        ? column.columnDef.header({ table, column, header: table.getFlatHeaders().find((h) => h.id === column.id)! })
-                        : column.columnDef.header}
+                      {typeof column.columnDef.header === 'function' ? (
+                        // by wrapping header [() => ReactNode] in a wrapper-div, styles like `w-full text-center` will no longer work as expected
+                        <div>{column.columnDef.header({ table, column, header: table.getFlatHeaders().find((h) => h.id === column.id)! })}</div>
+                      ) : (
+                        column.columnDef.header
+                      )}
                     </DropdownMenuCheckboxItem>
                   )
                 })}

--- a/src/components/Shared/Table/DataTable.tsx
+++ b/src/components/Shared/Table/DataTable.tsx
@@ -219,7 +219,7 @@ export function DataTable<T extends I[], I extends { id: string | number }>({ da
             <DropdownMenuContent align='end' className='w-56'>
               {table
                 .getAllColumns()
-                .filter((column) => typeof column.accessorFn !== 'undefined' && column.getCanHide())
+                .filter((column) => typeof column.accessorFn !== 'undefined' && column.getCanHide() && column.columnDef.header)
                 .map((column) => {
                   return (
                     <DropdownMenuCheckboxItem
@@ -230,8 +230,10 @@ export function DataTable<T extends I[], I extends { id: string | number }>({ da
                         column.toggleVisibility(!!value)
                         setColumnHidingPolicy('manual')
                       }}>
-                      {/* @ts-expect-error Expect accessorKey to be not recognized even though it exists */}
-                      {column.columnDef.accessorKey ?? column.id}
+                      {/* renders the column-header instead of (id / accessorKey) to re-use the same localized value */}
+                      {typeof column.columnDef.header === 'function'
+                        ? column.columnDef.header({ table, column, header: table.getFlatHeaders().find((h) => h.id === column.id)! })
+                        : column.columnDef.header}
                     </DropdownMenuCheckboxItem>
                   )
                 })}

--- a/src/components/Shared/Table/DataTable.tsx
+++ b/src/components/Shared/Table/DataTable.tsx
@@ -316,7 +316,12 @@ export function DataTable<T extends I[], I extends { id: string | number }>({
                                     <IconSortDescending className='mr-2 size-4' />
                                     {t('Sorting.descending_order_label')}
                                   </DropdownMenuItem>
-                                  <DropdownMenuItem disabled={header.column.getIsSorted() === false} onClick={() => header.column.clearSorting()}>
+                                  <DropdownMenuItem
+                                    enableTooltip={header.column.getIsSorted() === false}
+                                    tooltipOptions={{ content: 'This column is currently not being sorted.', variant: 'destructive', side: 'right' }}
+                                    className='data-disabled:cursor-not-allowed!'
+                                    disabled={header.column.getIsSorted() === false}
+                                    onClick={() => header.column.clearSorting()}>
                                     <EraserIcon className='mr-2 size-4' />
                                     {t('Sorting.reset_sorting_label')}
                                   </DropdownMenuItem>

--- a/src/components/Shared/Table/DataTable.tsx
+++ b/src/components/Shared/Table/DataTable.tsx
@@ -318,7 +318,7 @@ export function DataTable<T extends I[], I extends { id: string | number }>({
                                   </DropdownMenuItem>
                                   <DropdownMenuItem
                                     enableTooltip={header.column.getIsSorted() === false}
-                                    tooltipOptions={{ content: 'This column is currently not being sorted.', variant: 'destructive', side: 'right' }}
+                                    tooltipOptions={{ content: t('Sorting.reset_sorting_disabled_tooltip'), variant: 'destructive', side: 'right' }}
                                     className='data-disabled:cursor-not-allowed!'
                                     disabled={header.column.getIsSorted() === false}
                                     onClick={() => header.column.clearSorting()}>

--- a/src/components/Shared/Table/DataTable.tsx
+++ b/src/components/Shared/Table/DataTable.tsx
@@ -29,6 +29,7 @@ import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMe
 import { Label } from '@/components/shadcn/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/shadcn/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/shadcn/table'
+import Tooltip from '@/src/components/Shared/Tooltip'
 import { useCurrentLocale, useScopedI18n } from '@/src/i18n/client-localization'
 import getKeys from '@/src/lib/Shared/Keys'
 import { cn } from '@/src/lib/Shared/utils'
@@ -279,9 +280,13 @@ export function DataTable<T extends I[], I extends { id: string | number }>({
                                 {flexRender(header.column.columnDef.header, header.getContext())}
 
                                 {header.column.getIsSorted() === 'asc' ? (
-                                  <IconSortAscending className='size-4 opacity-80' title={t('Sorting.ascending_order_title')} />
+                                  <Tooltip content={t('Sorting.ascending_order_title')}>
+                                    <IconSortAscending className='size-4 opacity-80' />
+                                  </Tooltip>
                                 ) : header.column.getIsSorted() === 'desc' ? (
-                                  <IconSortDescending className='size-4 opacity-80' title={t('Sorting.descending_order_title')} />
+                                  <Tooltip content={t('Sorting.descending_order_title')}>
+                                    <IconSortDescending className='size-4 opacity-80' />
+                                  </Tooltip>
                                 ) : (
                                   <></>
                                 )}

--- a/src/components/checks/[share_token]/results/ExamQuestionResultTable.tsx
+++ b/src/components/checks/[share_token]/results/ExamQuestionResultTable.tsx
@@ -63,7 +63,7 @@ export default function ExamQuestionResultTable() {
     },
     {
       id: 'primary',
-      accessorKey: t('columns.question_accessorKey'),
+      accessorKey: 'questionText',
       header: t('columns.question_accessorKey'),
       cell: ({ row }) => {
         return <div className='text-left text-foreground'>{row.original.questionText}</div>
@@ -72,8 +72,7 @@ export default function ExamQuestionResultTable() {
     },
 
     {
-      id: 'category',
-      accessorKey: t('columns.category_accessorKey'),
+      accessorKey: 'category',
       header: () => <div className='text-center'>{t('columns.category_accessorKey')}</div>,
       cell: ({ row }) => (
         <Badge variant='outline' className='px-1.5 text-muted-foreground'>
@@ -83,8 +82,7 @@ export default function ExamQuestionResultTable() {
     },
 
     {
-      id: 'answer status',
-      accessorKey: t('columns.answer_status_accessorKey'),
+      accessorKey: 'answer status',
       header: () => <div className='text-center'>{t('columns.answer_status_accessorKey')}</div>,
       cell: () => (
         <Badge variant='outline' className='px-1.5 text-muted-foreground'>
@@ -103,8 +101,7 @@ export default function ExamQuestionResultTable() {
       ),
     },
     {
-      id: 'type',
-      accessorKey: t('columns.type_accessorKey'),
+      accessorKey: 'type',
       header: () => <div className='text-center'>{t('columns.type_accessorKey')}</div>,
       cell: ({ row }) => (
         <Badge variant='outline' className='px-1.5 text-muted-foreground lowercase'>
@@ -113,8 +110,7 @@ export default function ExamQuestionResultTable() {
       ),
     },
     {
-      id: 'score',
-      accessorKey: t('columns.score_accessorKey'),
+      accessorKey: 'score',
       header: () => <div className='text-center'>{t('columns.score_accessorKey')}</div>,
       cell: ({ row }) => (
         <div className='text-center text-xs text-foreground' id={`${row.original.id}-score`}>
@@ -123,14 +119,12 @@ export default function ExamQuestionResultTable() {
       ),
     },
     {
-      id: 'points',
-      accessorKey: t('columns.points_accessorKey'),
+      accessorKey: 'points',
       header: t('columns.points_accessorKey'),
       cell: ({ row }) => <div className='flex justify-center'>{row.original.points}</div>,
     },
     {
-      id: 'grade',
-      accessorKey: t('columns.grade_accessorKey'),
+      accessorKey: 'grade',
       header: () => <div className='text-center'>{t('columns.grade_accessorKey')}</div>,
       cell: ({ row }) => (
         <div className='flex justify-center'>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -389,6 +389,7 @@
         "ascending_order_title": "Zeilen in aufsteigender Reihenfolge sortieren",
         "descending_order_label": "Absteigend sortieren",
         "descending_order_title": "Zeilen in absteigender Reihenfolge sortieren",
+        "reset_sorting_label": "Sortierung entfernen",
         "column_sort_button_aria_label": "Sortieren nach {columnId}",
         "dropdown_sr_only_trigger_label": "Sortiermenü öffnen"
       }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -383,7 +383,15 @@
       "customize_columns_label_long": "Spalten anpassen",
       "customize_columns_label_short": "Spalten",
       "no_results_label": "Keine Ergebnisse.",
-      "page_size_label": "Zeilen pro Seite"
+      "page_size_label": "Zeilen pro Seite",
+      "Sorting": {
+        "ascending_order_label": "Aufsteigend sortieren",
+        "ascending_order_title": "Zeilen in aufsteigender Reihenfolge sortieren",
+        "descending_order_label": "Absteigend sortieren",
+        "descending_order_title": "Zeilen in absteigender Reihenfolge sortieren",
+        "column_sort_button_aria_label": "Sortieren nach {columnId}",
+        "dropdown_sr_only_trigger_label": "Sortiermenü öffnen"
+      }
     }
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -390,6 +390,7 @@
         "descending_order_label": "Absteigend sortieren",
         "descending_order_title": "Zeilen in absteigender Reihenfolge sortieren",
         "reset_sorting_label": "Sortierung entfernen",
+        "reset_sorting_disabled_tooltip": "Diese Spalte wird derzeit nicht sortiert.",
         "column_sort_button_aria_label": "Sortieren nach {columnId}",
         "dropdown_sr_only_trigger_label": "Sortiermenü öffnen"
       }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -227,18 +227,18 @@ export default {
           username_label: 'Benutzername'
         },
         columns: {
+          username_header: 'Benutzername',
+          status_header: 'Status',
+          duration_header: 'Dauer',
+          user_type_header: 'Benutzertyp',
+          score_header: 'Punktzahl',
+          totalScore_header: 'Maximale Punktzahl',
+          preview_action_cell: 'Vorschau',
           actions_menu: {
             delete_attempt_label: 'Versuch löschen',
             show_results_label: 'Ergebnisse anzeigen',
             sr_only_trigger: 'Menü öffnen'
-          },
-          duration_header: 'Dauer',
-          preview_action_cell: 'Vorschau',
-          score_header: 'Punktzahl',
-          status_header: 'Status',
-          totalScore_header: 'Maximale Punktzahl',
-          user_type_header: 'Benutzertyp',
-          username_header: 'Benutzername'
+          }
         }
       },
       description: 'Schauen Sie sich die Prüfungsversuche der Nutzer an.',
@@ -385,7 +385,15 @@ export default {
       customize_columns_label_long: 'Spalten anpassen',
       customize_columns_label_short: 'Spalten',
       no_results_label: 'Keine Ergebnisse.',
-      page_size_label: 'Zeilen pro Seite'
+      page_size_label: 'Zeilen pro Seite',
+      Sorting: {
+        ascending_order_label: 'Aufsteigend sortieren',
+        ascending_order_title: 'Zeilen in aufsteigender Reihenfolge sortieren',
+        descending_order_label: 'Absteigend sortieren',
+        descending_order_title: 'Zeilen in absteigender Reihenfolge sortieren',
+        column_sort_button_aria_label: 'Sortieren nach {columnId}',
+        dropdown_sr_only_trigger_label: 'Sortiermenü öffnen'
+      }
     }
   }
 } as const

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -391,6 +391,7 @@ export default {
         ascending_order_title: 'Zeilen in aufsteigender Reihenfolge sortieren',
         descending_order_label: 'Absteigend sortieren',
         descending_order_title: 'Zeilen in absteigender Reihenfolge sortieren',
+        reset_sorting_label: 'Sortierung entfernen',
         column_sort_button_aria_label: 'Sortieren nach {columnId}',
         dropdown_sr_only_trigger_label: 'Sortiermenü öffnen'
       }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -392,6 +392,7 @@ export default {
         descending_order_label: 'Absteigend sortieren',
         descending_order_title: 'Zeilen in absteigender Reihenfolge sortieren',
         reset_sorting_label: 'Sortierung entfernen',
+        reset_sorting_disabled_tooltip: 'Diese Spalte wird derzeit nicht sortiert.',
         column_sort_button_aria_label: 'Sortieren nach {columnId}',
         dropdown_sr_only_trigger_label: 'Sortiermenü öffnen'
       }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -389,6 +389,7 @@
         "ascending_order_label": "Sort ascending",
         "descending_order_title": "Sorting rows in descending order",
         "descending_order_label": "Sort descending",
+        "reset_sorting_label": "Reset Sorting",
         "dropdown_sr_only_trigger_label": "Open sort menu",
         "column_sort_button_aria_label": "Sort by {columnId}"
       }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -383,6 +383,14 @@
           "go_previous_page": "Go to previous page",
           "go_last_page": "Go to last page"
         }
+      },
+      "Sorting": {
+        "ascending_order_title": "Sorting rows in ascending order",
+        "ascending_order_label": "Sort ascending",
+        "descending_order_title": "Sorting rows in descending order",
+        "descending_order_label": "Sort descending",
+        "dropdown_sr_only_trigger_label": "Open sort menu",
+        "column_sort_button_aria_label": "Sort by {columnId}"
       }
     }
   }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -390,6 +390,7 @@
         "descending_order_title": "Sorting rows in descending order",
         "descending_order_label": "Sort descending",
         "reset_sorting_label": "Reset Sorting",
+        "reset_sorting_disabled_tooltip": "This column is currently not being sorted.",
         "dropdown_sr_only_trigger_label": "Open sort menu",
         "column_sort_button_aria_label": "Sort by {columnId}"
       }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -391,6 +391,7 @@ export default {
         descending_order_title: 'Sorting rows in descending order',
         descending_order_label: 'Sort descending',
         reset_sorting_label: 'Reset Sorting',
+        reset_sorting_disabled_tooltip: 'This column is currently not being sorted.',
         dropdown_sr_only_trigger_label: 'Open sort menu',
         column_sort_button_aria_label: 'Sort by {columnId}'
       }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -390,6 +390,7 @@ export default {
         ascending_order_label: 'Sort ascending',
         descending_order_title: 'Sorting rows in descending order',
         descending_order_label: 'Sort descending',
+        reset_sorting_label: 'Reset Sorting',
         dropdown_sr_only_trigger_label: 'Open sort menu',
         column_sort_button_aria_label: 'Sort by {columnId}'
       }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -384,6 +384,14 @@ export default {
           go_previous_page: 'Go to previous page',
           go_last_page: 'Go to last page'
         }
+      },
+      Sorting: {
+        ascending_order_title: 'Sorting rows in ascending order',
+        ascending_order_label: 'Sort ascending',
+        descending_order_title: 'Sorting rows in descending order',
+        descending_order_label: 'Sort descending',
+        dropdown_sr_only_trigger_label: 'Open sort menu',
+        column_sort_button_aria_label: 'Sort by {columnId}'
       }
     }
   }


### PR DESCRIPTION
> [!NOTE]
> This is what the sorting controls look like in the `DataTable` when enabled:
> https://github.com/user-attachments/assets/477a3519-7b85-4986-99df-fe5250cf5d02
>
> Note that users can "initiate" sorting by clicking on a given column or by opening the `DrownDownMenu` and selecting a respective sort-order. Users can also clear their column sort order by opening the `DropDownMenu` of the column that is being sorted and by selected the `Reset Sorting` item.


## Summary 

* **New Features**
  * Table headers now show sorting controls with ascending/descending indicators, a dropdown-menu to pick sort direction and a reset-sort item.
  * Sorting can be turned on or off per table
  * Added ability to reset column sorting to its default state.

* **Bug Fixes**
  * Column visibility menu now shows actual header labels instead of internal keys

* **Localization**
  * Added English and German translations for the new sorting UI and accessibility labels