### PR TITLE
Ref: Reduce react-hook-form property drilling & code duplication

### DIFF
--- a/src/app/[locale]/checks/[share_token]/practice/page.tsx
+++ b/src/app/[locale]/checks/[share_token]/practice/page.tsx
@@ -7,6 +7,7 @@ import { PracticeQuestionNavigation } from '@/src/components/checks/[share_token
 import { PracticeStoreProvider } from '@/src/components/checks/[share_token]/practice/PracticeStoreProvider'
 import { RenderPracticeQuestion } from '@/src/components/checks/[share_token]/practice/RenderPracticeQuestion'
 import PageHeading from '@/src/components/Shared/PageHeading'
+import requireAuthentication from '@/src/lib/auth/requireAuthentication'
 import prepareQuestions from '@/src/lib/checks/[share_token]/prepareQuestions'
 import _logger from '@/src/lib/log/Logger'
 import { cn } from '@/src/lib/Shared/utils'
@@ -14,6 +15,7 @@ import { cn } from '@/src/lib/Shared/utils'
 const logger = _logger.createModuleLogger('/' + import.meta.url.split('/').reverse().slice(0, 2).reverse().join('/')!)
 
 export default async function PracticePage({ params, searchParams }: { params: Promise<{ share_token: string }>; searchParams?: Promise<{ category?: '_none_' | string }> }) {
+  await requireAuthentication()
   const { share_token } = await params
   const { category } = (await searchParams) ?? {}
 

--- a/src/components/account/login/CredentialProviderForm.tsx
+++ b/src/components/account/login/CredentialProviderForm.tsx
@@ -20,8 +20,8 @@ export default function CredentialProviderForm<Schema extends z.ZodSchema = type
 }: {
   currentMode: 'signUp' | 'login'
   schema: Schema
-  formProps?: UseRHFFormProps<Schema>
-  formAction: RHFServerAction<Schema>
+  formProps?: UseRHFFormProps<z.infer<Schema>>
+  formAction: RHFServerAction<z.infer<Schema>>
   refererCallbackUrl?: string
   renderFields: (args: { form: ReturnType<typeof useRHF<Schema>>['form'] }) => React.ReactNode
 }) {

--- a/src/components/account/login/CredentialProviderForm.tsx
+++ b/src/components/account/login/CredentialProviderForm.tsx
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { Button } from '@/src/components/shadcn/button'
 import { Form } from '@/src/components/shadcn/form'
 import FormFieldError from '@/src/components/Shared/form/FormFieldError'
-import { RHFServerAction, UseRHFFormProps } from '@/src/hooks/Shared/form/react-hook-form/type'
+import { RHFBaseReturn, RHFServerAction, UseRHFFormProps } from '@/src/hooks/Shared/form/react-hook-form/type'
 import useRHF from '@/src/hooks/Shared/form/useRHF'
 import { cn } from '@/src/lib/Shared/utils'
 import { LoginSchema } from '@/src/schemas/AuthenticationSchema'
@@ -23,7 +23,7 @@ export default function CredentialProviderForm<Schema extends z.ZodSchema = type
   formProps?: UseRHFFormProps<z.infer<Schema>>
   formAction: RHFServerAction<z.infer<Schema>>
   refererCallbackUrl?: string
-  renderFields: (args: { form: ReturnType<typeof useRHF<Schema>>['form'] }) => React.ReactNode
+  renderFields: (args: { form: RHFBaseReturn<z.infer<Schema>>['form'] }) => React.ReactNode
 }) {
   const { form, runServerValidation, isServerValidationPending } = useRHF<Schema>(
     schema,

--- a/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
+++ b/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
@@ -3,51 +3,57 @@ import { MessageCircleQuestionIcon } from 'lucide-react'
 import { useFormContext } from 'react-hook-form'
 import DisplayFeedbackText from '@/src/components/checks/[share_token]/practice/FeedbackText'
 import { usePracticeFeeback } from '@/src/hooks/checks/[share_token]/practice/usePracticeFeedback'
+import { useRHFContext } from '@/src/hooks/Shared/form/react-hook-form/RHFProvider'
 import { cn } from '@/src/lib/Shared/utils'
 import type { OpenQuestion } from '@/src/schemas/QuestionSchema'
 import { QuestionInput } from '@/src/schemas/UserQuestionInputSchema'
 
 export function FeedbackOpenQuestion({
-  getFeedbackEvaluation,
   question,
-  isEvaluated,
   ...props
 }: {
-  isEvaluated: boolean
-  getFeedbackEvaluation: ReturnType<typeof usePracticeFeeback>
   question: OpenQuestion
 } & Pick<HTMLProps<HTMLTextAreaElement>, 'disabled'>) {
+  const { isValidationComplete, state } = useRHFContext<QuestionInput>(true)
+
+  const getFeedbackEvaluation = usePracticeFeeback(state, {
+    isSubmitSuccessful: isValidationComplete,
+    isSubmitted: isValidationComplete,
+    isPending: false,
+    isSubmitting: false,
+  })
+
   const { isCorrect, isIncorrect, reasoning } = getFeedbackEvaluation(question)
   const [isPinned, setPinned] = useState(false)
 
   useEffect(() => {
-    if (!isEvaluated || isCorrect) return
+    if (!isValidationComplete || isCorrect) return
 
     // toggle feedback-text display when answer is incorrect
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setPinned(true)
-  }, [isEvaluated])
+  }, [isValidationComplete])
 
   return (
     <OpenQuestionAnswer
       {...props}
-      disabled={isEvaluated || props.disabled}
-      data-evaluation-result={isEvaluated ? (isCorrect ? 'correct' : isIncorrect ? 'incorrect' : 'none') : 'none'}
+      disabled={isValidationComplete || props.disabled}
+      data-evaluation-result={isValidationComplete ? (isCorrect ? 'correct' : isIncorrect ? 'incorrect' : 'none') : 'none'}
       className={cn(
-        isEvaluated && 'relative ring-2',
+        isValidationComplete && 'relative ring-2',
         isCorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-green-500/20 ring-green-400/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/15 dark:ring-green-500/70',
         isIncorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-red-500/20 ring-red-500/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/15 dark:ring-red-400/70',
-        isEvaluated && 'pr-8',
+        isValidationComplete && 'pr-8',
       )}>
       <div className={cn('group/tooltip absolute top-1 right-1.5 z-10 flex cursor-pointer flex-row-reverse gap-1.5')} onClick={() => setPinned((prev) => !prev)}>
-        <DisplayFeedbackText disabled={!isEvaluated} pinned={isPinned} feedback={reasoning} side='right'>
+        <DisplayFeedbackText disabled={!isValidationComplete} pinned={isPinned} feedback={reasoning} side='right'>
           <MessageCircleQuestionIcon
-            className={cn('size-4.5 text-warning', !isPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isEvaluated && 'hidden', !reasoning && 'hidden')}
+            className={cn('size-4.5 text-warning', !isPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isValidationComplete && 'hidden', !reasoning && 'hidden')}
           />
         </DisplayFeedbackText>
       </div>
       {/* overlay to detect click-events in text-area while disabled */}
-      {isEvaluated && <div className='absolute inset-0 cursor-pointer' onClick={() => setPinned((prev) => !prev)}></div>}
+      {isValidationComplete && <div className='absolute inset-0 cursor-pointer' onClick={() => setPinned((prev) => !prev)}></div>}
     </OpenQuestionAnswer>
   )
 }

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -120,14 +120,14 @@ export function RenderPracticeQuestion() {
 
         <FeedbackLegend
           disabled={(!isValidationComplete && !(question.type === 'single-choice' || question.type === 'multiple-choice')) || question.id !== state.values?.question_id}
-          show={isSubmitSuccessful && isSubmitted && !(isSubmitting || isPending) && (question.type === 'single-choice' || question.type === 'multiple-choice')}
+          show={isValidationComplete && (question.type === 'single-choice' || question.type === 'multiple-choice')}
         />
 
         <div className='flex justify-center'>
           <Button
             title={!isValid ? 'Before checking this question you must first answer it' : undefined}
             disabled={!isValid}
-            hidden={isSubmitted && isSubmitSuccessful && !isPending}
+            hidden={isValidationComplete}
             className='mx-auto mt-2 bg-neutral-300/80 enabled:ring-1 enabled:ring-ring-subtle enabled:hover:bg-neutral-300 enabled:hover:ring-ring dark:bg-neutral-700 dark:enabled:ring-transparent dark:enabled:hover:bg-neutral-600 dark:enabled:hover:ring-ring'
             variant='secondary'
             type='submit'>
@@ -135,7 +135,7 @@ export function RenderPracticeQuestion() {
             Check Answer
           </Button>
 
-          <Button hidden={!isSubmitted || !isSubmitSuccessful || isPending} className='mx-auto mt-2' variant='success' onClick={nextRandomQuestion} type='button'>
+          <Button hidden={!isValidationComplete} className='mx-auto mt-2' variant='success' onClick={nextRandomQuestion} type='button'>
             Continue
           </Button>
         </div>

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -93,9 +93,11 @@ export function RenderPracticeQuestion() {
         </div>
 
         <div id='answer-options' className={cn('grid min-h-[35vh] min-w-[25vw] grid-cols-2 gap-8 rounded-md p-6 ring-1 ring-ring dark:ring-ring', question?.type === 'open-question' && 'grid-cols-1')}>
-          {question.type === 'multiple-choice' && <ChoiceAnswerOptions type='checkbox' question={question} getFeedbackEvaluation={getFeedbackEvaluation} />}
-
-          {question.type === 'single-choice' && <ChoiceAnswerOptions type='radio' question={question} getFeedbackEvaluation={getFeedbackEvaluation} />}
+          {
+            //prettier-ignore
+            (question.type === 'single-choice' || question.type === 'multiple-choice') && 
+              <ChoiceAnswerOptions type={question.type === 'single-choice' ? 'radio' : 'checkbox'} question={question} />
+          }
 
           {question.type === 'drag-drop' && <DragDropAnswers question={question} />}
 
@@ -195,23 +197,23 @@ function FeedbackIndicators({ correctlySelected, missingSelection, falslySelecte
 /**
  * This component renders the answer-options for ChoiceQuestions as they are almost identical, to reduce code duplication
  */
-function ChoiceAnswerOptions<Q extends ChoiceQuestion>({
-  question,
-  getFeedbackEvaluation,
-  type,
-}: {
-  type: Required<HTMLProps<HTMLInputElement>['type']>
-  question: Q
-  getFeedbackEvaluation: ReturnType<typeof usePracticeFeeback>
-}) {
+function ChoiceAnswerOptions<Q extends ChoiceQuestion>({ question, type }: { type: Required<HTMLProps<HTMLInputElement>['type']>; question: Q }) {
   const {
     isValidationComplete,
+    state,
     form: {
       register,
       formState: { errors },
     },
   } = useRHFContext<QuestionInput>(true)
   const registerKey: (index: number) => Parameters<UseFormRegister<QuestionInput>>['0'] = question.type === 'multiple-choice' ? (i) => `selection.${i}` : () => `selection`
+
+  const getFeedbackEvaluation = usePracticeFeeback(state, {
+    isSubmitSuccessful: isValidationComplete,
+    isSubmitted: isValidationComplete,
+    isPending: false,
+    isSubmitting: false,
+  })
 
   const { isCorrectlySelected, isFalslySelected, isMissingSelection, reasoning } = getFeedbackEvaluation(question)
   const [openFeedbacks, setOpenFeedbacks] = useState<ChoiceQuestion['answers'][number]['id'][]>([])

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react'
 import React, { HTMLProps } from 'react'
 import { motion, Variants } from 'framer-motion'
-import isEmpty from 'lodash/isEmpty'
 import { MessageCircleQuestionIcon } from 'lucide-react'
 import { CheckIcon, XIcon } from 'lucide-react'
 import { notFound, redirect, usePathname } from 'next/navigation'
@@ -48,20 +47,22 @@ export function RenderPracticeQuestion() {
     { serverAction: EvaluateAnswer, initialActionState: { success: false } },
   )
 
-  const { form, isValidationComplete, isServerValidationPending: isPending, state, runServerValidation } = RHFForm
-
   const {
-    watch,
-    formState: { isSubmitting, isValid, isSubmitted, isSubmitSuccessful, errors },
-  } = form
+    form: {
+      formState: { isValid, isSubmitting },
+      ...form
+    },
+    isValidationComplete,
+    isServerValidationPending: isPending,
+    state,
+    runServerValidation,
+  } = RHFForm
 
   const nextRandomQuestion = () =>
     questions.length > 1
       ? navigateToQuestion((currentQuestionIndex + 1) % questions.length)
       : // allow the same (only) question to be answered again and again.
         form.reset({ question_id: question.id, type: question.type as Any })
-
-  const getFeedbackEvaluation = usePracticeFeeback(state, { isSubmitSuccessful, isPending, isSubmitted, isSubmitting })
 
   const onSubmit = (_data: QuestionInput) => {
     logger.verbose('Submitting practice answer...', _data)
@@ -70,16 +71,6 @@ export function RenderPracticeQuestion() {
     storeAnswer({ ...form.getValues(), question_id: question.id })
     console.info(`[Submit] '${question.question}' has been answered & submitted`)
   }
-
-  useEffect(() => {
-    const sub = watch((values, { name }) => {
-      console.debug(`[${name ?? 'Form-State (validation)'}] changed`, values)
-    })
-
-    return () => sub.unsubscribe()
-  })
-
-  if (!isEmpty(errors)) console.log('error', errors)
 
   return (
     <RHFProvider {...RHFForm}>

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -101,9 +101,7 @@ export function RenderPracticeQuestion() {
 
           {question.type === 'drag-drop' && <DragDropAnswers question={question} />}
 
-          {question.type === 'open-question' && (
-            <FeedbackOpenQuestion isEvaluated={isValidationComplete} getFeedbackEvaluation={getFeedbackEvaluation} question={question} disabled={isSubmitted && isSubmitSuccessful && !isPending} />
-          )}
+          {question.type === 'open-question' && <FeedbackOpenQuestion question={question} disabled={isSubmitted && isSubmitSuccessful && !isPending} />}
         </div>
 
         <FeedbackLegend

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -101,7 +101,7 @@ export function RenderPracticeQuestion() {
 
           {question.type === 'drag-drop' && <DragDropAnswers question={question} />}
 
-          {question.type === 'open-question' && <FeedbackOpenQuestion question={question} disabled={isSubmitted && isSubmitSuccessful && !isPending} />}
+          {question.type === 'open-question' && <FeedbackOpenQuestion question={question} />}
         </div>
 
         <FeedbackLegend

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -41,7 +41,9 @@ export function RenderPracticeQuestion() {
   const RHFForm = useRHF(
     QuestionInputSchema,
     {
-      defaultValues: () => ({ question_id: question.id, type: question.type }),
+      // Warning: Type assertion is intentional.
+      // By setting the question_id and type, the form-values are (re-) set when the question changes, setting `values` makes the form controlled.
+      values: { question_id: question.id, type: question.type } as QuestionInput,
     },
     { serverAction: EvaluateAnswer, initialActionState: { success: false } },
   )
@@ -57,19 +59,9 @@ export function RenderPracticeQuestion() {
     questions.length > 1
       ? navigateToQuestion((currentQuestionIndex + 1) % questions.length)
       : // allow the same (only) question to be answered again and again.
-        form.reset()
+        form.reset({ question_id: question.id, type: question.type as Any })
 
   const getFeedbackEvaluation = usePracticeFeeback(state, { isSubmitSuccessful, isPending, isSubmitted, isSubmitting })
-
-  //* Handle reseting form inputs when question changes
-  useEffect(() => {
-    if (watch('type') === question.type && watch('question_id') === question.id) return
-    else {
-      //* When the question is changed reset the form (and set the new question id and type)
-      form.reset({ question_id: question.id, type: question.type as Any })
-      return
-    }
-  }, [question.id, question.type])
 
   const onSubmit = (_data: QuestionInput) => {
     logger.verbose('Submitting practice answer...', _data)

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -97,7 +97,7 @@ export function RenderPracticeQuestion() {
 
           {question.type === 'single-choice' && <ChoiceAnswerOptions type='radio' question={question} getFeedbackEvaluation={getFeedbackEvaluation} />}
 
-          {question.type === 'drag-drop' && <DragDropAnswers question={question} isEvaluated={isValidationComplete} state={state} />}
+          {question.type === 'drag-drop' && <DragDropAnswers question={question} />}
 
           {question.type === 'open-question' && (
             <FeedbackOpenQuestion isEvaluated={isValidationComplete} getFeedbackEvaluation={getFeedbackEvaluation} question={question} disabled={isSubmitted && isSubmitSuccessful && !isPending} />

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -59,15 +59,6 @@ export function RenderPracticeQuestion() {
       : // allow the same (only) question to be answered again and again.
         form.reset()
 
-  useEffect(() => {
-    if (!isSubmitSuccessful) return
-    if (isPending) return
-    if (isSubmitting) return
-
-    console.info(question.question, ' has been answered & submitted')
-    storeAnswer({ ...form.getValues(), question_id: question.id })
-  }, [isSubmitSuccessful, isPending, isSubmitting])
-
   const getFeedbackEvaluation = usePracticeFeeback(state, { isSubmitSuccessful, isPending, isSubmitted, isSubmitting })
 
   //* Handle reseting form inputs when question changes
@@ -83,6 +74,9 @@ export function RenderPracticeQuestion() {
   const onSubmit = (_data: QuestionInput) => {
     logger.verbose('Submitting practice answer...', _data)
     runServerValidation(_data)
+
+    storeAnswer({ ...form.getValues(), question_id: question.id })
+    console.info(`[Submit] '${question.question}' has been answered & submitted`)
   }
 
   useEffect(() => {

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import React, { HTMLProps } from 'react'
 import { motion, Variants } from 'framer-motion'
 import isEmpty from 'lodash/isEmpty'
-import { LoaderCircleIcon, MessageCircleQuestionIcon } from 'lucide-react'
+import { MessageCircleQuestionIcon } from 'lucide-react'
 import { CheckIcon, XIcon } from 'lucide-react'
 import { notFound, redirect, usePathname } from 'next/navigation'
 import { UseFormRegister } from 'react-hook-form'
@@ -130,8 +130,8 @@ export function RenderPracticeQuestion() {
             hidden={isValidationComplete}
             className='mx-auto mt-2 bg-neutral-300/80 enabled:ring-1 enabled:ring-ring-subtle enabled:hover:bg-neutral-300 enabled:hover:ring-ring dark:bg-neutral-700 dark:enabled:ring-transparent dark:enabled:hover:bg-neutral-600 dark:enabled:hover:ring-ring'
             variant='secondary'
+            isLoading={isSubmitting || isPending}
             type='submit'>
-            <LoaderCircleIcon className={cn('animate-spin', 'hidden', (isSubmitting || isPending) && 'block')} />
             Check Answer
           </Button>
 

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -210,7 +210,7 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({
       register,
       formState: { errors },
     },
-  } = useRHFContext<QuestionInput>()
+  } = useRHFContext<QuestionInput>(true)
   const registerKey: (index: number) => Parameters<UseFormRegister<QuestionInput>>['0'] = question.type === 'multiple-choice' ? (i) => `selection.${i}` : () => `selection`
 
   const { isCorrectlySelected, isFalslySelected, isMissingSelection, reasoning } = getFeedbackEvaluation(question)

--- a/src/components/checks/create/(sections)/(settings)/ExaminationSettings.tsx
+++ b/src/components/checks/create/(sections)/(settings)/ExaminationSettings.tsx
@@ -1,12 +1,12 @@
 import { format } from 'date-fns'
 import { useFormContext, useWatch } from 'react-hook-form'
 import Field from '@/src/components/Shared/form/Field'
-import useRHF from '@/src/hooks/Shared/form/useRHF'
+import { RHFBaseReturn } from '@/src/hooks/Shared/form/react-hook-form/type'
 import { useScopedI18n } from '@/src/i18n/client-localization'
 import { cn } from '@/src/lib/Shared/utils'
-import { KnowledgeCheckSettings, KnowledgeCheckSettingsSchema } from '@/src/schemas/KnowledgeCheckSettingsSchema'
+import { KnowledgeCheckSettings } from '@/src/schemas/KnowledgeCheckSettingsSchema'
 
-export function ExaminationSettings({ baseFieldProps }: {} & Pick<ReturnType<typeof useRHF<typeof KnowledgeCheckSettingsSchema>>, 'baseFieldProps'>) {
+export function ExaminationSettings({ baseFieldProps }: {} & Pick<RHFBaseReturn<KnowledgeCheckSettings>, 'baseFieldProps'>) {
   const t = useScopedI18n('Checks.Create.SettingSection.ExaminationSettings')
   const {
     control,

--- a/src/components/checks/create/(sections)/(settings)/PracticeSettings.tsx
+++ b/src/components/checks/create/(sections)/(settings)/PracticeSettings.tsx
@@ -1,11 +1,11 @@
 import { useFormContext, useWatch } from 'react-hook-form'
 import Field from '@/src/components/Shared/form/Field'
-import useRHF from '@/src/hooks/Shared/form/useRHF'
+import { RHFBaseReturn } from '@/src/hooks/Shared/form/react-hook-form/type'
 import { useScopedI18n } from '@/src/i18n/client-localization'
 import { cn } from '@/src/lib/Shared/utils'
-import { KnowledgeCheckSettings, KnowledgeCheckSettingsSchema } from '@/src/schemas/KnowledgeCheckSettingsSchema'
+import { KnowledgeCheckSettings } from '@/src/schemas/KnowledgeCheckSettingsSchema'
 
-export default function PracticeSettings({ baseFieldProps }: {} & Pick<ReturnType<typeof useRHF<typeof KnowledgeCheckSettingsSchema>>, 'baseFieldProps'>) {
+export default function PracticeSettings({ baseFieldProps }: {} & Pick<RHFBaseReturn<KnowledgeCheckSettings>, 'baseFieldProps'>) {
   const t = useScopedI18n('Checks.Create.SettingSection.PracticeSettings')
   const { control } = useFormContext<KnowledgeCheckSettings>()
   const { practice } = useWatch({ control: control })

--- a/src/components/checks/create/(sections)/(settings)/ShareSettings.tsx
+++ b/src/components/checks/create/(sections)/(settings)/ShareSettings.tsx
@@ -1,11 +1,11 @@
 import { useFormContext, useWatch } from 'react-hook-form'
 import Field from '@/src/components/Shared/form/Field'
-import useRHF from '@/src/hooks/Shared/form/useRHF'
+import { RHFBaseReturn } from '@/src/hooks/Shared/form/react-hook-form/type'
 import { useScopedI18n } from '@/src/i18n/client-localization'
 import { cn } from '@/src/lib/Shared/utils'
-import { KnowledgeCheckSettings, KnowledgeCheckSettingsSchema } from '@/src/schemas/KnowledgeCheckSettingsSchema'
+import { KnowledgeCheckSettings } from '@/src/schemas/KnowledgeCheckSettingsSchema'
 
-export default function ShareSettings({ baseFieldProps }: {} & Pick<ReturnType<typeof useRHF<typeof KnowledgeCheckSettingsSchema>>, 'baseFieldProps'>) {
+export default function ShareSettings({ baseFieldProps }: {} & Pick<RHFBaseReturn<KnowledgeCheckSettings>, 'baseFieldProps'>) {
   const t = useScopedI18n('Checks.Create.SettingSection.ShareSettings')
   const { control } = useFormContext<KnowledgeCheckSettings>()
   const { shareAccessibility } = useWatch({ control: control })

--- a/src/hooks/Shared/form/react-hook-form/RHFProvider.tsx
+++ b/src/hooks/Shared/form/react-hook-form/RHFProvider.tsx
@@ -7,12 +7,17 @@ type RHFContext<T extends object> = RHFBaseReturn<T> & Partial<RHFServerReturn<T
 
 const RHFContext = createContext<RHFContext<Any> | null>(null)
 
-export const useRHFContext = <T extends object>() => {
+export function useRHFContext<T extends object>(serverValidation: false): RHFBaseReturn<T>
+export function useRHFContext<T extends object>(serverValidation: true): RHFBaseReturn<T> & RHFServerReturn<T>
+export function useRHFContext<T extends object>(serverValidation: boolean) {
   const context = useContext(RHFContext)
   if (!context) {
     throw new Error('useRHFContext must be used within a RHFProvider')
   }
-  return context as RHFContext<T>
+
+  if (!serverValidation) return context as RHFBaseReturn<T>
+
+  return context as RHFServerReturn<T>
 }
 
 export const RHFProvider = <T extends object>({ children, ...props }: { children: ReactNode } & RHFContext<T>) => {

--- a/src/hooks/Shared/form/react-hook-form/RHFProvider.tsx
+++ b/src/hooks/Shared/form/react-hook-form/RHFProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, ReactNode, useContext } from 'react'
+import { Form } from '@/src/components/shadcn/form'
 import { RHFBaseReturn, RHFServerReturn } from '@/src/hooks/Shared/form/react-hook-form/type'
 import { Any } from '@/types'
 
@@ -15,5 +16,9 @@ export const useRHFContext = <T extends object>() => {
 }
 
 export const RHFProvider = <T extends object>({ children, ...props }: { children: ReactNode } & RHFContext<T>) => {
-  return <RHFContext.Provider value={props}>{children}</RHFContext.Provider>
+  return (
+    <RHFContext.Provider value={props}>
+      <Form {...props.form}>{children}</Form>
+    </RHFContext.Provider>
+  )
 }

--- a/src/hooks/Shared/form/react-hook-form/RHFProvider.tsx
+++ b/src/hooks/Shared/form/react-hook-form/RHFProvider.tsx
@@ -1,0 +1,19 @@
+import { createContext, ReactNode, useContext } from 'react'
+import { RHFBaseReturn, RHFServerReturn } from '@/src/hooks/Shared/form/react-hook-form/type'
+import { Any } from '@/types'
+
+type RHFContext<T extends object> = RHFBaseReturn<T> & Partial<RHFServerReturn<T>>
+
+const RHFContext = createContext<RHFContext<Any> | null>(null)
+
+export const useRHFContext = <T extends object>() => {
+  const context = useContext(RHFContext)
+  if (!context) {
+    throw new Error('useRHFContext must be used within a RHFProvider')
+  }
+  return context as RHFContext<T>
+}
+
+export const RHFProvider = <T extends object>({ children, ...props }: { children: ReactNode } & RHFContext<T>) => {
+  return <RHFContext.Provider value={props}>{children}</RHFContext.Provider>
+}

--- a/src/hooks/Shared/form/react-hook-form/RHFProvider.tsx
+++ b/src/hooks/Shared/form/react-hook-form/RHFProvider.tsx
@@ -17,6 +17,9 @@ export function useRHFContext<T extends object>(serverValidation: boolean) {
 
   if (!serverValidation) return context as RHFBaseReturn<T>
 
+  if ((context as Partial<RHFServerReturn<T>>).runServerValidation === undefined)
+    throw new Error(`useRHFContext with 'serverValidation' enabled can only be used when the respective 'useRHF' declaration uses a server-action.`)
+
   return context as RHFServerReturn<T>
 }
 

--- a/src/hooks/Shared/form/react-hook-form/type.ts
+++ b/src/hooks/Shared/form/react-hook-form/type.ts
@@ -29,6 +29,10 @@ export type UseRHFFormProps<TSchema extends z.ZodSchema> = Omit<UseFormProps<z.i
 export type RHFBaseReturn<TSchema extends z.ZodSchema> = {
   form: UseFormReturn<z.infer<TSchema>>
   descriptions: ReturnType<typeof extractDescriptionMap>
+  /**
+   * This property is set to true when both the client- and server- validation is complete. Previously this state was manually declared and usually named as `isEvaluated`.
+   */
+  isValidationComplete: boolean
   baseFieldProps: {
     form: UseFormReturn<z.infer<TSchema>>
     descriptions: ReturnType<typeof extractDescriptionMap>

--- a/src/hooks/Shared/form/react-hook-form/type.ts
+++ b/src/hooks/Shared/form/react-hook-form/type.ts
@@ -1,48 +1,47 @@
 import { DefaultValues, UseFormProps, UseFormReturn } from 'react-hook-form'
-import { z } from 'zod'
 import { extractDescriptionMap } from '@/src/schemas/utils/extractDescriptions'
 
-export type RHFServerState<TSchema extends z.ZodSchema> = {
+export type RHFServerState<Type extends object> = {
   success: boolean
-  fieldErrors?: Partial<Record<keyof z.infer<TSchema>, string[]>>
+  fieldErrors?: Partial<Record<keyof Type, string[]>>
   rootError?: string
-  values?: z.infer<TSchema>
+  values?: Type
 }
 
-export type RHFServerAction<TSchema extends z.ZodSchema> = (prev: RHFServerState<TSchema>, data: z.infer<TSchema>) => Promise<RHFServerState<TSchema>>
+export type RHFServerAction<Type extends object> = (prev: RHFServerState<Type>, data: Type) => Promise<RHFServerState<Type>>
 
-export type UseRHFOptions<TSchema extends z.ZodSchema> = {
-  initialActionState: RHFServerState<TSchema>
-  serverAction: RHFServerAction<TSchema>
+export type UseRHFOptions<Type extends object> = {
+  initialActionState: RHFServerState<Type>
+  serverAction: RHFServerAction<Type>
 }
 
-export type UseRHFFormProps<TSchema extends z.ZodSchema> = Omit<UseFormProps<z.infer<TSchema>>, 'resolver' | 'defaultValues'> & {
+export type UseRHFFormProps<Type extends object> = Omit<UseFormProps<Type>, 'resolver' | 'defaultValues'> & {
   /**
    * Dynamically build the form default values
    * @param stateValues The values returned by the server-validation action, e.g. to preserver user-inputs after submission
    * @param instantiatedValues Property instantiations of the schema without default-values, thus string --> '', number --> 0, ...
    * @returns The form default values
    */
-  defaultValues?: (stateValues: RHFServerState<TSchema>['values'], instantiatedValues: z.infer<TSchema>) => DefaultValues<z.infer<TSchema>>
+  defaultValues?: (stateValues: RHFServerState<Type>['values'], instantiatedValues: Type) => DefaultValues<Type>
 }
 
-export type RHFBaseReturn<TSchema extends z.ZodSchema> = {
-  form: UseFormReturn<z.infer<TSchema>>
+export type RHFBaseReturn<Type extends object> = {
+  form: UseFormReturn<Type>
   descriptions: ReturnType<typeof extractDescriptionMap>
   /**
    * This property is set to true when both the client- and server- validation is complete. Previously this state was manually declared and usually named as `isEvaluated`.
    */
   isValidationComplete: boolean
   baseFieldProps: {
-    form: UseFormReturn<z.infer<TSchema>>
+    form: UseFormReturn<Type>
     descriptions: ReturnType<typeof extractDescriptionMap>
   }
 }
 
-export type RHFServerReturn<TSchema extends z.ZodSchema> = {
-  runServerValidation: (values: z.infer<TSchema>) => void
-  state: RHFServerState<TSchema>
+export type RHFServerReturn<Type extends object> = {
+  runServerValidation: (values: Type) => void
+  state: RHFServerState<Type>
   isServerValidationPending: boolean
 }
 
-export type RHFWithServerReturn<TSchema extends z.ZodSchema> = RHFBaseReturn<TSchema> & RHFServerReturn<TSchema>
+export type RHFWithServerReturn<Type extends object> = RHFBaseReturn<Type> & RHFServerReturn<Type>

--- a/src/hooks/Shared/form/react-hook-form/utilts.ts
+++ b/src/hooks/Shared/form/react-hook-form/utilts.ts
@@ -1,18 +1,17 @@
 import { useEffect } from 'react'
 import { UseFormReturn } from 'react-hook-form'
-import { z } from 'zod'
 import { RHFBaseReturn, RHFServerAction, RHFServerState, UseRHFOptions } from '@/src/hooks/Shared/form/react-hook-form/type'
 import { extractDescriptionMap } from '@/src/schemas/utils/extractDescriptions'
 
-export function isServerAction<TSchema extends z.ZodSchema>(action: UseRHFOptions<TSchema>['serverAction'] | undefined): action is RHFServerAction<TSchema> {
+export function isServerAction<Type extends object>(action: UseRHFOptions<Type>['serverAction'] | undefined): action is RHFServerAction<Type> {
   return typeof action === 'function'
 }
 
-export function createNoopServerAction<TSchema extends z.ZodSchema>(): RHFServerAction<TSchema> {
+export function createNoopServerAction<Type extends object>(): RHFServerAction<Type> {
   return async (prev) => prev
 }
 
-export function buildBaseReturn<TSchema extends z.ZodSchema>(form: UseFormReturn<z.infer<TSchema>>, descriptions: ReturnType<typeof extractDescriptionMap>): RHFBaseReturn<TSchema> {
+export function buildBaseReturn<Type extends object>(form: UseFormReturn<Type>, descriptions: ReturnType<typeof extractDescriptionMap>): RHFBaseReturn<Type> {
   const { isSubmitting, isSubmitted, isSubmitSuccessful } = form.formState
   return {
     form,
@@ -29,17 +28,17 @@ export function buildBaseReturn<TSchema extends z.ZodSchema>(form: UseFormReturn
  * @param form.setErrror The `setError` function from the react-hook-form instance
  * @param form.reset The `reset` function from the react-hook-form instance
  */
-export function useServerValidationResults<TSchema extends z.ZodSchema>(
+export function useServerValidationResults<Type extends object>(
   hasServerValidation: boolean,
-  state: RHFServerState<TSchema>,
-  { setError, clearErrors }: {} & Pick<UseFormReturn<z.infer<TSchema>>, 'setError' | 'clearErrors'>,
+  state: RHFServerState<Type>,
+  { setError, clearErrors }: {} & Pick<UseFormReturn<Type>, 'setError' | 'clearErrors'>,
 ) {
   useEffect(() => {
     if (!hasServerValidation) return
 
     if (state.fieldErrors) {
       Object.entries(state.fieldErrors).forEach(([_key, msgs]) => {
-        const key = _key as keyof z.infer<TSchema>
+        const key = _key as keyof Type
 
         if (!msgs) return
 

--- a/src/hooks/Shared/form/react-hook-form/utilts.ts
+++ b/src/hooks/Shared/form/react-hook-form/utilts.ts
@@ -13,9 +13,11 @@ export function createNoopServerAction<TSchema extends z.ZodSchema>(): RHFServer
 }
 
 export function buildBaseReturn<TSchema extends z.ZodSchema>(form: UseFormReturn<z.infer<TSchema>>, descriptions: ReturnType<typeof extractDescriptionMap>): RHFBaseReturn<TSchema> {
+  const { isSubmitting, isSubmitted, isSubmitSuccessful } = form.formState
   return {
     form,
     descriptions,
+    isValidationComplete: isSubmitted && isSubmitSuccessful && !isSubmitting,
     baseFieldProps: { form, descriptions },
   }
 }

--- a/src/hooks/Shared/form/useRHF.ts
+++ b/src/hooks/Shared/form/useRHF.ts
@@ -37,18 +37,18 @@ function useServerValidation<TSchema extends z.ZodSchema>(options?: UseRHFOption
 }
 
 // prettier-ignore
-export default function useRHF<TSchema extends z.ZodSchema>( schema: TSchema, formProps?: UseRHFFormProps<TSchema>): RHFBaseReturn<TSchema>
+export default function useRHF<TSchema extends z.ZodSchema >( schema: TSchema, formProps?: UseRHFFormProps<z.infer<TSchema>>): RHFBaseReturn<z.infer<TSchema>>
 
 // prettier-ignore
-export default function useRHF<TSchema extends z.ZodSchema>( schema: TSchema, formProps: UseRHFFormProps<TSchema> | undefined, options: UseRHFOptions<TSchema>): RHFWithServerReturn<TSchema>
+export default function useRHF<TSchema extends z.ZodSchema >( schema: TSchema, formProps: UseRHFFormProps<z.infer<TSchema>> | undefined, options: UseRHFOptions<z.infer<TSchema>>): RHFWithServerReturn<z.infer<TSchema>>
 
 /**
  * Combines react-hook-form initialization with Zod schema validation + schema descriptions.
  * Optionally wires up a Next.js server action (useActionState) for server-side validation.
  */
-export default function useRHF<TSchema extends z.ZodSchema>(schema: TSchema, formProps?: UseRHFFormProps<TSchema>, options?: UseRHFOptions<TSchema>) {
+export default function useRHF<TSchema extends z.ZodSchema>(schema: TSchema, formProps?: UseRHFFormProps<z.infer<TSchema>>, options?: UseRHFOptions<z.infer<TSchema>>) {
   const descriptions = useMemo(() => extractDescriptionMap(schema), [schema])
-  const { hasServerValidation, ...serverReturnProps } = useServerValidation<TSchema>(options)
+  const { hasServerValidation, ...serverReturnProps } = useServerValidation<z.infer<TSchema>>(options)
   const { instantiate } = schemaUtilities(schema)
 
   const form = useForm<z.infer<TSchema>>({
@@ -64,7 +64,7 @@ export default function useRHF<TSchema extends z.ZodSchema>(schema: TSchema, for
 
   if (!hasServerValidation) return base
 
-  const serverReturn: RHFWithServerReturn<TSchema> = {
+  const serverReturn: RHFWithServerReturn<z.infer<TSchema>> = {
     ...base,
     ...serverReturnProps,
     isValidationComplete:

--- a/src/hooks/Shared/form/useRHF.ts
+++ b/src/hooks/Shared/form/useRHF.ts
@@ -64,5 +64,12 @@ export default function useRHF<TSchema extends z.ZodSchema>(schema: TSchema, for
 
   if (!hasServerValidation) return base
 
-  return { ...base, ...serverReturnProps }
+  const serverReturn: RHFWithServerReturn<TSchema> = {
+    ...base,
+    ...serverReturnProps,
+    isValidationComplete:
+      form.formState.isSubmitted && form.formState.isSubmitSuccessful && (!form.formState.isSubmitting || !serverReturnProps.isServerValidationPending) && !serverReturnProps.isServerValidationPending,
+  }
+
+  return serverReturn
 }

--- a/src/hooks/Shared/form/useRHF.ts
+++ b/src/hooks/Shared/form/useRHF.ts
@@ -11,20 +11,20 @@ import { schemaUtilities } from '@/src/schemas/utils/schemaUtilities'
  * Internal hook that encapsulates all server-action/useActionState wiring.
  * Keeps `useRHF` body focused on "schema + RHF init + return shape".
  */
-function useServerValidation<TSchema extends z.ZodSchema>(options?: UseRHFOptions<TSchema>): RHFServerReturn<TSchema> & { hasServerValidation: boolean } {
+function useServerValidation<Type extends object>(options?: UseRHFOptions<Type>): RHFServerReturn<Type> & { hasServerValidation: boolean } {
   const serverAction = options?.serverAction
-  const initialActionState = options?.initialActionState ?? ({} as RHFServerState<TSchema>)
+  const initialActionState = options?.initialActionState ?? ({} as RHFServerState<Type>)
   const hasServerValidation = isServerAction(serverAction)
 
   // Hooks must not be conditional; always provide an action function.
-  const actionForUseActionState = (serverAction ?? createNoopServerAction<TSchema>()) as RHFServerAction<TSchema>
+  const actionForUseActionState = (serverAction ?? createNoopServerAction<Type>()) as RHFServerAction<Type>
 
-  const [serverState, dispatchServerAction] = useActionState<RHFServerState<TSchema>, z.infer<TSchema>>(actionForUseActionState, initialActionState)
+  const [serverState, dispatchServerAction] = useActionState<RHFServerState<Type>, Type>(actionForUseActionState, initialActionState)
 
   const [isServerValidationPending, startTransition] = useTransition()
 
   const runServerValidation = useCallback(
-    (values: z.infer<TSchema>) => {
+    (values: Type) => {
       if (!hasServerValidation) return
       startTransition(() => {
         dispatchServerAction(values)


### PR DESCRIPTION
> [!NOTE]
> This pull request introduces a new `RHFProvider` component and `useRHFContext` utility function, which reduces property drilling to pass form-states to components. It updates the internal type definitions of `useRHF` util functions to simplify their re-usability. Based on these changes the code duplication and property-drilling was reduced by using the `RHFContext`. 

## Summary 

* **New Features**
  * Added `RHFProvider` component and `useRHFContext` utility function.
  * Added `isValidationComplete` property to  `RHFBaseReturn` type and hook.

* **Improvements**
  * Added authentication requirement to practice page to save practice results to a given user.
  * Stripped `z.zodSchema` from `useRHF` internal type declarations to simplify re-usability.
  * Wrapped react-hook-form `FormProvider` within `RHFProvider` to support both `useFormContext` and `useRHFContext`.
  * Simplified `RenderPracticeQuestion` component by de-coupling formState computations using `isValidationComplete`.
  * Improved readability of `RenderPracticeQuestion` by simplifying reset logic and storing of answers.
  * Simplified `useRHF` return type usages used in component signatures to accept `RHF` props.
  * Reduced property drilling by using `useRHFContext` in practice related components.

---
### Detailed Changelog

<details>
<summary>Details</summary>

[](https://google.com)

- **Features**:
  - Created `RHFProvider` and `useRHFContext` ([`bbaf52b4`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/bbaf52b4))
     With the help of this new provider and useContext handler the instantiation of form through `useRHF` can be shared across components without the need of property-drilling. This way the signature of components within such a provider can be simplified.
  

- **Fixes**:
  - Added auth requirement to practice page ([`d705a831`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/d705a831))
     Previously users were able to start practicing without being signed in, which meant that the practice results could not be saved to the respective (non-existent) user.
  

- **Chores**:
  - Stripped zod-schema from `useRHF` internal types ([`fd3027d9`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/fd3027d9))
     This commit essentially replaces the use of `T extends z.ZodSchema` with `T extends object>` to make these internal types easier to re-use. This way one might use these types to define the content of a Context.
  

- **Refactors**:
  - Added `isValidComplete` to `useRHF` ([`4d219f69`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/4d219f69))
     This new state variable is composed of the form-state submission states and the pending state of the server-validation. When set to true the form is done validating on the client- and server.
  
  - Wrapped rhf `FormProvider` within `RHFProvider` ([`ca0e880e`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/ca0e880e))
     By including the react-hook-form `FormProvider` aka. `Form` component, which is used by shadcn form-components the need to declare this wrapper manually is eliminated.
  
  - Applied `RHFProvider` to `RenderPQueston` ([`d244179d`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/d244179d))
     By applying the `RHFProvider` and `RHFContext` to the `RenderPracticeQueston` component the property drilling can be reduced and the form-related logic is unified (e.g. `isEvaluated`).
  
  - Simplified rhf validation state usages ([`6d8c246a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/6d8c246a))
     Previously the `isValidationComplete` aka. `isEvaluated` state was re-computed multiple times. Now it is being re-used to reduce code-duplication and improve readability.
  
  - Simplified check-answer loading indicator ([`1439d5e6`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/1439d5e6))
     
  - Simplified saving of practice results data ([`5e9190ce`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/5e9190ce))
     While the previous implementation worked nicely, it increased the code complexity. By moving the answer-save logic from the `useEffect` directly into the `onSubmit` handler the code is easier to understand.
  
  - Replaced reset logic with controlled form values ([`4d05778c`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/4d05778c))
     By replacing the `defaultValue` useForm property with `values` makes the form controlled. This means that whenever the question changes the values change as well, thereby resetting the form-values to the new values. This way the custom reset-logic through an `useEffect` is no longer needed.
  
  - Simplified `useRHF` return-type usages ([`4f77a362`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/4f77a362))
     Instead manually inferring the `useRHF` return type the `RHFBaseReturn` type is used instead to improve readability and reduce code duplication.
  
  - Explicitly typed `useRHFContext` util function ([`5b60bafc`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/5b60bafc))
     By adding the `serverValidation` argument to the `useRHFContext` property the return-type can be more explicit. When server-validation is enabled it will type the context as a union of `RHFBaseReturn` and `RHFServerReturn`. Otherwise it will type the context as `RHFBaseReturn`.
  
  - Added safe-guard to prevent type mismatches ([`066fd78a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/066fd78a))
     When users try to type a given `RHFContext` as a server-validated context, but server validation is not enabled / used then an error will be thrown. This way users may not accidentally access server-validation related properties (state, runServerValidation) when they are not defined.
  
  - Reduced property drilling by using `RHFContext` ([`a0ee7a46`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/a0ee7a46))
     This way the property drilling of `useRHF` properties in within the `DragDropAnswerOptions` component(s) is reduced by using the `RHFContext` instead.
  
  - Reduced practice choice-question prop-drilling ([`701aefbb`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/701aefbb))
     
  - Reduced prop-drilling using `RHFContext` for open-q ([`30a6ad89`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/30a6ad89))
     This way the property drilling of `useRHF` properties in within the `OpenQuestionAnswer` component(s) is reduced by using the `RHFContext` instead.
  
  - Removed duplicate open-question disabled prop ([`9c7f0546`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/9c7f0546))
     
  - Removed debug logs and unused declaration ([`536b1c45`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/536b1c45))
     


</details>
