### PR TITLE
Feat: Improve visual appearance of Tooltip and implementation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,8 @@ html[data-theme='dark'] {
   --accent: var(--color-neutral-600);
   --accent-foreground: var(--color-neutral-100);
 
+  --tooltip: oklch(40% 0 0);
+
   --card: oklch(28% 0 240);
   --card-foreground: oklch(0.985 0 0);
   --popover-foreground: oklch(0.985 0 0);
@@ -106,6 +108,8 @@ html[data-theme='dark'] {
 
   --accent: var(--color-neutral-300);
   --accent-foreground: var(--color-neutral-800);
+
+  --tooltip: oklch(90% 0 0);
 
   --card: oklch(0.205 0 0);
   --radius: 0.625rem;
@@ -182,6 +186,8 @@ html[data-theme='dark'] {
 
   --color-input: var(--input);
   --color-input-ring: var(--input-ring);
+
+  --color-tooltip: var(--tooltip);
 
   @keyframes accordion-down {
     from {

--- a/src/components/Shared/MultiStageProgress/MultiStageNavigationButtons.tsx
+++ b/src/components/Shared/MultiStageProgress/MultiStageNavigationButtons.tsx
@@ -8,7 +8,7 @@ export function MultiStageNextButton({ ...props }: Omit<SimpleButtonProps, 'onCl
   const { nextStage, stage, stages, enabled, reason } = useMultiStageStore((store) => store)
 
   return (
-    <Tooltip isDisabled={enabled} showsError content={reason}>
+    <Tooltip disabled={enabled} variant='destructive' content={reason}>
       <Button disabled={stage === stages.length || !enabled} {...props} type='button' onClick={() => nextStage()} />
     </Tooltip>
   )
@@ -18,7 +18,7 @@ export function MultiStageBackButton({ ...props }: Omit<SimpleButtonProps, 'onCl
   const { previousStage, stage, enabled, reason } = useMultiStageStore((store) => store)
 
   return (
-    <Tooltip isDisabled={enabled} showsError content={reason}>
+    <Tooltip disabled={enabled} variant='destructive' content={reason}>
       <Button {...props} disabled={stage === 1 || !enabled} type='button' onClick={() => previousStage()} />
     </Tooltip>
   )

--- a/src/components/Shared/MultiStageProgress/MultiStageProgressBar.tsx
+++ b/src/components/Shared/MultiStageProgress/MultiStageProgressBar.tsx
@@ -81,7 +81,7 @@ function ProgressRing({ stage, title }: Stage) {
   const { show: showOnSmallScreens } = useFilterStages_SmallScreens(stage)
 
   return (
-    <Tooltip isDisabled={enabled} showsError content={reason}>
+    <Tooltip disabled={enabled} variant='destructive' content={reason}>
       <button
         type='button'
         disabled={!enabled}

--- a/src/components/Shared/Tooltip.tsx
+++ b/src/components/Shared/Tooltip.tsx
@@ -11,10 +11,10 @@ export type TooltipProps = Omit<React.ComponentProps<typeof TooltipPrimitive.Con
   disabled?: boolean
 }
 
-export default function Tooltip({ disabled, config = {}, delay = 250, variant = 'normal', ...props }: TooltipProps) {
+export default function Tooltip({ disabled, config = {}, delay = 250, variant = 'normal', content, children, ...props }: TooltipProps) {
   return (
     <ShadcnTooltip delayDuration={delay} {...config} open={disabled === true ? false : config.open}>
-      <TooltipTrigger asChild>{props.children}</TooltipTrigger>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
       <TooltipContent
         {...props}
         className={cn(
@@ -23,7 +23,7 @@ export default function Tooltip({ disabled, config = {}, delay = 250, variant = 
           variant === 'destructive' && 'text-destructive shadow-red-500/30 dark:text-destructive dark:shadow-red-400/40',
           props.className,
         )}>
-        {props.content}
+        {content}
       </TooltipContent>
     </ShadcnTooltip>
   )

--- a/src/components/Shared/Tooltip.tsx
+++ b/src/components/Shared/Tooltip.tsx
@@ -1,22 +1,26 @@
-import { TooltipProps as HerouiTooltipProps } from '@heroui/tooltip'
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 import { Tooltip as ShadcnTooltip, TooltipContent, TooltipTrigger } from '@/src/components/shadcn/tooltip'
 import { cn } from '@/src/lib/Shared/utils'
+import { Any } from '@/types'
 
-type BaseTooltipProps = {
-  showsWarning?: boolean
-  showsError?: boolean
+export type TooltipProps = Omit<React.ComponentProps<typeof TooltipPrimitive.Content>, 'content'> & {
+  delay?: number
+  config?: Omit<React.ComponentProps<typeof TooltipPrimitive.Root>, 'delayDuration'>
+  variant?: 'normal' | 'destructive' | 'warning'
+  content: React.ReactNode | React.ReactElement | Any
+  disabled?: boolean
 }
 
-export type TooltipProps = BaseTooltipProps & HerouiTooltipProps
-
-export default function Tooltip({ delay = 250, showsWarning, showsError, ...props }: TooltipProps) {
+export default function Tooltip({ disabled, config = {}, delay = 250, variant = 'normal', ...props }: TooltipProps) {
   return (
-    <ShadcnTooltip delayDuration={delay}>
+    <ShadcnTooltip delayDuration={delay} {...config} open={disabled !== undefined && disabled === true ? false : config.open}>
       <TooltipTrigger asChild>{props.children}</TooltipTrigger>
       <TooltipContent
+        {...props}
         className={cn(
-          showsWarning && 'text-[#BF8415] shadow-orange-500/20 dark:text-orange-400 dark:shadow-orange-400/40',
-          showsError && 'text-destructive shadow-red-500/30 dark:text-destructive dark:shadow-red-400/40',
+          variant === 'warning' && 'text-[#BF8415] shadow-orange-500/20 dark:text-orange-400 dark:shadow-orange-400/40',
+          variant === 'destructive' && 'text-destructive shadow-red-500/30 dark:text-destructive dark:shadow-red-400/40',
+          props.className,
         )}>
         {props.content}
       </TooltipContent>

--- a/src/components/Shared/Tooltip.tsx
+++ b/src/components/Shared/Tooltip.tsx
@@ -1,4 +1,5 @@
-import { Tooltip as HerouiTooltip, TooltipProps as HerouiTooltipProps } from '@heroui/tooltip'
+import { TooltipProps as HerouiTooltipProps } from '@heroui/tooltip'
+import { Tooltip as ShadcnTooltip, TooltipContent, TooltipTrigger } from '@/src/components/shadcn/tooltip'
 import { cn } from '@/src/lib/Shared/utils'
 
 type BaseTooltipProps = {
@@ -8,19 +9,17 @@ type BaseTooltipProps = {
 
 export type TooltipProps = BaseTooltipProps & HerouiTooltipProps
 
-export default function Tooltip({ showsWarning, showsError, ...props }: TooltipProps) {
+export default function Tooltip({ delay = 250, showsWarning, showsError, ...props }: TooltipProps) {
   return (
-    <HerouiTooltip
-      delay={250}
-      offset={8}
-      closeDelay={0}
-      shouldFlip
-      {...props}
-      className={cn(
-        'rounded-md border-t border-r border-l border-neutral-300 bg-neutral-100 p-2 text-sm text-neutral-600 shadow-sm shadow-neutral-400 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-300/90 dark:shadow-neutral-700',
-        showsWarning && 'text-[#BF8415] shadow-orange-500/20 dark:text-orange-400 dark:shadow-orange-400/40',
-        showsError && 'text-[#D44D35] shadow-red-500/30 dark:text-red-400/90 dark:shadow-red-400/40',
-      )}
-    />
+    <ShadcnTooltip delayDuration={delay}>
+      <TooltipTrigger asChild>{props.children}</TooltipTrigger>
+      <TooltipContent
+        className={cn(
+          showsWarning && 'text-[#BF8415] shadow-orange-500/20 dark:text-orange-400 dark:shadow-orange-400/40',
+          showsError && 'text-destructive shadow-red-500/30 dark:text-destructive dark:shadow-red-400/40',
+        )}>
+        {props.content}
+      </TooltipContent>
+    </ShadcnTooltip>
   )
 }

--- a/src/components/Shared/Tooltip.tsx
+++ b/src/components/Shared/Tooltip.tsx
@@ -18,6 +18,7 @@ export default function Tooltip({ disabled, config = {}, delay = 250, variant = 
       <TooltipContent
         {...props}
         className={cn(
+          'shadow-md shadow-accent dark:shadow-card',
           variant === 'warning' && 'text-[#BF8415] shadow-orange-500/20 dark:text-orange-400 dark:shadow-orange-400/40',
           variant === 'destructive' && 'text-destructive shadow-red-500/30 dark:text-destructive dark:shadow-red-400/40',
           props.className,

--- a/src/components/Shared/Tooltip.tsx
+++ b/src/components/Shared/Tooltip.tsx
@@ -13,7 +13,7 @@ export type TooltipProps = Omit<React.ComponentProps<typeof TooltipPrimitive.Con
 
 export default function Tooltip({ disabled, config = {}, delay = 250, variant = 'normal', ...props }: TooltipProps) {
   return (
-    <ShadcnTooltip delayDuration={delay} {...config} open={disabled !== undefined && disabled === true ? false : config.open}>
+    <ShadcnTooltip delayDuration={delay} {...config} open={disabled === true ? false : config.open}>
       <TooltipTrigger asChild>{props.children}</TooltipTrigger>
       <TooltipContent
         {...props}

--- a/src/components/Shared/Tooltip.tsx
+++ b/src/components/Shared/Tooltip.tsx
@@ -19,8 +19,8 @@ export default function Tooltip({ disabled, config = {}, delay = 250, variant = 
         {...props}
         className={cn(
           'shadow-md shadow-accent dark:shadow-card',
-          variant === 'warning' && 'text-[#BF8415] shadow-orange-500/20 dark:text-orange-400 dark:shadow-orange-400/40',
-          variant === 'destructive' && 'text-destructive shadow-red-500/30 dark:text-destructive dark:shadow-red-400/40',
+          variant === 'warning' && 'text-[#BF8415] shadow-orange-700/15 dark:text-orange-400 dark:shadow-orange-400/15',
+          variant === 'destructive' && 'text-destructive shadow-red-500/15 dark:text-destructive dark:shadow-red-400/15',
           props.className,
         )}>
         {content}

--- a/src/components/Shared/form/Field.tsx
+++ b/src/components/Shared/form/Field.tsx
@@ -103,7 +103,7 @@ export default function Field<Values extends FieldValues>({
 
               <AnimatePresence mode='wait'>
                 {!hasError && (
-                  <Tooltip isDisabled={hasError || !description} offset={props.type === 'checkbox' ? 12 : 0} content={description}>
+                  <Tooltip disabled={hasError || !description} content={description}>
                     <motion.div
                       data-disabled={field.disabled || props.disabled}
                       exit={{ opacity: 0 }}

--- a/src/components/checks/(hamburger-menu)/KnowledgeCheckMenu.tsx
+++ b/src/components/checks/(hamburger-menu)/KnowledgeCheckMenu.tsx
@@ -43,9 +43,8 @@ export default function KnowledgeCheckMenu({ id, questions, share_key, owner_id,
   const hasQuestions = questions.length > 0
 
   const baseTooltipOptions: Partial<TooltipProps> = {
-    showsError: true,
-    offset: 0,
-    placement: 'right-end',
+    variant: 'destructive',
+    side: 'right',
   }
 
   /**
@@ -74,7 +73,7 @@ export default function KnowledgeCheckMenu({ id, questions, share_key, owner_id,
   return (
     <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
       <DropdownMenuTrigger asChild>
-        <Button variant='ghost' size='icon' onClick={(e) => e.preventDefault()} className='h-auto w-auto px-1 py-0.5 hover:ring-1 hover:ring-ring-hover'>
+        <Button variant='ghost' size='icon' onClick={(e) => e.preventDefault()} className='size-auto px-1 py-0.5 hover:ring-1 hover:ring-ring-hover'>
           <EllipsisIcon className='size-5 text-neutral-500 dark:text-neutral-400' />
         </Button>
       </DropdownMenuTrigger>

--- a/src/components/checks/ShareKnowledgeCheckButton.tsx
+++ b/src/components/checks/ShareKnowledgeCheckButton.tsx
@@ -27,7 +27,7 @@ export function ShareKnowledgeCheckButton({ check, className }: { check: Knowled
 
   return (
     <Tooltip
-      showsError={isEmpty}
+      variant={isEmpty ? 'destructive' : 'normal'}
       content={
         <div className='flex items-center gap-1.5'>
           <InfoIcon className='size-4' />

--- a/src/components/checks/create/(create-question)/CreateQuestionDialog.tsx
+++ b/src/components/checks/create/(create-question)/CreateQuestionDialog.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react-hooks/incompatible-library */
 import { HTMLProps, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
-import { TooltipProps } from '@heroui/tooltip'
 import { zodResolver } from '@hookform/resolvers/zod'
 import isEmpty from 'lodash/isEmpty'
 import isEqual from 'lodash/isEqual'
@@ -14,7 +13,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import Field from '@/src/components/Shared/form/Field'
 import FieldError from '@/src/components/Shared/form/FormFieldError'
 import { default as CreateableSelect, default as Select } from '@/src/components/Shared/form/Select'
-import Tooltip from '@/src/components/Shared/Tooltip'
+import Tooltip, { TooltipProps } from '@/src/components/Shared/Tooltip'
 import debounceFunction from '@/src/hooks/Shared/debounceFunction'
 import { useScopedI18n } from '@/src/i18n/client-localization'
 import { getUUID } from '@/src/lib/Shared/getUUID'

--- a/src/components/checks/create/SaveCheckButton.tsx
+++ b/src/components/checks/create/SaveCheckButton.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { Tooltip } from '@heroui/tooltip'
 import { InfoIcon } from 'lucide-react'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
 import { useCheckStore } from '@/src/components/checks/create/CreateCheckProvider'
 import { useNavigationAbort } from '@/src/components/navigation-abortion/NavigationAbortProvider'
 import { Button } from '@/src/components/shadcn/button'
+import Tooltip from '@/src/components/Shared/Tooltip'
 import { saveAction } from '@/src/lib/checks/create/SaveAction'
 import { cn } from '@/src/lib/Shared/utils'
 import { safeParseKnowledgeCheck } from '@/src/schemas/KnowledgeCheck'
@@ -45,7 +45,7 @@ export function SaveCheckButton({ cacheKey, callbackPath }: { cacheKey?: string;
 
   return (
     <Tooltip
-      isDisabled={safeParse.success}
+      disabled={safeParse.success}
       content={
         <div className='flex items-center gap-1.5'>
           <InfoIcon className='size-4 text-destructive' />
@@ -53,9 +53,6 @@ export function SaveCheckButton({ cacheKey, callbackPath }: { cacheKey?: string;
         </div>
       }
       delay={250}
-      offset={8}
-      closeDelay={0}
-      shouldFlip
       className={cn(
         'rounded-md bg-neutral-100 p-2 text-sm shadow-sm shadow-neutral-400 dark:bg-neutral-800 dark:text-neutral-300 dark:shadow-neutral-700',
         !safeParse.success && 'dark:text-red-400/90 dark:shadow-red-400/40',

--- a/src/components/checks/discover/DiscoverFilterFields.tsx
+++ b/src/components/checks/discover/DiscoverFilterFields.tsx
@@ -87,7 +87,7 @@ export function DiscoverFilterFields() {
                 ))}
               </DropdownMenuContent>
             </DropdownMenu>
-            <Tooltip offset={12} placement='right' size='sm' content={isCaseSensitive ? t('FilterFields.tooltips.filter_case_sensitive') : t('FilterFields.tooltips.filter_case_ignored')}>
+            <Tooltip side='right' content={isCaseSensitive ? t('FilterFields.tooltips.filter_case_sensitive') : t('FilterFields.tooltips.filter_case_ignored')}>
               <Toggle
                 aria-label='Toggle Case Sensitivity'
                 size='xs'

--- a/src/components/shadcn/dropdown-menu.tsx
+++ b/src/components/shadcn/dropdown-menu.tsx
@@ -58,7 +58,7 @@ function DropdownMenuItem({
   enableTooltip?: boolean
 }) {
   return (
-    <ConditionalTooltip showTooltip={enableTooltip} {...tooltipOptions}>
+    <ConditionalTooltip showTooltip={enableTooltip} content={''} {...tooltipOptions}>
       <DropdownMenuPrimitive.Item
         data-slot='dropdown-menu-item'
         data-inset={inset}
@@ -153,7 +153,7 @@ function DropdownMenuSubTrigger({
   enableTooltip?: boolean
 }) {
   return (
-    <ConditionalTooltip showTooltip={enableTooltip} {...tooltipOptions}>
+    <ConditionalTooltip showTooltip={enableTooltip} content={''} {...tooltipOptions}>
       <DropdownMenuPrimitive.SubTrigger
         data-slot='dropdown-menu-sub-trigger'
         data-inset={inset}

--- a/src/components/shadcn/tooltip.tsx
+++ b/src/components/shadcn/tooltip.tsx
@@ -27,12 +27,12 @@ function TooltipContent({ className, sideOffset = 0, children, ...props }: React
         data-slot='tooltip-content'
         sideOffset={sideOffset}
         className={cn(
-          'z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-primary px-3 py-1.5 text-xs text-balance text-primary-foreground fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+          'z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-tooltip px-3 py-1.5 text-xs text-balance text-foreground/80 fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
           className,
         )}
         {...props}>
         {children}
-        <TooltipPrimitive.Arrow className='z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-primary fill-primary' />
+        <TooltipPrimitive.Arrow className='z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-tooltip fill-tooltip' />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
> [!NOTE]
> This pull request updates the implementation of the shared `Tooltip`component. It now uses the shadcn-tooltip as a base instead of using the `heroui/tooltip`. In doing so the background styles of the shadcn Tooltip were modified to align with the applications theme. Apart from that all the existing `Tooltip` usages were updated to align with the updated `Tooltip` signature from the shadcn-tooltip. 


## Summary 

* **New Features**
  * Introduced tooltip color variables and styling variants (normal, destructive, warning) for improved visual consistency.

* **Refactor**
  * Migrated tooltip component to a modern Radix/Shadcn-based implementation for better performance and maintainability.

* **Style**
  * Improved tooltip visuals and state variants (normal/destructive/warning) using clearer error and warning shadows.


----
### Detailed Changelog

<details>
<summary>Changelog</summary>

[](url)
- **Refactors**:
  - Updated shared `Tooltip` to use shadcn `Tooltip` ([`d8e5cba9`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/d8e5cba9))
     This way all existing tooltips will now use the shadcn tooltip instead of the heroui tooltip.
  
  - Updated `Tooltip` props to satisfy shadcn tooltip ([`255504aa`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/255504aa))
     
  - Simplified tooltip disabled condition ([`bc04e25d`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/bc04e25d))
     
  - Improved `Tooltip` property de-structuring ([`9ed5b723`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/9ed5b723))
     The content and children props remain in {...props} and are spread into TooltipContent. While children is harmlessly overridden by the JSX children ({props.content}) it may cause confusion. Thus, both the `content` and `children` properties are de-structured and passed explicitly to the respective elements.
  

- **Styles**:
  - Updated shadcn `Tooltip` background color ([`36654ab8`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/36654ab8))
     
  - Added shadow to tooltip for more depth ([`71a42836`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/71a42836))
     
  - Adjusted tooltip destructive, warning shadows ([`2faa66a8`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/2faa66a8))
     

</details>

