### PR TITLE
Feat: Introduce textual feedback display through tooltips to practice

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,17 @@
 
 @theme {
   --breakpoint-3xl: 120rem;
+
+  --animate-scale: scale 1.15s ease-in-out infinite;
+  @keyframes scale {
+    0%,
+    100% {
+      transform: scale(1.1);
+    }
+    50% {
+      transform: scale(0.9);
+    }
+  }
 }
 
 @layer components {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,6 +53,10 @@ html[data-theme='dark'] {
 
   --tooltip: oklch(40% 0 0);
 
+  --destructive: oklch(0.704 0.191 22.216);
+  --success: oklch(0.654 0.291 140.216);
+  --warning: oklch(0.704 0.191 95.216);
+
   --card: oklch(28% 0 240);
   --card-foreground: oklch(0.985 0 0);
   --popover-foreground: oklch(0.985 0 0);
@@ -62,7 +66,6 @@ html[data-theme='dark'] {
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -111,6 +114,10 @@ html[data-theme='dark'] {
 
   --tooltip: oklch(90% 0 0);
 
+  --destructive: oklch(0.577 0.245 27.325);
+  --success: oklch(0.587 0.245 140.325);
+  --warning: oklch(0.8 0.16 83);
+
   --card: oklch(0.205 0 0);
   --radius: 0.625rem;
   --card: oklch(1 0 0);
@@ -122,7 +129,6 @@ html[data-theme='dark'] {
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -158,7 +164,6 @@ html[data-theme='dark'] {
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
   --color-border: var(--border);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
@@ -188,6 +193,10 @@ html[data-theme='dark'] {
   --color-input-ring: var(--input-ring);
 
   --color-tooltip: var(--tooltip);
+
+  --color-destructive: var(--destructive);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
 
   @keyframes accordion-down {
     from {

--- a/src/components/Shared/drag-drop/DragDropContainer.tsx
+++ b/src/components/Shared/drag-drop/DragDropContainer.tsx
@@ -15,9 +15,10 @@ interface DragDropContainerProps {
   className?: string
   onSwapStart?: SwapStartEventHandler
   onSwapEnd?: SwapEndEventHandler
+  hideMoveIndicators?: boolean
 }
 
-export default function DragDropContainer({ children, className, onSwapEnd, onSwapStart, ...config }: DragDropContainerProps & Partial<Config>) {
+export default function DragDropContainer({ children, className, onSwapEnd, onSwapStart, hideMoveIndicators, ...config }: DragDropContainerProps & Partial<Config>) {
   const swapyRef = useRef<Swapy | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -68,7 +69,7 @@ export default function DragDropContainer({ children, className, onSwapEnd, onSw
   }, [])
 
   return (
-    <div ref={containerRef} className={cn('group/drag-drop-container', className)} data-enabled={config.enabled ?? true}>
+    <div ref={containerRef} className={cn('group/drag-drop-container', className)} data-enabled={config.enabled ?? true} data-hide-move-indicators={hideMoveIndicators}>
       {children}
     </div>
   )

--- a/src/components/Shared/drag-drop/DragDropContainer.tsx
+++ b/src/components/Shared/drag-drop/DragDropContainer.tsx
@@ -69,7 +69,7 @@ export default function DragDropContainer({ children, className, onSwapEnd, onSw
   }, [])
 
   return (
-    <div ref={containerRef} className={cn('group/drag-drop-container', className)} data-enabled={config.enabled ?? true} data-hide-move-indicators={hideMoveIndicators}>
+    <div ref={containerRef} className={cn('group/drag-drop-container', className)} data-enabled={config.enabled ?? true} data-hide-move-indicators={hideMoveIndicators || undefined}>
       {children}
     </div>
   )

--- a/src/components/Shared/drag-drop/DragDropItem.tsx
+++ b/src/components/Shared/drag-drop/DragDropItem.tsx
@@ -35,18 +35,23 @@ export function DragDropItem({ children, className, name, onSwap, initialIndex, 
         {...props}
         data-swapy-item={name || getUUID()}
         className={cn(
-          'group relative flex cursor-move items-center gap-4 rounded-md bg-neutral-300/40 p-3 px-4 pr-12 ring-1 ring-neutral-400/50 select-none group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-300/60 group-data-[enabled=true]/drag-drop-container:active:bg-neutral-400/40 dark:bg-neutral-800 dark:ring-neutral-600/80 dark:group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-700/60 dark:group-data-[enabled=true]/drag-drop-container:active:bg-neutral-700/60',
+          'p-3 px-4',
+          // add padding when move icon is shown
+          'group-data-[hide-move-indicators=false]/drag-drop-container:pr-12',
+          'group relative flex cursor-move items-center gap-4 rounded-md bg-neutral-300/40 ring-1 ring-neutral-400/50 select-none group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-300/60 group-data-[enabled=true]/drag-drop-container:active:bg-neutral-400/40 dark:bg-neutral-800 dark:ring-neutral-600/80 dark:group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-700/60 dark:group-data-[enabled=true]/drag-drop-container:active:bg-neutral-700/60',
           className,
         )}>
         {showPositionCounter && initialIndex !== undefined && <DragDropItemPositionCounter initialIndex={initialIndex} />}
         {children}
         <MoveIcon
           className={cn(
-            'absolute top-0 right-5 bottom-0 my-auto size-4.5 text-neutral-500 dark:text-neutral-400',
+            'absolute inset-y-0 right-5 my-auto size-4.5 text-neutral-500 dark:text-neutral-400',
             // disabled icon styles
             'group-data-[enabled=false]/drag-drop-container:text-muted-foreground/40 dark:group-data-[enabled=false]/drag-drop-container:text-muted-foreground/40',
             // hover, active styles
             'group-data-[enabled=true]/drag-drop-container:group-hover:text-neutral-700 group-data-[enabled=true]/drag-drop-container:group-active:text-neutral-800 dark:group-data-[enabled=true]/drag-drop-container:group-hover:text-neutral-200/90 dark:group-data-[enabled=true]/drag-drop-container:group-active:text-neutral-100',
+            // hide move-icon when `hide-move-indicators` data attribute is set
+            'group-data-[hide-move-indicators=true]/drag-drop-container:hidden',
           )}
         />
       </div>

--- a/src/components/Shared/drag-drop/DragDropItem.tsx
+++ b/src/components/Shared/drag-drop/DragDropItem.tsx
@@ -1,11 +1,11 @@
-import { HTMLProps, useEffect, useRef } from 'react'
+import React, { HTMLProps, useEffect, useRef } from 'react'
 import { cn } from '@heroui/theme'
 import { MoveIcon } from 'lucide-react'
 import { ItemSwapEvent } from '@/src/components/Shared/drag-drop/DragDropContainer'
 import { DragDropItemPositionCounter } from '@/src/components/Shared/drag-drop/DragDropPositionCounter'
 import { getUUID } from '@/src/lib/Shared/getUUID'
 
-interface DragDropItemProps {
+interface DragDropItemProps extends Pick<React.ComponentProps<'div'>, 'onClick'> {
   children: React.ReactNode
   className?: string
   onSwap?: (e: ItemSwapEvent) => void

--- a/src/components/Shared/drag-drop/DragDropItem.tsx
+++ b/src/components/Shared/drag-drop/DragDropItem.tsx
@@ -38,7 +38,7 @@ export function DragDropItem({ children, className, name, onSwap, initialIndex, 
           'p-3 px-4',
           // add padding when move icon is shown
           'group-data-[hide-move-indicators=false]/drag-drop-container:pr-12',
-          'group relative flex cursor-move items-center gap-4 rounded-md bg-neutral-300/40 ring-1 ring-neutral-400/50 select-none group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-300/60 group-data-[enabled=true]/drag-drop-container:active:bg-neutral-400/40 dark:bg-neutral-800 dark:ring-neutral-600/80 dark:group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-700/60 dark:group-data-[enabled=true]/drag-drop-container:active:bg-neutral-700/60',
+          'group relative flex items-center gap-4 rounded-md bg-neutral-300/40 ring-1 ring-neutral-400/50 select-none group-data-[enabled=true]/drag-drop-container:cursor-move group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-300/60 group-data-[enabled=true]/drag-drop-container:active:bg-neutral-400/40 dark:bg-neutral-800 dark:ring-neutral-600/80 dark:group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-700/60 dark:group-data-[enabled=true]/drag-drop-container:active:bg-neutral-700/60',
           className,
         )}>
         {showPositionCounter && initialIndex !== undefined && <DragDropItemPositionCounter initialIndex={initialIndex} />}

--- a/src/components/Shared/drag-drop/DragDropItem.tsx
+++ b/src/components/Shared/drag-drop/DragDropItem.tsx
@@ -37,7 +37,7 @@ export function DragDropItem({ children, className, name, onSwap, initialIndex, 
         className={cn(
           'p-3 px-4',
           // add padding-right to make space for move-icon when it is shown (thus not disabled `hide-move-indicators` set to true)
-          'group-not-data-[hide-move-indicators=true]/drag-drop-container:pr-12',
+          'group-not-data-hide-move-indicators/drag-drop-container:pr-12',
           'group relative flex items-center gap-4 rounded-md bg-neutral-300/40 ring-1 ring-neutral-400/50 select-none group-data-[enabled=true]/drag-drop-container:cursor-move group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-300/60 group-data-[enabled=true]/drag-drop-container:active:bg-neutral-400/40 dark:bg-neutral-800 dark:ring-neutral-600/80 dark:group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-700/60 dark:group-data-[enabled=true]/drag-drop-container:active:bg-neutral-700/60',
           className,
         )}>
@@ -51,7 +51,7 @@ export function DragDropItem({ children, className, name, onSwap, initialIndex, 
             // hover, active styles
             'group-data-[enabled=true]/drag-drop-container:group-hover:text-neutral-700 group-data-[enabled=true]/drag-drop-container:group-active:text-neutral-800 dark:group-data-[enabled=true]/drag-drop-container:group-hover:text-neutral-200/90 dark:group-data-[enabled=true]/drag-drop-container:group-active:text-neutral-100',
             // hide move-icon when `hide-move-indicators` data attribute is set
-            'group-data-[hide-move-indicators=true]/drag-drop-container:hidden',
+            'group-data-hide-move-indicators/drag-drop-container:hidden',
           )}
         />
       </div>

--- a/src/components/Shared/drag-drop/DragDropItem.tsx
+++ b/src/components/Shared/drag-drop/DragDropItem.tsx
@@ -36,8 +36,8 @@ export function DragDropItem({ children, className, name, onSwap, initialIndex, 
         data-swapy-item={name || getUUID()}
         className={cn(
           'p-3 px-4',
-          // add padding when move icon is shown
-          'group-data-[hide-move-indicators=false]/drag-drop-container:pr-12',
+          // add padding-right to make space for move-icon when it is shown (thus not disabled `hide-move-indicators` set to true)
+          'group-not-data-[hide-move-indicators=true]/drag-drop-container:pr-12',
           'group relative flex items-center gap-4 rounded-md bg-neutral-300/40 ring-1 ring-neutral-400/50 select-none group-data-[enabled=true]/drag-drop-container:cursor-move group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-300/60 group-data-[enabled=true]/drag-drop-container:active:bg-neutral-400/40 dark:bg-neutral-800 dark:ring-neutral-600/80 dark:group-data-[enabled=true]/drag-drop-container:hover:bg-neutral-700/60 dark:group-data-[enabled=true]/drag-drop-container:active:bg-neutral-700/60',
           className,
         )}>

--- a/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
+++ b/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
@@ -1,5 +1,7 @@
-import { HTMLProps } from 'react'
+import { HTMLProps, useState } from 'react'
+import { MessageCircleQuestionIcon } from 'lucide-react'
 import { useFormContext } from 'react-hook-form'
+import DisplayFeedbackText from '@/src/components/checks/[share_token]/practice/FeedbackText'
 import { usePracticeFeeback } from '@/src/hooks/checks/[share_token]/practice/usePracticeFeedback'
 import { cn } from '@/src/lib/Shared/utils'
 import type { OpenQuestion } from '@/src/schemas/QuestionSchema'
@@ -16,37 +18,45 @@ export function FeedbackOpenQuestion({
   question: OpenQuestion
 } & Pick<HTMLProps<HTMLTextAreaElement>, 'disabled'>) {
   const { isCorrect, isIncorrect, reasoning } = getFeedbackEvaluation(question)
+  const [isPinned, setPinned] = useState(false)
 
   return (
     <OpenQuestionAnswer
       {...props}
       disabled={isEvaluated || props.disabled}
-      title={reasoning}
       data-evaluation-result={isEvaluated ? (isCorrect ? 'correct' : isIncorrect ? 'incorrect' : 'none') : 'none'}
       className={cn(
         isEvaluated && 'relative ring-2',
         isCorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-green-500/20 ring-green-400/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/15 dark:ring-green-500/70',
-        isIncorrect &&
-          'cursor-help bg-radial from-neutral-200/60 via-neutral-200/60 to-red-500/20 ring-red-500/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/15 dark:ring-red-400/70',
-      )}
-    />
+        isIncorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-red-500/20 ring-red-500/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/15 dark:ring-red-400/70',
+        isEvaluated && 'pr-8',
+      )}>
+      <DisplayFeedbackText disabled={!isEvaluated} pinned={isPinned} feedback={reasoning} side='right'>
+        <div className={cn('group/tooltip absolute top-1 right-1.5 flex flex-row-reverse gap-1.5')}>
+          <MessageCircleQuestionIcon className={cn('size-4.5 text-warning', !isPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isEvaluated && 'hidden')} />
+        </div>
+      </DisplayFeedbackText>
+    </OpenQuestionAnswer>
   )
 }
 
-export function OpenQuestionAnswer({ ...props }: {} & HTMLProps<HTMLTextAreaElement>) {
+export function OpenQuestionAnswer({ children, ...props }: { children?: React.ReactNode } & HTMLProps<HTMLTextAreaElement>) {
   const { register } = useFormContext<QuestionInput>()
 
   return (
-    <textarea
-      {...props}
-      {...register('input')}
-      className={cn(
-        'rounded-md bg-neutral-100/90 px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 dark:bg-neutral-800 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50',
-        'enabled:hover:cursor-text enabled:hover:ring-ring-hover enabled:focus:ring-[1.2px] enabled:focus:ring-ring-focus enabled:dark:hover:ring-ring-hover enabled:dark:focus:ring-ring-focus',
-        'resize-none',
-        'my-auto h-full min-h-32',
-        props.className,
-      )}
-    />
+    <div className='relative *:w-full'>
+      <textarea
+        {...props}
+        {...register('input')}
+        className={cn(
+          'rounded-md bg-neutral-100/90 px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 dark:bg-neutral-800 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50',
+          'enabled:hover:cursor-text enabled:hover:ring-ring-hover enabled:focus:ring-[1.2px] enabled:focus:ring-ring-focus enabled:dark:hover:ring-ring-hover enabled:dark:focus:ring-ring-focus',
+          'resize-none',
+          'my-auto h-full min-h-32',
+          props.className,
+        )}
+      />
+      {children}
+    </div>
   )
 }

--- a/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
+++ b/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
@@ -41,7 +41,9 @@ export function FeedbackOpenQuestion({
       )}>
       <div className={cn('group/tooltip absolute top-1 right-1.5 z-10 flex cursor-pointer flex-row-reverse gap-1.5')}>
         <DisplayFeedbackText disabled={!isEvaluated} pinned={isPinned} feedback={reasoning} side='right'>
-          <MessageCircleQuestionIcon className={cn('size-4.5 text-warning', !isPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isEvaluated && 'hidden')} />
+          <MessageCircleQuestionIcon
+            className={cn('size-4.5 text-warning', !isPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isEvaluated && 'hidden', !reasoning && 'hidden')}
+          />
         </DisplayFeedbackText>
       </div>
       {/* overlay to detect click-events in text-area while disabled */}

--- a/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
+++ b/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
@@ -39,7 +39,7 @@ export function FeedbackOpenQuestion({
         isIncorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-red-500/20 ring-red-500/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/15 dark:ring-red-400/70',
         isEvaluated && 'pr-8',
       )}>
-      <div className={cn('group/tooltip absolute top-1 right-1.5 z-10 flex cursor-pointer flex-row-reverse gap-1.5')}>
+      <div className={cn('group/tooltip absolute top-1 right-1.5 z-10 flex cursor-pointer flex-row-reverse gap-1.5')} onClick={() => setPinned((prev) => !prev)}>
         <DisplayFeedbackText disabled={!isEvaluated} pinned={isPinned} feedback={reasoning} side='right'>
           <MessageCircleQuestionIcon
             className={cn('size-4.5 text-warning', !isPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isEvaluated && 'hidden', !reasoning && 'hidden')}

--- a/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
+++ b/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
@@ -1,4 +1,4 @@
-import { HTMLProps, useState } from 'react'
+import { HTMLProps, useEffect, useState } from 'react'
 import { MessageCircleQuestionIcon } from 'lucide-react'
 import { useFormContext } from 'react-hook-form'
 import DisplayFeedbackText from '@/src/components/checks/[share_token]/practice/FeedbackText'
@@ -19,6 +19,14 @@ export function FeedbackOpenQuestion({
 } & Pick<HTMLProps<HTMLTextAreaElement>, 'disabled'>) {
   const { isCorrect, isIncorrect, reasoning } = getFeedbackEvaluation(question)
   const [isPinned, setPinned] = useState(false)
+
+  useEffect(() => {
+    if (!isEvaluated || isCorrect) return
+
+    // toggle feedback-text display when answer is incorrect
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPinned(true)
+  }, [isEvaluated])
 
   return (
     <OpenQuestionAnswer

--- a/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
+++ b/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
@@ -31,11 +31,13 @@ export function FeedbackOpenQuestion({
         isIncorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-red-500/20 ring-red-500/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/15 dark:ring-red-400/70',
         isEvaluated && 'pr-8',
       )}>
-      <DisplayFeedbackText disabled={!isEvaluated} pinned={isPinned} feedback={reasoning} side='right'>
-        <div className={cn('group/tooltip absolute top-1 right-1.5 flex flex-row-reverse gap-1.5')}>
+      <div className={cn('group/tooltip absolute top-1 right-1.5 z-10 flex cursor-pointer flex-row-reverse gap-1.5')}>
+        <DisplayFeedbackText disabled={!isEvaluated} pinned={isPinned} feedback={reasoning} side='right'>
           <MessageCircleQuestionIcon className={cn('size-4.5 text-warning', !isPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isEvaluated && 'hidden')} />
-        </div>
-      </DisplayFeedbackText>
+        </DisplayFeedbackText>
+      </div>
+      {/* overlay to detect click-events in text-area while disabled */}
+      {isEvaluated && <div className='absolute inset-0 cursor-pointer' onClick={() => setPinned((prev) => !prev)}></div>}
     </OpenQuestionAnswer>
   )
 }
@@ -44,7 +46,7 @@ export function OpenQuestionAnswer({ children, ...props }: { children?: React.Re
   const { register } = useFormContext<QuestionInput>()
 
   return (
-    <div className='relative *:w-full'>
+    <div className='group relative *:w-full'>
       <textarea
         {...props}
         {...register('input')}

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -109,7 +109,7 @@ function AnswerFeedback({
             <XIcon className='size-4' />
           </div>
         )}
-        <MessageCircleQuestionIcon className={cn('size-4.5 text-warning', !isFeedbackPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110')} />
+        <MessageCircleQuestionIcon className={cn('size-4.5 text-warning', !isFeedbackPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !answerFeedbackText && 'hidden')} />
       </div>
     </DisplayFeedbackText>
   )

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -92,7 +92,7 @@ function AnswerFeedback({
 
   const correctPosition = feedbackEvaluation.getCorrectPosition(id)
   // when a given answer is not found, -1 is returned as the correctPosition for that answer - which would lead to the last reasoning in the array to be used by default.
-  const answerFeedbackText = correctPosition >= 0 ? feedbackEvaluation.reasoning?.at(correctPosition) : undefined
+  const answerFeedbackText = feedbackEvaluation.reasoning?.get(id)
 
   return (
     <DisplayFeedbackText feedback={answerFeedbackText} side='right' pinned={isFeedbackPinned}>

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -91,7 +91,6 @@ function AnswerFeedback({
   if (!show) return null
 
   const correctPosition = feedbackEvaluation.getCorrectPosition(id)
-  // when a given answer is not found, -1 is returned as the correctPosition for that answer - which would lead to the last reasoning in the array to be used by default.
   const answerFeedbackText = feedbackEvaluation.reasoning?.get(id)
 
   return (

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -91,7 +91,8 @@ function AnswerFeedback({
   if (!show) return null
 
   const correctPosition = feedbackEvaluation.getCorrectPosition(id)
-  const answerFeedbackText = feedbackEvaluation.reasoning?.at(correctPosition)
+  // when a given answer is not found, -1 is returned as the correctPosition for that answer - which would lead to the last reasoning in the array to be used by default.
+  const answerFeedbackText = correctPosition >= 0 ? feedbackEvaluation.reasoning?.at(correctPosition) : undefined
 
   return (
     <DisplayFeedbackText feedback={answerFeedbackText} side='right' pinned={isFeedbackPinned}>

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -17,6 +17,7 @@ export default function DragDropAnswers({ isEvaluated, ...props }: { question: D
 
   return (
     <DragDropContainer
+      hideMoveIndicators={isEvaluated}
       key={props.question.id + props.question.type + isEvaluated.toString()}
       className='col-span-2 my-auto space-y-6'
       enabled={!isEvaluated}

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -66,6 +66,7 @@ function DragDropAnswerOptions({ question, state, isEvaluated }: { question: Dra
     <DragDropItem
       key={id}
       name={id}
+      className={cn(isEvaluated && feedbackEvaluation.reasoning?.has(id) && 'cursor-pointer')}
       onClick={isEvaluated ? () => setOpenFeedbacks((prev) => (prev.includes(id) ? prev.filter((prev_id) => prev_id !== id) : prev.concat([id]))) : undefined}
       data-evaluation-result={isEvaluated ? (feedbackEvaluation.isCorrectlyPositioned(id) ? 'correct' : feedbackEvaluation.isFalslyPositioned(id) ? 'incorrect' : 'none') : undefined}>
       <DragDropItemPositionCounter initialIndex={position} />

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ArrowUpFromLineIcon, CheckIcon, MessageCircleQuestionIcon, XIcon } from 'lucide-react'
 import { useFormContext } from 'react-hook-form'
 import DisplayFeedbackText from '@/src/components/checks/[share_token]/practice/FeedbackText'
@@ -53,6 +53,14 @@ function DragDropAnswerOptions({ question, state, isEvaluated }: { question: Dra
 
   const feedbackEvaluation = getFeedbackEvaluation(question)
   const [openFeedbacks, setOpenFeedbacks] = useState<DragDropQuestion['answers'][number]['id'][]>([])
+
+  useEffect(() => {
+    if (!isEvaluated) return
+
+    // automatically display feedback texts for wrong positioned answers
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setOpenFeedbacks(options.filter((o) => feedbackEvaluation.isFalslyPositioned(o.id)).map((o) => o.id))
+  }, [isEvaluated])
 
   return options.map(({ id, answer, position }, i) => (
     <DragDropItem

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from 'react-hook-form'
 import DragDropContainer from '@/src/components/Shared/drag-drop/DragDropContainer'
 import { DragDropItem } from '@/src/components/Shared/drag-drop/DragDropItem'
 import { DragDropItemPositionCounter } from '@/src/components/Shared/drag-drop/DragDropPositionCounter'
-import { usePracticeFeeback } from '@/src/hooks/checks/[share_token]/practice/usePracticeFeedback'
+import { DragDropFeedbackEvaluation, usePracticeFeeback } from '@/src/hooks/checks/[share_token]/practice/usePracticeFeedback'
 import { PracticeFeedbackServerState } from '@/src/lib/checks/[share_token]/practice/EvaluateAnswer'
 import { cn } from '@/src/lib/Shared/utils'
 import { DragDropQuestion } from '@/src/schemas/QuestionSchema'
@@ -49,28 +49,40 @@ function DragDropAnswerOptions({ question, state, isEvaluated }: { question: Dra
     isSubmitting: false,
   })
 
-  const { isCorrectlyPositioned, isFalslyPositioned, getCorrectPosition, reasoning } = getFeedbackEvaluation(question)
+  const feedbackEvaluation = getFeedbackEvaluation(question)
 
   return options.map(({ id, answer, position }, i) => (
     <DragDropItem
       key={id}
       name={id}
-      title={isEvaluated ? reasoning?.at(i) : undefined}
+      title={isEvaluated ? feedbackEvaluation.reasoning?.at(i) : undefined}
       className={cn(isEvaluated && 'cursor-help')}
-      data-evaluation-result={isEvaluated ? (isCorrectlyPositioned(id) ? 'correct' : isFalslyPositioned(id) ? 'incorrect' : 'none') : undefined}>
+      data-evaluation-result={isEvaluated ? (feedbackEvaluation.isCorrectlyPositioned(id) ? 'correct' : feedbackEvaluation.isFalslyPositioned(id) ? 'incorrect' : 'none') : undefined}>
       <DragDropItemPositionCounter initialIndex={position} />
       {answer}
-      <AnswerFeedback show={isEvaluated} correctPosition={getCorrectPosition(id)} isCorrect={isCorrectlyPositioned(id)} position={position} />
+      <AnswerFeedback show={isEvaluated} id={id} feedbackEvaluation={feedbackEvaluation} position={position} />
     </DragDropItem>
   ))
 }
 
-function AnswerFeedback({ show, position, correctPosition, isCorrect }: { show: boolean; position: number; correctPosition: number; isCorrect: boolean }) {
+function AnswerFeedback({
+  show,
+  position,
+  feedbackEvaluation,
+  id,
+}: {
+  show: boolean
+  id: DragDropQuestion['answers'][number]['id']
+  feedbackEvaluation: DragDropFeedbackEvaluation
+  position: number
+}) {
   if (!show) return null
+
+  const correctPosition = feedbackEvaluation.getCorrectPosition(id)
 
   return (
     <div className='drag-drop-feedback-indicators ml-auto flex items-center gap-2'>
-      {isCorrect ? (
+      {feedbackEvaluation.isCorrectlyPositioned(id) ? (
         <CheckIcon className='size-4 text-green-600 dark:text-green-500/70' />
       ) : (
         <div className='flex items-center gap-4 text-red-600/70 dark:text-red-500/70'>

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -95,7 +95,7 @@ function AnswerFeedback({
   const answerFeedbackText = feedbackEvaluation.reasoning?.get(id)
 
   return (
-    <DisplayFeedbackText feedback={answerFeedbackText} side='right' pinned={isFeedbackPinned}>
+    <DisplayFeedbackText feedback={answerFeedbackText} side='right' pinned={isFeedbackPinned} answerIndex={correctPosition}>
       <div className='drag-drop-feedback-indicators group/tooltip ml-auto flex cursor-pointer items-center gap-2'>
         {feedbackEvaluation.isCorrectlyPositioned(id) ? (
           <CheckIcon className='size-4 text-green-600 dark:text-green-500/70' />

--- a/src/components/checks/[share_token]/practice/FeedbackText.tsx
+++ b/src/components/checks/[share_token]/practice/FeedbackText.tsx
@@ -1,11 +1,36 @@
+import { useState } from 'react'
 import Tooltip, { TooltipProps } from '@/src/components/Shared/Tooltip'
 
-type ShowFeedbackTextProps = Pick<TooltipProps, 'side' | 'sideOffset' | 'disabled'> & {
+export type DisplayFeedbackTextProps = Pick<TooltipProps, 'side' | 'sideOffset' | 'disabled'> & {
   feedback?: string
-  open?: boolean
+  /**
+   * the tooltip can be "pinned" when true, the tooltip stays open until the parent unpins it (used for mobile toggling / default-open wrong answers)
+   * hover/focus behavior is preserved when tooltip is not pinned by parent, by listening for onOpenChange updates and updating `hoverOpen` state.
+   */
+  pinned?: boolean
   children: React.ReactNode
 }
-export default function DisplayFeedbackText(props: ShowFeedbackTextProps) {
-  if (!props.feedback) return <>{props.children}</>
-  return <Tooltip content={props.feedback} config={{ open: props.open }} className='max-w-[25vw] text-wrap' {...props} />
+
+export default function DisplayFeedbackText({ feedback, pinned: isPinned, children, ...props }: DisplayFeedbackTextProps) {
+  const [hoverOpen, setHoverOpen] = useState(false)
+  const open = isPinned || hoverOpen
+
+  if (!feedback) return <>{children}</>
+
+  return (
+    <Tooltip
+      content={feedback}
+      className='max-w-[25vw] text-wrap'
+      config={{
+        open,
+        onOpenChange: (next) => {
+          // when pinned, ignore hover-driven close/open events
+          if (isPinned) return
+          setHoverOpen(next)
+        },
+      }}
+      {...props}>
+      {children}
+    </Tooltip>
+  )
 }

--- a/src/components/checks/[share_token]/practice/FeedbackText.tsx
+++ b/src/components/checks/[share_token]/practice/FeedbackText.tsx
@@ -1,0 +1,11 @@
+import Tooltip, { TooltipProps } from '@/src/components/Shared/Tooltip'
+
+type ShowFeedbackTextProps = Pick<TooltipProps, 'side' | 'sideOffset' | 'disabled'> & {
+  feedback?: string
+  open?: boolean
+  children: React.ReactNode
+}
+export default function DisplayFeedbackText(props: ShowFeedbackTextProps) {
+  if (!props.feedback) return <>{props.children}</>
+  return <Tooltip content={props.feedback} config={{ open: props.open }} className='max-w-[25vw] text-wrap' {...props} />
+}

--- a/src/components/checks/[share_token]/practice/FeedbackText.tsx
+++ b/src/components/checks/[share_token]/practice/FeedbackText.tsx
@@ -20,7 +20,7 @@ export default function DisplayFeedbackText({ feedback, pinned: isPinned, childr
   return (
     <Tooltip
       content={feedback}
-      className='max-w-[25vw] text-wrap'
+      className='max-w-[50vw] text-wrap lg:max-w-[25vw]'
       config={{
         open,
         onOpenChange: (next) => {

--- a/src/components/checks/[share_token]/practice/FeedbackText.tsx
+++ b/src/components/checks/[share_token]/practice/FeedbackText.tsx
@@ -9,9 +9,10 @@ export type DisplayFeedbackTextProps = Pick<TooltipProps, 'side' | 'sideOffset' 
    */
   pinned?: boolean
   children: React.ReactNode
+  answerIndex?: number
 }
 
-export default function DisplayFeedbackText({ feedback, pinned: isPinned, children, ...props }: DisplayFeedbackTextProps) {
+export default function DisplayFeedbackText({ feedback, pinned: isPinned, children, answerIndex = 0, ...props }: DisplayFeedbackTextProps) {
   const [hoverOpen, setHoverOpen] = useState(false)
   const open = isPinned || hoverOpen
 
@@ -19,7 +20,12 @@ export default function DisplayFeedbackText({ feedback, pinned: isPinned, childr
 
   return (
     <Tooltip
-      content={feedback}
+      content={
+        <div className='flex flex-col gap-1'>
+          <h2 className='text-sm font-medium'>Feedback for Answer {answerIndex + 1}</h2>
+          <p>{feedback}</p>
+        </div>
+      }
       className='max-w-[50vw] text-wrap lg:max-w-[25vw]'
       config={{
         open,

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -234,11 +234,18 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
     register,
     formState: { errors },
   } = useFormContext<QuestionInput>()
+  const { isCorrectlySelected, isFalslySelected, isMissingSelection, reasoning } = getFeedbackEvaluation(question as SingleChoice)
   const [openFeedbacks, setOpenFeedbacks] = useState<ChoiceQuestion['answers'][number]['id'][]>([])
 
-  return question.answers.map((a, i) => {
-    const { isCorrectlySelected, isFalslySelected, isMissingSelection, reasoning } = getFeedbackEvaluation(question as SingleChoice)
+  // auto-opens feedback-text tooltips for wrongfully selected answer-options
+  useEffect(() => {
+    if (openFeedbacks.length > 0) return
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setOpenFeedbacks([...question.answers.filter((a) => isFalslySelected(a)).map((a) => a.id)])
+  }, [isEvaluated])
+
+  return question.answers.map((a, i) => {
     return (
       <label
         key={a.id}

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -271,9 +271,9 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
         {a.answer}
 
         <DisplayFeedbackText disabled={!isEvaluated} open={openFeedbacks.includes(a.id) ? true : undefined} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'}>
-          <div className={cn('absolute top-1 right-1 flex gap-2')}>
+          <div className={cn('absolute top-1 right-1.5 flex gap-1.5', i % 2 === 0 && 'left-1.5 flex-row-reverse justify-between')}>
             <FeedbackIndicators correctlySelected={isCorrectlySelected(a)} missingSelection={isMissingSelection(a)} falslySelected={isFalslySelected(a)} />
-            <MessageCircleQuestionIcon className='size-5 text-warning' />
+            <MessageCircleQuestionIcon className='size-4.5 text-warning' />
           </div>
         </DisplayFeedbackText>
 

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -247,27 +247,14 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
 
   return question.answers.map((a, i) => {
     return (
-      <label
+      <ChoiceOption
         key={a.id}
         onClick={isEvaluated ? () => setOpenFeedbacks((prev) => (prev.includes(a.id) ? prev.filter((id) => id !== a.id) : prev.concat([a.id]))) : undefined}
-        className={cn(
-          'rounded-md bg-neutral-100/90 px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 dark:bg-neutral-800 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50',
-          'has-enabled:hover:cursor-pointer has-enabled:hover:ring-ring-hover has-enabled:dark:hover:ring-ring-hover',
-          'has-enabled:focus:ring-[1.2px] has-enabled:focus:ring-ring-focus has-enabled:dark:focus:ring-ring-focus',
-          'flex items-center justify-center',
-          'resize-none select-none',
-          'has-enabled:has-checked:bg-neutral-200/60 has-enabled:has-checked:font-semibold has-enabled:has-checked:ring-[1.5px] has-enabled:has-checked:ring-ring-hover dark:has-enabled:has-checked:bg-neutral-700/60 dark:has-enabled:has-checked:ring-neutral-300',
-
-          isEvaluated && 'relative ring-2',
-          isEvaluated && !!reasoning?.at(i) && 'group cursor-pointer',
-          isEvaluated &&
-            isCorrectlySelected(a) &&
-            'bg-radial from-neutral-200/60 via-neutral-100/60 to-green-600/20 font-semibold ring-green-400/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/20 dark:ring-green-500/70',
-          isEvaluated &&
-            isFalslySelected(a) &&
-            'from-neutral-200/60 via-neutral-100/60 to-red-500/20 ring-red-500/70 has-checked:bg-radial has-checked:font-semibold dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/20 dark:ring-red-400/70',
-          isEvaluated && isMissingSelection(a) && 'ring-0 outline-2 outline-yellow-500 outline-dashed dark:outline-yellow-400/60',
-        )}
+        mode={isEvaluated ? 'feedback' : 'input'}
+        isCorrect={isEvaluated && isCorrectlySelected(a)}
+        isWrong={isEvaluated && isFalslySelected(a)}
+        isMissing={isEvaluated && isMissingSelection(a)}
+        feedbackText={reasoning?.at(i)}
         htmlFor={a.id}>
         {a.answer}
 
@@ -289,7 +276,49 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
         />
 
         <FormFieldError field={registerKey(i)} errors={errors} />
-      </label>
+      </ChoiceOption>
     )
   })
+}
+
+function ChoiceOption({
+  mode,
+  feedbackText,
+  isCorrect,
+  isWrong,
+  isMissing,
+  ...props
+}: React.ComponentProps<'label'> & {
+  mode: 'feedback' | 'input'
+  feedbackText?: string
+  isCorrect?: boolean
+  isWrong?: boolean
+  isMissing?: boolean
+}) {
+  return (
+    <label
+      {...props}
+      className={cn(
+        'rounded-md bg-neutral-100/90 px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 dark:bg-neutral-800 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50',
+        'has-enabled:hover:cursor-pointer has-enabled:hover:ring-ring-hover has-enabled:dark:hover:ring-ring-hover',
+        'has-enabled:focus:ring-[1.2px] has-enabled:focus:ring-ring-focus has-enabled:dark:focus:ring-ring-focus',
+        'flex items-center justify-center',
+        'resize-none select-none',
+        'has-enabled:has-checked:bg-neutral-200/60 has-enabled:has-checked:font-semibold has-enabled:has-checked:ring-[1.5px] has-enabled:has-checked:ring-ring-hover dark:has-enabled:has-checked:bg-neutral-700/60 dark:has-enabled:has-checked:ring-neutral-300',
+
+        mode === 'feedback' &&
+          cn(
+            'relative ring-2',
+            !!feedbackText && 'group cursor-pointer',
+            isCorrect &&
+              'bg-radial from-neutral-200/60 via-neutral-100/60 to-green-600/20 font-semibold ring-green-400/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/20 dark:ring-green-500/70',
+
+            isWrong &&
+              'from-neutral-200/60 via-neutral-100/60 to-red-500/20 ring-red-500/70 has-checked:bg-radial has-checked:font-semibold dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/20 dark:ring-red-400/70',
+
+            isMissing && 'ring-0 outline-2 outline-yellow-500 outline-dashed dark:outline-yellow-400/60',
+          ),
+      )}
+    />
+  )
 }

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -254,9 +254,9 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({
         htmlFor={a.id}>
         {a.answer}
 
-        <DisplayFeedbackText disabled={!isEvaluated} open={openFeedbacks.includes(a.id) ? true : undefined} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'}>
-          <div className={cn('absolute top-1 right-1.5 flex flex-row-reverse gap-1.5', i % 2 === 0 && 'left-1.5 flex-row justify-between')}>
-            <MessageCircleQuestionIcon className={cn('size-4.5 text-warning', !openFeedbacks.includes(a.id) ? 'group-hover:animate-scale' : 'scale-110')} />
+        <DisplayFeedbackText disabled={!isEvaluated} pinned={openFeedbacks.includes(a.id)} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'}>
+          <div className={cn('group/tooltip absolute top-1 right-1.5 flex flex-row-reverse gap-1.5', i % 2 === 0 && 'left-1.5 flex-row justify-between')}>
+            <MessageCircleQuestionIcon className={cn('size-4.5 text-warning', !openFeedbacks.includes(a.id) ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110')} />
             <FeedbackIndicators correctlySelected={isCorrectlySelected(a)} missingSelection={isMissingSelection(a)} falslySelected={isFalslySelected(a)} />
           </div>
         </DisplayFeedbackText>

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -257,7 +257,12 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({
         <DisplayFeedbackText disabled={!isEvaluated} pinned={openFeedbacks.includes(a.id)} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'}>
           <div className={cn('group/tooltip absolute top-1 right-1.5 flex flex-row-reverse gap-1.5', i % 2 === 0 && 'left-1.5 flex-row justify-between')}>
             <MessageCircleQuestionIcon
-              className={cn('size-4.5 text-warning', !openFeedbacks.includes(a.id) ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isEvaluated && 'hidden')}
+              className={cn(
+                'size-4.5 text-warning',
+                !openFeedbacks.includes(a.id) ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110',
+                !isEvaluated && 'hidden',
+                !reasoning?.at(i) && 'hidden',
+              )}
             />
             <FeedbackIndicators correctlySelected={isCorrectlySelected(a)} missingSelection={isMissingSelection(a)} falslySelected={isFalslySelected(a)} />
           </div>

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -142,7 +142,7 @@ export function RenderPracticeQuestion() {
             Check Answer
           </Button>
 
-          <Button hidden={!isSubmitted || !isSubmitSuccessful || isPending} className='mx-auto mt-2 bg-green-500/60 dark:bg-green-800' variant='secondary' onClick={nextRandomQuestion} type='button'>
+          <Button hidden={!isSubmitted || !isSubmitSuccessful || isPending} className='mx-auto mt-2 ' variant='success' onClick={nextRandomQuestion} type='button'>
             Continue
           </Button>
         </div>

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -21,7 +21,7 @@ import { useLogger } from '@/src/hooks/log/useLogger'
 import useRHF from '@/src/hooks/Shared/form/useRHF'
 import { EvaluateAnswer } from '@/src/lib/checks/[share_token]/practice/EvaluateAnswer'
 import { cn } from '@/src/lib/Shared/utils'
-import { ChoiceQuestion, Question, SingleChoice } from '@/src/schemas/QuestionSchema'
+import { ChoiceQuestion, Question } from '@/src/schemas/QuestionSchema'
 import { QuestionInput, QuestionInputSchema } from '@/src/schemas/UserQuestionInputSchema'
 import { Any } from '@/types'
 
@@ -111,13 +111,9 @@ export function RenderPracticeQuestion() {
         </div>
 
         <div id='answer-options' className={cn('grid min-h-[35vh] min-w-[25vw] grid-cols-2 gap-8 rounded-md p-6 ring-1 ring-ring dark:ring-ring', question?.type === 'open-question' && 'grid-cols-1')}>
-          {question.type === 'multiple-choice' && (
-            <ChoiceAnswerOption type='checkbox' registerKey={(i) => `selection.${i}`} question={question} getFeedbackEvaluation={getFeedbackEvaluation} isEvaluated={isEvaluated} />
-          )}
+          {question.type === 'multiple-choice' && <ChoiceAnswerOptions type='checkbox' question={question} getFeedbackEvaluation={getFeedbackEvaluation} isEvaluated={isEvaluated} />}
 
-          {question.type === 'single-choice' && (
-            <ChoiceAnswerOption type='radio' registerKey={() => 'selection'} question={question} getFeedbackEvaluation={getFeedbackEvaluation} isEvaluated={isEvaluated} />
-          )}
+          {question.type === 'single-choice' && <ChoiceAnswerOptions type='radio' question={question} getFeedbackEvaluation={getFeedbackEvaluation} isEvaluated={isEvaluated} />}
 
           {question.type === 'drag-drop' && <DragDropAnswers question={question} isEvaluated={isEvaluated} state={state} />}
 
@@ -217,8 +213,7 @@ function FeedbackIndicators({ correctlySelected, missingSelection, falslySelecte
 /**
  * This component renders the answer-options for ChoiceQuestions as they are almost identical, to reduce code duplication
  */
-function ChoiceAnswerOption<Q extends ChoiceQuestion>({
-  registerKey,
+function ChoiceAnswerOptions<Q extends ChoiceQuestion>({
   question,
   getFeedbackEvaluation,
   isEvaluated,
@@ -226,7 +221,6 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
 }: {
   isEvaluated: boolean
   type: Required<HTMLProps<HTMLInputElement>['type']>
-  registerKey: (index: number) => Parameters<UseFormRegister<QuestionInput>>['0']
   question: Q
   getFeedbackEvaluation: ReturnType<typeof usePracticeFeeback>
 }) {
@@ -234,7 +228,9 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
     register,
     formState: { errors },
   } = useFormContext<QuestionInput>()
-  const { isCorrectlySelected, isFalslySelected, isMissingSelection, reasoning } = getFeedbackEvaluation(question as SingleChoice)
+  const registerKey: (index: number) => Parameters<UseFormRegister<QuestionInput>>['0'] = question.type === 'multiple-choice' ? (i) => `selection.${i}` : () => `selection`
+
+  const { isCorrectlySelected, isFalslySelected, isMissingSelection, reasoning } = getFeedbackEvaluation(question)
   const [openFeedbacks, setOpenFeedbacks] = useState<ChoiceQuestion['answers'][number]['id'][]>([])
 
   // auto-opens feedback-text tooltips for wrongfully selected answer-options

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -256,7 +256,9 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({
 
         <DisplayFeedbackText disabled={!isEvaluated} pinned={openFeedbacks.includes(a.id)} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'}>
           <div className={cn('group/tooltip absolute top-1 right-1.5 flex flex-row-reverse gap-1.5', i % 2 === 0 && 'left-1.5 flex-row justify-between')}>
-            <MessageCircleQuestionIcon className={cn('size-4.5 text-warning', !openFeedbacks.includes(a.id) ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110')} />
+            <MessageCircleQuestionIcon
+              className={cn('size-4.5 text-warning', !openFeedbacks.includes(a.id) ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isEvaluated && 'hidden')}
+            />
             <FeedbackIndicators correctlySelected={isCorrectlySelected(a)} missingSelection={isMissingSelection(a)} falslySelected={isFalslySelected(a)} />
           </div>
         </DisplayFeedbackText>

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import React, { HTMLProps } from 'react'
 import { motion, Variants } from 'framer-motion'
 import isEmpty from 'lodash/isEmpty'
-import { LoaderCircleIcon } from 'lucide-react'
+import { LoaderCircleIcon, MessageCircleQuestionIcon } from 'lucide-react'
 import { CheckIcon, XIcon } from 'lucide-react'
 import { notFound, redirect, usePathname } from 'next/navigation'
 import { useFormContext } from 'react-hook-form'
@@ -240,44 +240,48 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
     const { isCorrectlySelected, isFalslySelected, isMissingSelection, reasoning } = getFeedbackEvaluation(question as SingleChoice)
 
     return (
-      <DisplayFeedbackText disabled={!isEvaluated} open={openFeedbacks.includes(a.id) ? true : undefined} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'} key={a.id}>
-        <label
-          onClick={isEvaluated ? () => setOpenFeedbacks((prev) => (prev.includes(a.id) ? prev.filter((id) => id !== a.id) : prev.concat([a.id]))) : undefined}
-          className={cn(
-            'rounded-md bg-neutral-100/90 px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 dark:bg-neutral-800 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50',
-            'has-enabled:hover:cursor-pointer has-enabled:hover:ring-ring-hover has-enabled:dark:hover:ring-ring-hover',
-            'has-enabled:focus:ring-[1.2px] has-enabled:focus:ring-ring-focus has-enabled:dark:focus:ring-ring-focus',
-            'flex items-center justify-center',
-            'resize-none select-none',
-            'has-enabled:has-checked:bg-neutral-200/60 has-enabled:has-checked:font-semibold has-enabled:has-checked:ring-[1.5px] has-enabled:has-checked:ring-ring-hover dark:has-enabled:has-checked:bg-neutral-700/60 dark:has-enabled:has-checked:ring-neutral-300',
+      <label
+        key={a.id}
+        onClick={isEvaluated ? () => setOpenFeedbacks((prev) => (prev.includes(a.id) ? prev.filter((id) => id !== a.id) : prev.concat([a.id]))) : undefined}
+        className={cn(
+          'rounded-md bg-neutral-100/90 px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 dark:bg-neutral-800 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50',
+          'has-enabled:hover:cursor-pointer has-enabled:hover:ring-ring-hover has-enabled:dark:hover:ring-ring-hover',
+          'has-enabled:focus:ring-[1.2px] has-enabled:focus:ring-ring-focus has-enabled:dark:focus:ring-ring-focus',
+          'flex items-center justify-center',
+          'resize-none select-none',
+          'has-enabled:has-checked:bg-neutral-200/60 has-enabled:has-checked:font-semibold has-enabled:has-checked:ring-[1.5px] has-enabled:has-checked:ring-ring-hover dark:has-enabled:has-checked:bg-neutral-700/60 dark:has-enabled:has-checked:ring-neutral-300',
 
-            isEvaluated && 'relative ring-2',
-            isEvaluated &&
-              isCorrectlySelected(a) &&
-              'bg-radial from-neutral-200/60 via-neutral-100/60 to-green-600/20 font-semibold ring-green-400/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/20 dark:ring-green-500/70',
-            isEvaluated &&
-              isFalslySelected(a) &&
-              'cursor-help from-neutral-200/60 via-neutral-100/60 to-red-500/20 ring-red-500/70 has-checked:bg-radial has-checked:font-semibold dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/20 dark:ring-red-400/70',
-            isEvaluated && isMissingSelection(a) && 'cursor-help ring-0 outline-2 outline-yellow-500 outline-dashed dark:outline-yellow-400/60',
-          )}
-          htmlFor={a.id}>
-          {a.answer}
+          isEvaluated && 'relative ring-2',
+          isEvaluated &&
+            isCorrectlySelected(a) &&
+            'bg-radial from-neutral-200/60 via-neutral-100/60 to-green-600/20 font-semibold ring-green-400/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/20 dark:ring-green-500/70',
+          isEvaluated &&
+            isFalslySelected(a) &&
+            'cursor-help from-neutral-200/60 via-neutral-100/60 to-red-500/20 ring-red-500/70 has-checked:bg-radial has-checked:font-semibold dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/20 dark:ring-red-400/70',
+          isEvaluated && isMissingSelection(a) && 'cursor-help ring-0 outline-2 outline-yellow-500 outline-dashed dark:outline-yellow-400/60',
+        )}
+        htmlFor={a.id}>
+        {a.answer}
 
-          <FeedbackIndicators correctlySelected={isCorrectlySelected(a)} missingSelection={isMissingSelection(a)} falslySelected={isFalslySelected(a)} />
+        <DisplayFeedbackText disabled={!isEvaluated} open={openFeedbacks.includes(a.id) ? true : undefined} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'}>
+          <div className={cn('absolute top-1 right-1 flex gap-2')}>
+            <FeedbackIndicators correctlySelected={isCorrectlySelected(a)} missingSelection={isMissingSelection(a)} falslySelected={isFalslySelected(a)} />
+            <MessageCircleQuestionIcon className='size-5 text-warning' />
+          </div>
+        </DisplayFeedbackText>
 
-          <input
-            className='hidden'
-            id={a.id}
-            type={type}
-            {...register(registerKey(i))}
-            disabled={isEvaluated}
-            value={a.id}
-            data-evaluation-result={isEvaluated ? (isCorrectlySelected(a) ? 'correct' : isFalslySelected(a) ? 'incorrect' : isMissingSelection(a) ? 'missing' : 'none') : 'none'}
-          />
+        <input
+          className='hidden'
+          id={a.id}
+          type={type}
+          {...register(registerKey(i))}
+          disabled={isEvaluated}
+          value={a.id}
+          data-evaluation-result={isEvaluated ? (isCorrectlySelected(a) ? 'correct' : isFalslySelected(a) ? 'incorrect' : isMissingSelection(a) ? 'missing' : 'none') : 'none'}
+        />
 
-          <FormFieldError field={registerKey(i)} errors={errors} />
-        </label>
-      </DisplayFeedbackText>
+        <FormFieldError field={registerKey(i)} errors={errors} />
+      </label>
     )
   })
 }

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -250,18 +250,18 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({
         isCorrect={isEvaluated && isCorrectlySelected(a)}
         isWrong={isEvaluated && isFalslySelected(a)}
         isMissing={isEvaluated && isMissingSelection(a)}
-        feedbackText={reasoning?.at(i)}
+        feedbackText={reasoning?.get(a.id)}
         htmlFor={a.id}>
         {a.answer}
 
-        <DisplayFeedbackText disabled={!isEvaluated} pinned={openFeedbacks.includes(a.id)} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'}>
+        <DisplayFeedbackText disabled={!isEvaluated} pinned={openFeedbacks.includes(a.id)} feedback={reasoning?.get(a.id)} side={i % 2 === 1 ? 'right' : 'left'}>
           <div className={cn('group/tooltip absolute top-1 right-1.5 flex flex-row-reverse gap-1.5', i % 2 === 0 && 'left-1.5 flex-row justify-between')}>
             <MessageCircleQuestionIcon
               className={cn(
                 'size-4.5 text-warning',
                 !openFeedbacks.includes(a.id) ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110',
                 !isEvaluated && 'hidden',
-                !reasoning?.at(i) && 'hidden',
+                !reasoning?.get(a.id) && 'hidden',
               )}
             />
             <FeedbackIndicators correctlySelected={isCorrectlySelected(a)} missingSelection={isMissingSelection(a)} falslySelected={isFalslySelected(a)} />

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -11,11 +11,11 @@ import { useFormContext } from 'react-hook-form'
 import { UseFormRegister } from 'react-hook-form'
 import { FeedbackOpenQuestion } from '@/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer'
 import DragDropAnswers from '@/src/components/checks/[share_token]/practice/DragDropAnswerOptions'
+import DisplayFeedbackText from '@/src/components/checks/[share_token]/practice/FeedbackText'
 import { usePracticeStore } from '@/src/components/checks/[share_token]/practice/PracticeStoreProvider'
 import { Button } from '@/src/components/shadcn/button'
 import { Form } from '@/src/components/shadcn/form'
 import FormFieldError from '@/src/components/Shared/form/FormFieldError'
-import Tooltip from '@/src/components/Shared/Tooltip'
 import { usePracticeFeeback } from '@/src/hooks/checks/[share_token]/practice/usePracticeFeedback'
 import { useLogger } from '@/src/hooks/log/useLogger'
 import useRHF from '@/src/hooks/Shared/form/useRHF'
@@ -207,9 +207,9 @@ function FeedbackLegend({ show, disabled }: { show: boolean; disabled?: boolean 
 function FeedbackIndicators({ correctlySelected, missingSelection, falslySelected }: { correctlySelected?: boolean; missingSelection?: boolean; falslySelected?: boolean }) {
   return (
     <>
-      <CheckIcon className={cn('absolute top-1 right-1 hidden size-5 text-green-400 dark:text-green-500', correctlySelected && 'block')} />
-      <XIcon className={cn('absolute top-1 right-1 hidden size-5 text-red-400 dark:text-red-500', falslySelected && 'block')} />
-      <CheckIcon className={cn('absolute top-1 right-1 hidden size-5 text-yellow-400/80 dark:text-yellow-500/80', missingSelection && 'block')} />
+      <CheckIcon className={cn('hidden size-5 text-green-400 dark:text-green-500', correctlySelected && 'block')} />
+      <XIcon className={cn('hidden size-5 text-red-400 dark:text-red-500', falslySelected && 'block')} />
+      <CheckIcon className={cn('hidden size-5 text-yellow-400/80 dark:text-yellow-500/80', missingSelection && 'block')} />
     </>
   )
 }
@@ -240,13 +240,7 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
     const { isCorrectlySelected, isFalslySelected, isMissingSelection, reasoning } = getFeedbackEvaluation(question as SingleChoice)
 
     return (
-      <Tooltip
-        className='max-w-[25vw] text-wrap'
-        disabled={!isEvaluated}
-        config={{ open: openFeedbacks.includes(a.id) ? true : undefined }}
-        content={reasoning?.at(i)}
-        side={i % 2 === 1 ? 'right' : 'left'}
-        key={a.id}>
+      <DisplayFeedbackText disabled={!isEvaluated} open={openFeedbacks.includes(a.id) ? true : undefined} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'} key={a.id}>
         <label
           onClick={isEvaluated ? () => setOpenFeedbacks((prev) => (prev.includes(a.id) ? prev.filter((id) => id !== a.id) : prev.concat([a.id]))) : undefined}
           className={cn(
@@ -283,7 +277,7 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
 
           <FormFieldError field={registerKey(i)} errors={errors} />
         </label>
-      </Tooltip>
+      </DisplayFeedbackText>
     )
   })
 }

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -255,9 +255,9 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({
         {a.answer}
 
         <DisplayFeedbackText disabled={!isEvaluated} open={openFeedbacks.includes(a.id) ? true : undefined} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'}>
-          <div className={cn('absolute top-1 right-1.5 flex gap-1.5', i % 2 === 0 && 'left-1.5 flex-row-reverse justify-between')}>
-            <FeedbackIndicators correctlySelected={isCorrectlySelected(a)} missingSelection={isMissingSelection(a)} falslySelected={isFalslySelected(a)} />
+          <div className={cn('absolute top-1 right-1.5 flex flex-row-reverse gap-1.5', i % 2 === 0 && 'left-1.5 flex-row justify-between')}>
             <MessageCircleQuestionIcon className={cn('size-4.5 text-warning', !openFeedbacks.includes(a.id) ? 'group-hover:animate-scale' : 'scale-110')} />
+            <FeedbackIndicators correctlySelected={isCorrectlySelected(a)} missingSelection={isMissingSelection(a)} falslySelected={isFalslySelected(a)} />
           </div>
         </DisplayFeedbackText>
 

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -259,13 +259,14 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
           'has-enabled:has-checked:bg-neutral-200/60 has-enabled:has-checked:font-semibold has-enabled:has-checked:ring-[1.5px] has-enabled:has-checked:ring-ring-hover dark:has-enabled:has-checked:bg-neutral-700/60 dark:has-enabled:has-checked:ring-neutral-300',
 
           isEvaluated && 'relative ring-2',
+          isEvaluated && !!reasoning?.at(i) && 'group cursor-pointer',
           isEvaluated &&
             isCorrectlySelected(a) &&
             'bg-radial from-neutral-200/60 via-neutral-100/60 to-green-600/20 font-semibold ring-green-400/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/20 dark:ring-green-500/70',
           isEvaluated &&
             isFalslySelected(a) &&
-            'cursor-help from-neutral-200/60 via-neutral-100/60 to-red-500/20 ring-red-500/70 has-checked:bg-radial has-checked:font-semibold dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/20 dark:ring-red-400/70',
-          isEvaluated && isMissingSelection(a) && 'cursor-help ring-0 outline-2 outline-yellow-500 outline-dashed dark:outline-yellow-400/60',
+            'from-neutral-200/60 via-neutral-100/60 to-red-500/20 ring-red-500/70 has-checked:bg-radial has-checked:font-semibold dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/20 dark:ring-red-400/70',
+          isEvaluated && isMissingSelection(a) && 'ring-0 outline-2 outline-yellow-500 outline-dashed dark:outline-yellow-400/60',
         )}
         htmlFor={a.id}>
         {a.answer}
@@ -273,7 +274,7 @@ function ChoiceAnswerOption<Q extends ChoiceQuestion>({
         <DisplayFeedbackText disabled={!isEvaluated} open={openFeedbacks.includes(a.id) ? true : undefined} feedback={reasoning?.at(i)} side={i % 2 === 1 ? 'right' : 'left'}>
           <div className={cn('absolute top-1 right-1.5 flex gap-1.5', i % 2 === 0 && 'left-1.5 flex-row-reverse justify-between')}>
             <FeedbackIndicators correctlySelected={isCorrectlySelected(a)} missingSelection={isMissingSelection(a)} falslySelected={isFalslySelected(a)} />
-            <MessageCircleQuestionIcon className='size-4.5 text-warning' />
+            <MessageCircleQuestionIcon className={cn('size-4.5 text-warning', !openFeedbacks.includes(a.id) ? 'group-hover:animate-scale' : 'scale-110')} />
           </div>
         </DisplayFeedbackText>
 

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -254,7 +254,7 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({
         htmlFor={a.id}>
         {a.answer}
 
-        <DisplayFeedbackText disabled={!isEvaluated} pinned={openFeedbacks.includes(a.id)} feedback={reasoning?.get(a.id)} side={i % 2 === 1 ? 'right' : 'left'}>
+        <DisplayFeedbackText disabled={!isEvaluated} answerIndex={i} pinned={openFeedbacks.includes(a.id)} feedback={reasoning?.get(a.id)} side={i % 2 === 1 ? 'right' : 'left'}>
           <div className={cn('group/tooltip absolute top-1 right-1.5 flex flex-row-reverse gap-1.5', i % 2 === 0 && 'left-1.5 flex-row justify-between')}>
             <MessageCircleQuestionIcon
               className={cn(

--- a/src/components/shadcn/button.tsx
+++ b/src/components/shadcn/button.tsx
@@ -17,6 +17,8 @@ const buttonVariants = cva(
         ),
         destructive:
           'bg-destructive text-white shadow-xs focus-visible:ring-destructive/20 enabled:hover:bg-destructive/80 enabled:active:bg-destructive/90! dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
+        success: 'bg-success text-white shadow-xs focus-visible:ring-success/20 enabled:hover:bg-success/80 enabled:active:bg-success/90! dark:bg-success/60 dark:focus-visible:ring-success/40',
+        warning: 'bg-warning text-white shadow-xs focus-visible:ring-warning/20 enabled:hover:bg-warning/80 enabled:active:bg-warning/90! dark:bg-warning/60 dark:focus-visible:ring-warning/40',
         outline:
           'bg-transparent text-secondary-foreground shadow-xs ring-1 ring-input-ring enabled:hover:bg-secondary/80 disabled:ring-neutral-300 dark:text-neutral-200 dark:ring-input-ring dark:enabled:hover:bg-neutral-700 dark:disabled:ring-neutral-500',
         secondary: 'bg-secondary text-secondary-foreground shadow-xs enabled:hover:bg-secondary/80',

--- a/src/hooks/checks/[share_token]/practice/usePracticeFeedback.ts
+++ b/src/hooks/checks/[share_token]/practice/usePracticeFeedback.ts
@@ -48,6 +48,7 @@ export function usePracticeFeeback(
   function getFeedbackEvaluation(question: MultipleChoice): ChoiceFeedbackEvaluation<MultipleChoice['type']>
   function getFeedbackEvaluation(question: OpenQuestion): OpenQuestionFeedbackEvaluation
   function getFeedbackEvaluation(question: DragDropQuestion): DragDropFeedbackEvaluation
+  function getFeedbackEvaluation(question: ChoiceQuestion): ChoiceFeedbackEvaluation<SingleChoice['type']> | ChoiceFeedbackEvaluation<MultipleChoice['type']>
   function getFeedbackEvaluation(question: Question): PracticeFeedbackReturn {
     //? Indicates whether the pre-conditions are satisfied so that a feedback-evaluation may be returned. Namely, whether the answers are submitted and whether the received feedback is for the respective question.
     const isEvaluated = isSubmitted && isSubmitSuccessful && (!isSubmitting || !isPending) && state.values?.question_id === question.id

--- a/src/hooks/checks/[share_token]/practice/usePracticeFeedback.ts
+++ b/src/hooks/checks/[share_token]/practice/usePracticeFeedback.ts
@@ -13,7 +13,7 @@ type ChoiceFeedbackEvaluation<Type extends ChoiceQuestion['type']> = FeedbackEva
   reasoning?: Extract<PracticeFeedback, { type: Type }>['reasoning']
 }
 
-type DragDropFeedbackEvaluation = FeedbackEvaluation<DragDropQuestion['type']> & {
+export type DragDropFeedbackEvaluation = FeedbackEvaluation<DragDropQuestion['type']> & {
   isCorrectlyPositioned: (answerId: string) => boolean
   isFalslyPositioned: (answerId: string) => boolean
   getCorrectPosition: (answerId: string) => number

--- a/src/lib/checks/[share_token]/practice/EvaluateAnswer.ts
+++ b/src/lib/checks/[share_token]/practice/EvaluateAnswer.ts
@@ -61,12 +61,15 @@ async function createFeedback({ question_id, ...answer }: QuestionInput): Promis
 
       const feedback: FeedbackMap = new Map()
 
-      question.answers.forEach((answer, i) =>
-        feedback.set(
-          answer.id,
-          answer.correct ? `Answer ${i} is correct because ${lorem().split(' ').slice(0, 30).join(' ')}` : `Answer ${i} is false because ${lorem().split(' ').slice(0, 30).join(' ')}`,
-        ),
-      )
+      question.answers
+        // produce feedback for selected option(s) and the correct one that was not selected
+        .filter((a) => (answer.selection === a.id && !a.correct) || (answer.selection !== a.id && a.correct))
+        .forEach((answer, i) =>
+          feedback.set(
+            answer.id,
+            answer.correct ? `Answer ${i} is correct because ${lorem().split(' ').slice(0, 30).join(' ')}` : `Answer ${i} is false because ${lorem().split(' ').slice(0, 30).join(' ')}`,
+          ),
+        )
 
       return {
         type: answer.type,
@@ -80,12 +83,16 @@ async function createFeedback({ question_id, ...answer }: QuestionInput): Promis
 
       const feedback: FeedbackMap = new Map()
 
-      question.answers.forEach((answer, i) =>
-        feedback.set(
-          answer.id,
-          answer.correct ? `Answer ${i} is correct because ${lorem().split(' ').slice(0, 30).join(' ')}` : `Answer ${i} is false because ${lorem().split(' ').slice(0, 30).join(' ')}`,
-        ),
-      )
+      question.answers
+        // produce feedback for selected option(s) and the correct one that was not selected
+        .filter((a) => (answer.selection.includes(a.id) && !a.correct) || (!answer.selection.includes(a.id) && a.correct))
+        .forEach((answer, i) =>
+          feedback.set(
+            answer.id,
+            answer.correct ? `Answer ${i} is correct because ${lorem().split(' ').slice(0, 30).join(' ')}` : `Answer ${i} is false because ${lorem().split(' ').slice(0, 30).join(' ')}`,
+          ),
+        )
+
       return {
         type: answer.type,
         solution: question.answers.filter((a) => a.correct).map((answer) => answer.id),
@@ -113,14 +120,11 @@ async function createFeedback({ question_id, ...answer }: QuestionInput): Promis
 
       const feedback: FeedbackMap = new Map()
 
-      question.answers.forEach((a, i) =>
-        feedback.set(
-          a.id,
-          answer.input.at(i) === a.id
-            ? `Answer (${orderedAnswers.find(({ id }) => id === answer.input.at(i))?.answer}) at position ${i + 1} is correct because ${lorem().split(' ').slice(0, 30).join(' ')}`
-            : `Answer (${orderedAnswers.find(({ id }) => id === answer.input.at(i))?.answer}) at position ${i + 1} is false because ${lorem().split(' ').slice(0, 30).join(' ')}`,
-        ),
-      )
+      question.answers
+        .filter((a, i) => answer.input.at(i) !== a.id)
+        .forEach((a, i) =>
+          feedback.set(a.id, `Answer (${orderedAnswers.find(({ id }) => id === answer.input.at(i))?.answer}) at position ${i + 1} is false because ${lorem().split(' ').slice(0, 30).join(' ')}`),
+        )
 
       return {
         type: answer.type,

--- a/src/lib/checks/[share_token]/practice/EvaluateAnswer.ts
+++ b/src/lib/checks/[share_token]/practice/EvaluateAnswer.ts
@@ -2,6 +2,7 @@
 
 import { getKnowledgeCheckQuestionById } from '@/database/knowledgeCheck/questions/select'
 import _logger from '@/src/lib/log/Logger'
+import lorem from '@/src/lib/Shared/Lorem'
 import { DragDropQuestion, MultipleChoice, OpenQuestion, SingleChoice } from '@/src/schemas/QuestionSchema'
 import { QuestionInput, QuestionInputSchema } from '@/src/schemas/UserQuestionInputSchema'
 
@@ -58,7 +59,9 @@ async function createFeedback({ question_id, ...answer }: QuestionInput): Promis
       return {
         type: answer.type,
         solution: question.answers.find((a) => a.correct)!.id,
-        reasoning: question.answers.map((answer, i) => (answer.correct ? `Answer ${i} is correct because...` : `Answer ${i} is false because..`)),
+        reasoning: question.answers.map((answer, i) =>
+          answer.correct ? `Answer ${i} is correct because ${lorem().split(' ').slice(0, 30).join(' ')}` : `Answer ${i} is false because ${lorem().split(' ').slice(0, 30).join(' ')}`,
+        ),
       }
 
     case 'multiple-choice':
@@ -66,7 +69,9 @@ async function createFeedback({ question_id, ...answer }: QuestionInput): Promis
       return {
         type: answer.type,
         solution: question.answers.filter((a) => a.correct).map((answer) => answer.id),
-        reasoning: question.answers.map((answer, i) => (answer.correct ? `Answer ${i} is correct because...` : `Answer ${i} is false because..`)),
+        reasoning: question.answers.map((answer, i) =>
+          answer.correct ? `Answer ${i} is correct because ${lorem().split(' ').slice(0, 30).join(' ')}` : `Answer ${i} is false because ${lorem().split(' ').slice(0, 30).join(' ')}`,
+        ),
       }
 
     case 'open-question':
@@ -78,7 +83,7 @@ async function createFeedback({ question_id, ...answer }: QuestionInput): Promis
       return {
         type: answer.type,
         solution: question.expectation,
-        reasoning: `This answer is ${degreeOfCorrectness >= 0.5 ? 'correct' : 'incorrect'} because...`,
+        reasoning: `This answer is ${degreeOfCorrectness >= 0.5 ? 'correct' : 'incorrect'} because ${lorem().split(' ').slice(0, 30).join(' ')}`,
         degreeOfCorrectness: degreeOfCorrectness,
       }
 
@@ -92,8 +97,8 @@ async function createFeedback({ question_id, ...answer }: QuestionInput): Promis
         solution: correctlyOrdered,
         reasoning: correctlyOrdered.map((id, i) =>
           answer.input.at(i) === id
-            ? `Answer (${orderedAnswers.find(({ id }) => id === answer.input.at(i))?.answer}) at position ${i + 1} is correct because...`
-            : `Answer (${orderedAnswers.find(({ id }) => id === answer.input.at(i))?.answer}) at position ${i + 1} is false because..`,
+            ? `Answer (${orderedAnswers.find(({ id }) => id === answer.input.at(i))?.answer}) at position ${i + 1} is correct because ${lorem().split(' ').slice(0, 30).join(' ')}`
+            : `Answer (${orderedAnswers.find(({ id }) => id === answer.input.at(i))?.answer}) at position ${i + 1} is false because ${lorem().split(' ').slice(0, 30).join(' ')}`,
         ),
       }
   }

--- a/src/tests/e2e/checks/[share_token]/practice/PracticeCheck.cy.tsx
+++ b/src/tests/e2e/checks/[share_token]/practice/PracticeCheck.cy.tsx
@@ -237,10 +237,7 @@ describe('RenderPracticeQuestion Test Suite', { viewportWidth: 1280, viewportHei
       })
 
       cy.get('button').contains('Continue').should('exist').and('be.visible')
-      cy.get(`#answer-options`)
-        .children()
-        .first()
-        .should('have.attr', 'data-evaluation-result', type === 'correct' ? 'correct' : 'incorrect')
+      cy.get(`#answer-options textarea`).should('have.attr', 'data-evaluation-result', type === 'correct' ? 'correct' : 'incorrect')
     }),
   )
   ;([{ type: 'correct' }, { type: 'incorrect' }] as const).forEach(({ type }) =>
@@ -368,9 +365,7 @@ describe('RenderPracticeQuestion Test Suite', { viewportWidth: 1280, viewportHei
                 break
               }
               case 'open-question': {
-                cy.get(`#answer-options`)
-                  .children()
-                  .should('have.attr', 'data-evaluation-result', type === 'correct' ? 'correct' : 'incorrect')
+                cy.get(`#answer-options textarea`).should('have.attr', 'data-evaluation-result', type === 'correct' ? 'correct' : 'incorrect')
                 break
               }
               case 'drag-drop': {


### PR DESCRIPTION
> [!NOTE]
> This pull request introduces the display of feedback texts to the answer-options of (choice, drag-drop) and inputs (open-question) of users. To do this `tooltips` are used at the moment to show the feedback on hover and onToggle, meaning that users can toggle the feedback-display to keep the tooltip open. This is what the feedback display looks right now:
> <details>
> <summary>Screenshots</summary>
> <img width="1149" height="623" alt="single choice question feedback" src="https://github.com/user-attachments/assets/dbd7f7fa-12ec-4e10-8f41-1ec4eb1fef18" />
>
>  <img width="1429" height="639" alt="multiple choice question feedback" src="https://github.com/user-attachments/assets/15b52075-0421-406b-88f2-9ddb01e88305" />
>
>
> <img width="1136" height="633" alt="drag drop question feedback" src="https://github.com/user-attachments/assets/0af259bf-1981-4595-939b-3a60b50f6628" />
>
> <img width="1113" height="561" alt="open question feedback" src="https://github.com/user-attachments/assets/3a8f5aab-5032-4db7-a0d2-266a74ce6183" />
> </details>
>

> [!TIP]
> Note that this implementation can be widely used but also comes with at least one shortcoming. For example when two options that are close to each other display their feedback-texts, tooltips will probably overlap. One way of solving this would be by ensuring that only one feedback-text may be opened at once (hover and toggle). 

## Summary

* **Features**
  * Added feedback indicator and text display to open-, single choice-, multiple choice- and drag drop- questions. 
  * Added auto-open feedback for all wrong-input mechanism to all question types
  * Added move-icon hiding capabilities to `DragDropItem` e.g. when feedback is being displayed.

* **Improvements**
  * Introduced new "success" and "warning" button variants
  * Improved practice 'Continue' button coloring by using new `success` variant
  * Enriched dummy feedback texts using lorem in `EvluateAnswer`
  * Transformed feedback-reasoning from array into map, with the answer-id being the key
  * Limited feedback generation to wrong- and missing- answers. 
  
* **Styles**
  * Introduced new "success" and "warning" css variables for both color-modes.
  * Simplified move-indicator alignment when move-icon is not hidden
  * Added `animate-scale` custom tailwind animation
  * Removed `cusor-move` in `DragDropItem` when moving is disabled

---
### Detailed Changelog

<details>
<summary>Changelog</summary>

[](https://google.com)

- **Features**:
  - Introduced `success` and `warning` btn variants ([`79f962d6`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/79f962d6))
     
  - Drafted feedback text display for choice questions ([`18dfc2f1`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/18dfc2f1))
     By using tooltips the feedback-text for questions is shown when hovering over answers. At the same time the tooltip's appearance can be toggled by clicking on the answer-option, which is especially useful for mobile devices that cannot hover.
  
  - Added `DragDropItem` move icon hide functionality ([`1918ad1a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/1918ad1a))
     This commit adds the `hide-move-indicators` data-attribute to the `DragDropContainer` when this property is set to false the move-indicators in each `DragDropItem` will be hidden. This may be useful to use the space of the move-icon for a feedback icon instead.
  
  - Added feedback indicator, display to drag-drop ([`c4fb22cd`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/c4fb22cd))
     
  - Added auto open feedback text logic ([`62227329`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/62227329))
     This `useEffect` essentially pre-populates the open-feedbacks id state with the ones that were wrong-fully selected / positioned by the user.
  
  - Added feedback text display to open-question ([`920b1736`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/920b1736))
     
  - Added auto open feedback text logic to open-question ([`0b01dc33`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/0b01dc33))
     This `useEffect` essentially pre opens the feedback-text tooltip when an open-question has been answered incorrectly.
  

- **Refactors**:
  - Fixed practice continue button interactive states ([`23e5d26b`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/23e5d26b))
     Previously the `Continue` button had a success-background but did use the styles of the `secondary` variant on hover, focus, active and so on. By using a the new `success` variant the button is properly styled in these situations.
  
  - Externalized tooltip feedback into component ([`763d5690`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/763d5690))
     This way the rendering of feedback for a given answer-option is can be easily re-used. This means that one does not have to re-configure and re-duplicate the same tooltip configuration for every type of question. .
  
  - Moved feedback trigger to feedback-indicator ([`83932c59`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/83932c59))
     This way the feedback-trigger container is no longer the answer-option itself, but a dedicated feedback-indicator.
  
  - Opened feedback text display for wrong selections ([`a836a14b`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/a836a14b))
     This way users are automatically shown the feedback text for answer-options that were wrongfully selected.
  
  - Externalized choice answer option label ([`59d65bb4`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/59d65bb4))
     This way the styling of the choice-answer-option is no longer defined within the `ChoiceAnswerOption` component that renders all options. Thereby decluttering the `ChoiceAnswerOption` component that renders each option.
  
  - Simplified choice answer rendering ([`f62467fe`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f62467fe))
     
  - Fixed feedback indicator position w/o other indicators ([`709bc01f`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/709bc01f))
     Previously the feedback indicator for answer-options in the left column was positioned on the right top corner, when no other indicators were shown. By inverting the flex-box order this issue is resolved thereby ensuring that the feedback-indicator is always in the top-left and top-right corner depending on the column.
  
  - Updated `DisplayFeedbackT` tooltip to be controlled ([`143c06aa`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/143c06aa))
     Previously the tooltip was changing between uncontrolled and controlled to support hover-events and pinned feedback-tooltips. Since this violates best practices the feedback-tooltip has been converted to being a controlled component, while preserving its behavior.
  
  - Enriched dummy question feedback in `EvaluateAnswer` ([`54134691`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/54134691))
     This commits adds 30 words of lorems to the feedback-reasoning output to simulate larger feedback texts.
  
  - Prepared drag-drop feedback component ([`6a80b00a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/6a80b00a))
     In doing so the feedback evaluation result is now accessible from within the `AnswerFeedback` component for drag-drop answers. In the next step a feedback-text-tooltip will be introduced.
  
  - Added toggling of open-question feedback text ([`0383aecf`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/0383aecf))
     
  - Simplified move-indicator alignment when not hidden ([`6c2793e5`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/6c2793e5))
     This commit essentially strengthens the selectors to add padding when the move-icon is not hidden, thus shown. This way the icon is properly aligned when the data-property is set to false or not set at all.
  
  - Simplified move-indicator hiding classes ([`f7cdc860`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f7cdc860))
     By only setting the `hide-move-indicators` data attribute when it is set to true, the style-querying is much easier. That way one must only check whether the element has the data-attribute or not.
  
  - Updated open-question feedback test selector ([`17414443`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/17414443))
     The reason for this change is that the textarea that holds the user-input and data-attribute about the evaluation has been wrapped in a div. That way the test selectors failed to retrieve the textarea, more specifically the `evaluation-results` data attribute of the textarea.
  
  - Added guard against missing drag-drop feedback ([`565b9fa8`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/565b9fa8))
     Previously the drag-drop feedback (`reasoning`) was accessed through the currentPosition (index). However, when the currentPosition for an answer was not found, e.g. because the answer does not exist, -1 was returned instead. This meant that the last option's reasoning would have been used instead. By checking whether a valid (current) position was returned this issue is resolved.
  
  - Added `hidden` to icon when no feedback text exists ([`f4cb85d0`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f4cb85d0))
     This way the feedback-text indicator is only shown for answer-options / fields which have a respective feedback text.
  
  - Transformed feedback reasoning into map ([`0ab4c8b0`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/0ab4c8b0))
     This way the retrieval of the feedback (`reasoning`) for answer-options is much easier and no longer index based. This way the feedback may only include feedbacks for a set of options and not all options.
  
  - Added click handler to open-q feedback indicator ([`87cf6cd3`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/87cf6cd3))
     This way users can not only click within the textarea to toggle the feedback-text display but also on the icon itself.
  
  - Added simple header to feedback-text tooltip ([`7441e759`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/7441e759))
     
  - Removed outdated misleading comment ([`d1179015`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/d1179015))
     
  - Limited feedback generation to missing / wrong inputs ([`cacd0b09`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/cacd0b09))
     This way feedback will only be available for selections that were wrong or missing. That means that feedback indicators are not shown for answers that are wrong and that were not selected and for correctly selected answers.
  

- **Styles**:
  - Added success, warning color variables ([`8a6d114e`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/8a6d114e))
     
  - Repositioned feedback-indictor to outmost corner ([`b7b1af18`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/b7b1af18))
     This way the feedback-indicator is almost in outmost top corner. Meaning for answers in the left column of the grid the indicator is shown in the top left and for answers in the right column the feedback indicator is shown in the top right. This greatly improves the look-and-feel when the tooltip is open.
  
  - Added `animate-scale` animation + class ([`3cc83641`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/3cc83641))
     
  - Added feedback-indicator animation on hover ([`5d40c0e4`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/5d40c0e4))
     This way the feedback indicator is emphasized when a given answer-option is hovered to indicate that there it is an action.
  
  - Updated feedback-tooltip max-width on small screens ([`28b063fc`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/28b063fc))
     
  - Updated feedback-indicator to hide before feedback ([`f35bfd9f`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f35bfd9f))
     This way the feedback indicator is only shown when the form has been submitted successfully and thus feedback should exists.
  
  - Disabled `cursor-move` when drag is disabled ([`0b36a88a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/0b36a88a))
     This way the move-cursor is no longer shown by a `DragDropItem` that is rendered within  a `DragDropContainer` that is disabled.
  
  - Added cursor-pointer to `DDItem` for feedback ([`f00edbb3`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f00edbb3))
     By adding the cursor-pointer to the `DragDropItem` when it shows the feedback-text indicators lets users know that clicking on the item will perform an action.
  

</details>