### PR TITLE
Feat: Unify practice layout and add coloring to practice navigation

### DIFF
--- a/src/app/[locale]/checks/[share_token]/practice/page.tsx
+++ b/src/app/[locale]/checks/[share_token]/practice/page.tsx
@@ -36,17 +36,15 @@ export default async function PracticePage({ params, searchParams }: { params: P
   // When there are no categories to switch between -> set (practice-) questions to be the base-questions.
   let practiceQuestions = categories.length > 1 ? [] : unfilteredQuestions
 
-  // category already selected
-  if (category) {
-    const categoryName = decodeURIComponent(category)
+  const categoryName = decodeURIComponent(category ?? '')
 
-    if (categoryName === '_none_') {
-      logger.debug('Pre-setting practice questions to be unfiltered.')
-      practiceQuestions = unfilteredQuestions
-    } else {
-      logger.debug(`Pre-setting practice questions to use '${categoryName}' category.`)
-      practiceQuestions = unfilteredQuestions.filter((q) => q.category.toLowerCase().trim() === categoryName.toLowerCase().trim())
-    }
+  // when mixed-category (_none_) is selected or no category is selected at all
+  if (categoryName === '_none_' || categoryName.trim().length === 0) {
+    logger.debug('Pre-setting practice questions to be unfiltered.')
+    practiceQuestions = unfilteredQuestions
+  } else {
+    logger.debug(`Pre-setting practice questions to use '${categoryName}' category.`)
+    practiceQuestions = unfilteredQuestions.filter((q) => q.category.toLowerCase().trim() === categoryName.toLowerCase().trim())
   }
 
   return (

--- a/src/app/[locale]/checks/[share_token]/practice/page.tsx
+++ b/src/app/[locale]/checks/[share_token]/practice/page.tsx
@@ -32,19 +32,20 @@ export default async function PracticePage({ params, searchParams }: { params: P
     { hideSolutions: false, answerOrder: 'create-order', questionOrder: 'create-order' },
   )
   const categories = Array.from(new Set(unfilteredQuestions.map((q) => q.category)))
-
-  // When there are no categories to switch between -> set (practice-) questions to be the base-questions.
-  let practiceQuestions = categories.length > 1 ? [] : unfilteredQuestions
-
   const categoryName = decodeURIComponent(category ?? '')
 
-  // when mixed-category (_none_) is selected or no category is selected at all
-  if (categoryName === '_none_' || categoryName.trim().length === 0) {
-    logger.debug('Pre-setting practice questions to be unfiltered.')
+  let practiceQuestions: typeof unfilteredQuestions
+
+  if (categories.length <= 1 || categoryName === '_none_') {
+    logger.verbose('Pre-setting practice questions to be unfiltered.')
     practiceQuestions = unfilteredQuestions
-  } else {
-    logger.debug(`Pre-setting practice questions to use '${categoryName}' category.`)
+  } else if (categories.length > 1 && !!categoryName) {
+    logger.verbose(`Pre-setting practice questions to use '${categoryName}' category.`)
     practiceQuestions = unfilteredQuestions.filter((q) => q.category.toLowerCase().trim() === categoryName.toLowerCase().trim())
+  } else {
+    logger.verbose('User has not selected a practice-category, redirected to category selection page.')
+    // when users have not selected a category, but should have because there are available categories to choose from, they are redirected
+    redirect('practice/category')
   }
 
   return (

--- a/src/app/[locale]/checks/[share_token]/practice/page.tsx
+++ b/src/app/[locale]/checks/[share_token]/practice/page.tsx
@@ -56,7 +56,9 @@ export default async function PracticePage({ params, searchParams }: { params: P
       <PageHeading title='Practice' />
 
       <div className='grid gap-12 @[60rem]:grid-cols-[1fr_auto] @[60rem]:gap-[7vw]'>
-        <PracticeQuestionNavigation />
+        <div className='flex justify-center *:max-w-8/12 *:flex-1'>
+          <PracticeQuestionNavigation />
+        </div>
         <div className='flex justify-center @[60rem]:order-first'>
           <div className='flex max-w-11/12 flex-1 flex-col 2xl:max-w-4/5'>
             <PracticeProgress />

--- a/src/app/[locale]/checks/[share_token]/practice/page.tsx
+++ b/src/app/[locale]/checks/[share_token]/practice/page.tsx
@@ -29,7 +29,7 @@ export default async function PracticePage({ params, searchParams }: { params: P
 
   const unfilteredQuestions = prepareQuestions(
     check.questions.filter((q) => q.accessibility === 'all' || q.accessibility === 'practice-only'),
-    { hideSolutions: true, answerOrder: 'create-order', questionOrder: 'create-order' },
+    { hideSolutions: false, answerOrder: 'create-order', questionOrder: 'create-order' },
   )
   const categories = Array.from(new Set(unfilteredQuestions.map((q) => q.category)))
 

--- a/src/app/[locale]/checks/[share_token]/practice/page.tsx
+++ b/src/app/[locale]/checks/[share_token]/practice/page.tsx
@@ -55,16 +55,17 @@ export default async function PracticePage({ params, searchParams }: { params: P
 
       <PageHeading title='Practice' />
 
-      <div className='mx-auto w-full max-w-3/4 lg:max-w-1/2'>
+      <div className='grid gap-12 @[60rem]:grid-cols-[1fr_auto] @[60rem]:gap-[7vw]'>
         <PracticeQuestionNavigation />
-
-        <PracticeProgress />
-
-        <RenderPracticeQuestion />
-
-        <div className={cn('flex justify-between', practiceQuestions.length <= 1 && 'hidden')}>
-          <PracticeNavigationPreviousButton />
-          <PracticeNavigationNextButton />
+        <div className='flex justify-center @[60rem]:order-first'>
+          <div className='flex max-w-11/12 flex-1 flex-col 2xl:max-w-4/5'>
+            <PracticeProgress />
+            <RenderPracticeQuestion />
+            <div className={cn('flex justify-between', practiceQuestions.length <= 1 && 'hidden')}>
+              <PracticeNavigationPreviousButton />
+              <PracticeNavigationNextButton />
+            </div>
+          </div>
         </div>
       </div>
     </PracticeStoreProvider>

--- a/src/app/[locale]/checks/[share_token]/practice/page.tsx
+++ b/src/app/[locale]/checks/[share_token]/practice/page.tsx
@@ -36,16 +36,31 @@ export default async function PracticePage({ params, searchParams }: { params: P
 
   let practiceQuestions: typeof unfilteredQuestions
 
-  if (categories.length <= 1 || categoryName === '_none_') {
-    logger.verbose('Pre-setting practice questions to be unfiltered.')
-    practiceQuestions = unfilteredQuestions
-  } else if (categories.length > 1 && !!categoryName) {
-    logger.verbose(`Pre-setting practice questions to use '${categoryName}' category.`)
-    practiceQuestions = unfilteredQuestions.filter((q) => q.category.toLowerCase().trim() === categoryName.toLowerCase().trim())
-  } else {
-    logger.verbose('User has not selected a practice-category, redirected to category selection page.')
-    // when users have not selected a category, but should have because there are available categories to choose from, they are redirected
-    redirect('practice/category')
+  switch (true) {
+    case categories.length === 1:
+    case categoryName === '_none_': {
+      logger.verbose('Pre-setting practice questions to be unfiltered.')
+      practiceQuestions = unfilteredQuestions
+      break
+    }
+
+    // selected category is not found
+    case categories.every((c) => c.toLowerCase() !== categoryName.toLowerCase()): {
+      logger.verbose('User has not selected a practice-category, redirected to category selection page.')
+      redirect('practice/category')
+    }
+
+    // category is found and matches
+    case categories.some((c) => c.toLowerCase() === categoryName.toLowerCase()): {
+      logger.verbose(`Pre-setting practice questions to use '${categoryName}' category.`)
+      practiceQuestions = unfilteredQuestions.filter((q) => q.category.toLowerCase() === categoryName.toLowerCase())
+      break
+    }
+
+    default: {
+      logger.warn('Fallback: Assigning all practice questions as `practiceQuestions`.')
+      practiceQuestions = unfilteredQuestions
+    }
   }
 
   return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,8 +65,37 @@ html[data-theme='dark'] {
   --tooltip: oklch(40% 0 0);
 
   --destructive: oklch(0.704 0.191 22.216);
+  --destructive-100: oklch(0.9 0.191 22.216);
+  --destructive-200: oklch(0.8 0.191 22.216);
+  --destructive-300: oklch(0.7 0.191 22.216);
+  --destructive-400: oklch(0.6 0.191 22.216);
+  --destructive-500: oklch(0.5 0.191 22.216);
+  --destructive-600: oklch(0.4 0.191 22.216);
+  --destructive-700: oklch(0.3 0.191 22.216);
+  --destructive-800: oklch(0.2 0.191 22.216);
+  --destructive-900: oklch(0.1 0.191 22.216);
+
   --success: oklch(0.654 0.291 140.216);
+  --success-900: oklch(0.154 0.291 140.216);
+  --success-800: oklch(0.254 0.291 140.216);
+  --success-700: oklch(0.354 0.291 140.216);
+  --success-600: oklch(0.454 0.291 140.216);
+  --success-500: oklch(0.554 0.291 140.216);
+  --success-400: oklch(0.654 0.291 140.216);
+  --success-300: oklch(0.754 0.291 140.216);
+  --success-200: oklch(0.854 0.291 140.216);
+  --success-100: oklch(0.954 0.291 140.216);
+
   --warning: oklch(0.704 0.191 95.216);
+  --warning-100: oklch(0.9 0.191 95.216);
+  --warning-200: oklch(0.8 0.191 95.216);
+  --warning-300: oklch(0.7 0.191 95.216);
+  --warning-400: oklch(0.6 0.191 95.216);
+  --warning-500: oklch(0.5 0.191 95.216);
+  --warning-600: oklch(0.4 0.191 95.216);
+  --warning-700: oklch(0.3 0.191 95.216);
+  --warning-800: oklch(0.2 0.191 95.216);
+  --warning-900: oklch(0.1 0.191 95.216);
 
   --card: oklch(28% 0 240);
   --card-foreground: oklch(0.985 0 0);
@@ -126,8 +155,37 @@ html[data-theme='dark'] {
   --tooltip: oklch(90% 0 0);
 
   --destructive: oklch(0.577 0.245 27.325);
+  --destructive-100: oklch(0.9 0.245 27.325);
+  --destructive-200: oklch(0.8 0.245 27.325);
+  --destructive-300: oklch(0.7 0.245 27.325);
+  --destructive-400: oklch(0.6 0.245 27.325);
+  --destructive-500: oklch(0.5 0.245 27.325);
+  --destructive-600: oklch(0.4 0.245 27.325);
+  --destructive-700: oklch(0.3 0.245 27.325);
+  --destructive-800: oklch(0.2 0.245 27.325);
+  --destructive-900: oklch(0.1 0.245 27.325);
+
   --success: oklch(0.587 0.245 140.325);
+  --success-900: oklch(0.187 0.245 140.325);
+  --success-800: oklch(0.287 0.245 140.325);
+  --success-700: oklch(0.387 0.245 140.325);
+  --success-600: oklch(0.487 0.245 140.325);
+  --success-500: oklch(0.587 0.245 140.325);
+  --success-400: oklch(0.687 0.245 140.325);
+  --success-300: oklch(0.787 0.245 140.325);
+  --success-200: oklch(0.887 0.245 140.325);
+  --success-100: oklch(0.987 0.245 140.325);
+
   --warning: oklch(0.8 0.16 83);
+  --warning-100: oklch(0.9 0.16 83);
+  --warning-200: oklch(0.8 0.16 83);
+  --warning-300: oklch(0.7 0.16 83);
+  --warning-400: oklch(0.6 0.16 83);
+  --warning-500: oklch(0.5 0.16 83);
+  --warning-600: oklch(0.4 0.16 83);
+  --warning-700: oklch(0.3 0.16 83);
+  --warning-800: oklch(0.2 0.16 83);
+  --warning-900: oklch(0.1 0.16 83);
 
   --card: oklch(0.205 0 0);
   --radius: 0.625rem;
@@ -206,8 +264,37 @@ html[data-theme='dark'] {
   --color-tooltip: var(--tooltip);
 
   --color-destructive: var(--destructive);
+  --color-destructive-100: var(--destructive-100);
+  --color-destructive-200: var(--destructive-200);
+  --color-destructive-300: var(--destructive-300);
+  --color-destructive-400: var(--destructive-400);
+  --color-destructive-500: var(--destructive-500);
+  --color-destructive-600: var(--destructive-600);
+  --color-destructive-700: var(--destructive-700);
+  --color-destructive-800: var(--destructive-800);
+  --color-destructive-900: var(--destructive-900);
+
   --color-success: var(--success);
+  --color-success-100: var(--success-100);
+  --color-success-200: var(--success-200);
+  --color-success-300: var(--success-300);
+  --color-success-400: var(--success-400);
+  --color-success-500: var(--success-500);
+  --color-success-600: var(--success-600);
+  --color-success-700: var(--success-700);
+  --color-success-800: var(--success-800);
+  --color-success-900: var(--success-900);
+
   --color-warning: var(--warning);
+  --color-warning-100: var(--warning-100);
+  --color-warning-200: var(--warning-200);
+  --color-warning-300: var(--warning-300);
+  --color-warning-400: var(--warning-400);
+  --color-warning-500: var(--warning-500);
+  --color-warning-600: var(--warning-600);
+  --color-warning-700: var(--warning-700);
+  --color-warning-800: var(--warning-800);
+  --color-warning-900: var(--warning-900);
 
   @keyframes accordion-down {
     from {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,12 +17,6 @@
   }
 }
 
-@property --rb-angle {
-  syntax: '<angle>';
-  inherits: true;
-  initial-value: 0turn;
-}
-
 @layer components {
   .grid-container {
     --grid-desired-gap: 56px;
@@ -40,50 +34,6 @@
 
     /* auto-fit collapses unused tracks (prevents “empty columns”) */
     grid-template-columns: repeat(auto-fit, minmax(max(var(--grid-item-min-width), var(--grid-item-max-width)), 1fr));
-  }
-}
-/* Keyframes can be plain CSS */
-@keyframes rotate-border {
-  to {
-    --rb-angle: 1turn;
-  }
-}
-
-/* ✅ Another Tailwind utility: rotate-border-anim */
-@utility rotate-border-anim {
-  animation: rotate-border 2.5s linear infinite;
-}
-
-/* ✅ This becomes a Tailwind utility: rotate-border */
-@utility rotate-border {
-  --rb-border: 1px;
-  --rb-angle: 0turn;
-  --rb-a: var(--color-indigo-500);
-  --rb-b: var(--color-indigo-300);
-  --rb-muted: transparent;
-
-  position: relative;
-
-  /* Don’t hardcode if you prefer Tailwind rounding — inherit from `rounded-*` */
-  border-radius: inherit;
-
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    padding: var(--rb-border);
-    border-radius: inherit;
-
-    background: conic-gradient(from var(--rb-angle), var(--rb-muted) 80%, var(--rb-a) 86%, var(--rb-b) 90%, var(--rb-a) 94%, var(--rb-muted));
-
-    -webkit-mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-
-    pointer-events: none;
-    box-sizing: border-box;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,6 +17,12 @@
   }
 }
 
+@property --rb-angle {
+  syntax: '<angle>';
+  inherits: true;
+  initial-value: 0turn;
+}
+
 @layer components {
   .grid-container {
     --grid-desired-gap: 56px;
@@ -34,6 +40,50 @@
 
     /* auto-fit collapses unused tracks (prevents “empty columns”) */
     grid-template-columns: repeat(auto-fit, minmax(max(var(--grid-item-min-width), var(--grid-item-max-width)), 1fr));
+  }
+}
+/* Keyframes can be plain CSS */
+@keyframes rotate-border {
+  to {
+    --rb-angle: 1turn;
+  }
+}
+
+/* ✅ Another Tailwind utility: rotate-border-anim */
+@utility rotate-border-anim {
+  animation: rotate-border 2.5s linear infinite;
+}
+
+/* ✅ This becomes a Tailwind utility: rotate-border */
+@utility rotate-border {
+  --rb-border: 1px;
+  --rb-angle: 0turn;
+  --rb-a: var(--color-indigo-500);
+  --rb-b: var(--color-indigo-300);
+  --rb-muted: transparent;
+
+  position: relative;
+
+  /* Don’t hardcode if you prefer Tailwind rounding — inherit from `rounded-*` */
+  border-radius: inherit;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    padding: var(--rb-border);
+    border-radius: inherit;
+
+    background: conic-gradient(from var(--rb-angle), var(--rb-muted) 80%, var(--rb-a) 86%, var(--rb-b) 90%, var(--rb-a) 94%, var(--rb-muted));
+
+    -webkit-mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+
+    pointer-events: none;
+    box-sizing: border-box;
   }
 }
 

--- a/src/components/Shared/CountdownTime.tsx
+++ b/src/components/Shared/CountdownTime.tsx
@@ -9,7 +9,7 @@ import { addSeconds, differenceInMilliseconds, formatDuration, isAfter } from 'd
  * @param duration The max-time limit the user can use to finish a respective action
  * @returns The time left until the `duration` is reached.
  */
-export function TimeTicker({ start: rawStartDate, duration, onTimeUp }: { start: Date; duration: number; onTimeUp?: () => void }) {
+export function CountdownTime({ start: rawStartDate, duration, onTimeUp }: { start: Date; duration: number; onTimeUp?: () => void }) {
   const [remainingTime, setRemainingTime] = useState<string | null>(null)
   const [startDate] = useState(new Date(Date.parse(rawStartDate.toString()))) //* ensure date-object even if stringified
   const [endDate] = useState(addSeconds(startDate, duration))

--- a/src/components/Shared/StopwatchTime.tsx
+++ b/src/components/Shared/StopwatchTime.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { differenceInMilliseconds, formatDuration } from 'date-fns'
+
+/**
+ * This component essentially returns / displays the time that a user e.g. spents on a page.
+ * @param start The date at which the user started his action
+ * @param delimiter Defines how the time-segments are separeted. By default: ` and `.
+ * @returns The time that has passed since the `start`
+ */
+export function StopwatchTime({ start: rawStartDate, delimiter = ' and ' }: { start: Date; delimiter?: string }) {
+  const [timeSpent, setTimeSpent] = useState<string | null>(null)
+  const [startDate] = useState(new Date(Date.parse(rawStartDate.toString()))) //* ensure date-object even if stringified
+
+  const computeDifference = useCallback(() => {
+    const difference = differenceInMilliseconds(new Date(Date.now()), startDate)
+    const differenceDate = new Date(difference)
+
+    setTimeSpent(
+      formatDuration({ seconds: differenceDate.getSeconds(), minutes: differenceDate.getMinutes() || undefined, hours: differenceDate.getHours() - 1 || undefined }, { zero: true, delimiter }),
+    )
+  }, [startDate, setTimeSpent, delimiter])
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    computeDifference() //* set time-spent immediately after component is rendered, so that there is no delay (first-interval) until time is rendered.
+
+    const interval = setInterval(() => {
+      computeDifference()
+    }, 1000)
+
+    return () => clearInterval(interval)
+  }, [computeDifference])
+
+  return <>{timeSpent}</>
+}

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 import { cn } from '@/src/lib/Shared/utils'
 import { Question } from '@/src/schemas/QuestionSchema'
 
@@ -19,16 +20,18 @@ export default function QuestionNavigationMenu({
   children?: React.ReactNode
   questionStatus?: (question: Question, index: number) => 'correct' | 'incorrect' | 'partly-correct' | 'unanswered'
 }) {
+  const t = useScopedI18n('Components.QuestionNavigation')
+
   return (
     <div className={cn('flex h-fit min-w-72 flex-col justify-evenly gap-3 rounded-md p-4 ring-[1.5px] ring-ring-subtle dark:ring-neutral-600', className)}>
-      <span className='font-semibold text-neutral-700 dark:text-neutral-300'>Questions</span>
+      <span className='font-semibold text-neutral-700 dark:text-neutral-300'>{t('title')}</span>
       <nav className='grid grid-cols-[repeat(auto-fill,30px)] gap-2' id='question-navigation'>
         {questions.map((_, i) => {
           const status = questionStatus?.(_, i) ?? 'unanswered'
 
           return (
             <button
-              aria-label={status ? `Question ${i + 1} is ${status.replace('-', ' ')}` : undefined}
+              aria-label={t('question_aria_label', { index: i + 1, status: t(`question_status_${status}`) })}
               data-selected={i === currentQuestionIndex || undefined}
               data-status-correct={status === 'correct' || undefined}
               data-status-incorrect={status === 'incorrect' || undefined}

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -42,11 +42,12 @@ export default function QuestionNavigationMenu({
               'data-status-partly-correct:bg-linear-to-bl data-status-partly-correct:from-neutral-100 data-status-partly-correct:to-warning-200/20 data-status-partly-correct:to-60% data-status-partly-correct:ring-warning-400/40 dark:data-status-partly-correct:from-neutral-700 dark:data-status-partly-correct:to-warning/30 dark:data-status-partly-correct:to-50% dark:data-status-partly-correct:ring-warning/40',
 
               'not-data-status-unanswered:hover:bg-current/15 not-data-status-unanswered:hover:ring-2 dark:hover:bg-current/10',
-              i === currentQuestionIndex &&
-                'rotate-border rotate-border-anim [--rb-a:var(--color-neutral-500)] [--rb-b:var(--color-neutral-700)] [--rb-border:3px] dark:[--rb-a:var(--color-neutral-400)] dark:[--rb-b:var(--color-white)]',
+              'data-selected:ring-offset-1 data-selected:ring-offset-current/5 not-data-status-unanswered:data-selected:ring-2 data-status-unanswered:data-selected:ring-[1.7px] dark:data-selected:ring-offset-2 dark:data-selected:ring-offset-current/20',
+              'relative',
             )}
             onClick={() => onQuestionClick(i)}
             key={`question-nav-${i}`}>
+            <span className='absolute inset-0 m-auto hidden size-[65%] animate-ping rounded-md bg-neutral-700 opacity-25 in-data-selected:inline-flex dark:bg-neutral-100' />
             {i + 1}
           </button>
         ))}

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -42,10 +42,12 @@ export default function QuestionNavigationMenu({
               'data-status-partly-correct:bg-linear-to-bl data-status-partly-correct:from-neutral-100 data-status-partly-correct:to-warning-200/20 data-status-partly-correct:to-60% data-status-partly-correct:ring-warning-400/40 dark:data-status-partly-correct:from-neutral-700 dark:data-status-partly-correct:to-warning/30 dark:data-status-partly-correct:to-50% dark:data-status-partly-correct:ring-warning/40',
 
               'not-data-status-unanswered:hover:bg-current/15 not-data-status-unanswered:hover:ring-2 dark:hover:bg-current/10',
-              'not-data-status-unanswered:data-selected:ring-2 data-status-unanswered:data-selected:ring-[1.7px]',
+              'data-selected:ring-offset-1 data-selected:ring-offset-current/5 not-data-status-unanswered:data-selected:ring-2 data-status-unanswered:data-selected:ring-[1.7px] dark:data-selected:ring-offset-2 dark:data-selected:ring-offset-current/20',
+              'relative',
             )}
             onClick={() => onQuestionClick(i)}
             key={`question-nav-${i}`}>
+            <span className='absolute inset-0 m-auto hidden size-[65%] animate-ping rounded-md bg-neutral-700 opacity-25 in-data-selected:inline-flex dark:bg-neutral-100' />
             {i + 1}
           </button>
         ))}

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -24,10 +24,11 @@ export default function QuestionNavigationMenu({
       <span className='font-semibold text-neutral-700 dark:text-neutral-300'>Questions</span>
       <nav className='grid grid-cols-[repeat(auto-fill,30px)] gap-2' id='question-navigation'>
         {questions.map((_, i) => {
-          const status = questionStatus?.(_, i)
+          const status = questionStatus?.(_, i) ?? 'unanswered'
 
           return (
             <button
+              aria-label={status ? `Question ${i + 1} is ${status.replace('-', ' ')}` : undefined}
               data-selected={i === currentQuestionIndex || undefined}
               data-status-correct={status === 'correct' || undefined}
               data-status-incorrect={status === 'incorrect' || undefined}

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -22,7 +22,7 @@ export default function QuestionNavigationMenu({
   return (
     <div className={cn('flex h-fit min-w-72 flex-col justify-evenly gap-3 rounded-md p-4 ring-[1.5px] ring-ring-subtle dark:ring-neutral-600', className)}>
       <span className='font-semibold text-neutral-700 dark:text-neutral-300'>Questions</span>
-      <nav className='grid grid-cols-[repeat(auto-fill,30px)] gap-2' id='exam-question-navigation'>
+      <nav className='grid grid-cols-[repeat(auto-fill,30px)] gap-2' id='question-navigation'>
         {questions.map((_, i) => (
           <button
             data-selected={i === currentQuestionIndex || undefined}

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -23,34 +23,38 @@ export default function QuestionNavigationMenu({
     <div className={cn('flex h-fit min-w-72 flex-col justify-evenly gap-3 rounded-md p-4 ring-[1.5px] ring-ring-subtle dark:ring-neutral-600', className)}>
       <span className='font-semibold text-neutral-700 dark:text-neutral-300'>Questions</span>
       <nav className='grid grid-cols-[repeat(auto-fill,30px)] gap-2' id='question-navigation'>
-        {questions.map((_, i) => (
-          <button
-            data-selected={i === currentQuestionIndex || undefined}
-            data-status-correct={questionStatus?.(_, i) === 'correct' || undefined}
-            data-status-incorrect={questionStatus?.(_, i) === 'incorrect' || undefined}
-            data-status-partly-correct={questionStatus?.(_, i) === 'partly-correct' || undefined}
-            data-status-unanswered={questionStatus?.(_, i) === 'unanswered' || undefined}
-            className={cn(
-              'ring-ring dark:ring-ring',
-              'flex size-7 items-center justify-center rounded-lg p-1 text-sm ring-1 hover:cursor-pointer hover:bg-neutral-300/60 hover:ring-ring-hover data-selected:hover:cursor-default dark:hover:bg-neutral-600/80 dark:hover:ring-ring-hover',
-              'data-selected:data-status-unanswered:bg-neutral-300 data-selected:data-status-unanswered:ring-neutral-600/60 dark:data-selected:data-status-unanswered:bg-neutral-600/60 dark:data-selected:data-status-unanswered:ring-neutral-300/40',
+        {questions.map((_, i) => {
+          const status = questionStatus?.(_, i)
 
-              'data-status-correct:bg-linear-to-bl data-status-correct:from-neutral-100 data-status-correct:to-success-300/20 data-status-correct:to-60% data-status-correct:ring-success-400/40 dark:data-status-correct:from-neutral-700 dark:data-status-correct:to-success/30 dark:data-status-correct:to-50% dark:data-status-correct:ring-success/40',
+          return (
+            <button
+              data-selected={i === currentQuestionIndex || undefined}
+              data-status-correct={status === 'correct' || undefined}
+              data-status-incorrect={status === 'incorrect' || undefined}
+              data-status-partly-correct={status === 'partly-correct' || undefined}
+              data-status-unanswered={status === 'unanswered' || undefined}
+              className={cn(
+                'ring-ring dark:ring-ring',
+                'flex size-7 items-center justify-center rounded-lg p-1 text-sm ring-1 hover:cursor-pointer hover:bg-neutral-300/60 hover:ring-ring-hover data-selected:hover:cursor-default dark:hover:bg-neutral-600/80 dark:hover:ring-ring-hover',
+                'data-selected:data-status-unanswered:bg-neutral-300 data-selected:data-status-unanswered:ring-neutral-600/60 dark:data-selected:data-status-unanswered:bg-neutral-600/60 dark:data-selected:data-status-unanswered:ring-neutral-300/40',
 
-              'data-status-incorrect:bg-linear-to-bl data-status-incorrect:from-neutral-100 data-status-incorrect:to-destructive-300/20 data-status-incorrect:to-60% data-status-incorrect:ring-destructive-400/40 dark:data-status-incorrect:from-neutral-700 dark:data-status-incorrect:to-destructive/30 dark:data-status-incorrect:to-50% dark:data-status-incorrect:ring-destructive/40',
+                'data-status-correct:bg-linear-to-bl data-status-correct:from-neutral-100 data-status-correct:to-success-300/20 data-status-correct:to-60% data-status-correct:ring-success-400/40 dark:data-status-correct:from-neutral-700 dark:data-status-correct:to-success/30 dark:data-status-correct:to-50% dark:data-status-correct:ring-success/40',
 
-              'data-status-partly-correct:bg-linear-to-bl data-status-partly-correct:from-neutral-100 data-status-partly-correct:to-warning-200/20 data-status-partly-correct:to-60% data-status-partly-correct:ring-warning-400/40 dark:data-status-partly-correct:from-neutral-700 dark:data-status-partly-correct:to-warning/30 dark:data-status-partly-correct:to-50% dark:data-status-partly-correct:ring-warning/40',
+                'data-status-incorrect:bg-linear-to-bl data-status-incorrect:from-neutral-100 data-status-incorrect:to-destructive-300/20 data-status-incorrect:to-60% data-status-incorrect:ring-destructive-400/40 dark:data-status-incorrect:from-neutral-700 dark:data-status-incorrect:to-destructive/30 dark:data-status-incorrect:to-50% dark:data-status-incorrect:ring-destructive/40',
 
-              'not-data-status-unanswered:hover:bg-current/15 not-data-status-unanswered:hover:ring-2 dark:hover:bg-current/10',
-              'data-selected:ring-offset-1 data-selected:ring-offset-current/5 not-data-status-unanswered:data-selected:ring-2 data-status-unanswered:data-selected:ring-[1.7px] dark:data-selected:ring-offset-2 dark:data-selected:ring-offset-current/20',
-              'relative',
-            )}
-            onClick={() => onQuestionClick(i)}
-            key={`question-nav-${i}`}>
-            <span className='absolute inset-0 m-auto hidden size-[65%] animate-ping rounded-md bg-neutral-700 opacity-25 in-data-selected:inline-flex dark:bg-neutral-100' />
-            {i + 1}
-          </button>
-        ))}
+                'data-status-partly-correct:bg-linear-to-bl data-status-partly-correct:from-neutral-100 data-status-partly-correct:to-warning-200/20 data-status-partly-correct:to-60% data-status-partly-correct:ring-warning-400/40 dark:data-status-partly-correct:from-neutral-700 dark:data-status-partly-correct:to-warning/30 dark:data-status-partly-correct:to-50% dark:data-status-partly-correct:ring-warning/40',
+
+                'not-data-status-unanswered:hover:bg-current/15 not-data-status-unanswered:hover:ring-2 dark:hover:bg-current/10',
+                'data-selected:ring-offset-1 data-selected:ring-offset-current/5 not-data-status-unanswered:data-selected:ring-2 data-status-unanswered:data-selected:ring-[1.7px] dark:data-selected:ring-offset-2 dark:data-selected:ring-offset-current/20',
+                'relative',
+              )}
+              onClick={() => onQuestionClick(i)}
+              key={`question-nav-${i}`}>
+              <span className='absolute inset-0 m-auto hidden size-[65%] animate-ping rounded-md bg-neutral-700 opacity-25 in-data-selected:inline-flex dark:bg-neutral-100' />
+              {i + 1}
+            </button>
+          )
+        })}
       </nav>
       {children}
     </div>

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import { cn } from '@/src/lib/Shared/utils'
 import { Question } from '@/src/schemas/QuestionSchema'

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -42,12 +42,11 @@ export default function QuestionNavigationMenu({
               'data-status-partly-correct:bg-linear-to-bl data-status-partly-correct:from-neutral-100 data-status-partly-correct:to-warning-200/20 data-status-partly-correct:to-60% data-status-partly-correct:ring-warning-400/40 dark:data-status-partly-correct:from-neutral-700 dark:data-status-partly-correct:to-warning/30 dark:data-status-partly-correct:to-50% dark:data-status-partly-correct:ring-warning/40',
 
               'not-data-status-unanswered:hover:bg-current/15 not-data-status-unanswered:hover:ring-2 dark:hover:bg-current/10',
-              'data-selected:ring-offset-1 data-selected:ring-offset-current/5 not-data-status-unanswered:data-selected:ring-2 data-status-unanswered:data-selected:ring-[1.7px] dark:data-selected:ring-offset-2 dark:data-selected:ring-offset-current/20',
-              'relative',
+              i === currentQuestionIndex &&
+                'rotate-border rotate-border-anim [--rb-a:var(--color-neutral-500)] [--rb-b:var(--color-neutral-700)] [--rb-border:3px] dark:[--rb-a:var(--color-neutral-400)] dark:[--rb-b:var(--color-white)]',
             )}
             onClick={() => onQuestionClick(i)}
             key={`question-nav-${i}`}>
-            <span className='absolute inset-0 m-auto hidden size-[65%] animate-ping rounded-md bg-neutral-700 opacity-25 in-data-selected:inline-flex dark:bg-neutral-100' />
             {i + 1}
           </button>
         ))}

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -23,10 +23,12 @@ export default function QuestionNavigationMenu({
       <nav className='grid grid-cols-[repeat(auto-fill,30px)] gap-2' id='exam-question-navigation'>
         {questions.map((_, i) => (
           <button
+            data-selected={i === currentQuestionIndex || undefined}
             className={cn(
               'ring-ring dark:ring-ring',
-              'flex size-7 items-center justify-center rounded-lg p-1 text-sm ring-1 hover:cursor-pointer hover:bg-neutral-300/60 hover:ring-ring-hover dark:hover:bg-neutral-600/80 dark:hover:ring-ring-hover',
-              i === currentQuestionIndex && 'bg-neutral-300 ring-neutral-600/60 hover:cursor-default dark:bg-neutral-600/60 dark:ring-neutral-300/60',
+              'flex size-7 items-center justify-center rounded-lg p-1 text-sm ring-1 hover:cursor-pointer hover:bg-neutral-300/60 hover:ring-ring-hover data-selected:hover:cursor-default dark:hover:bg-neutral-600/80 dark:hover:ring-ring-hover',
+              'data-selected:bg-neutral-300 data-selected:ring-neutral-600/60 dark:data-selected:bg-neutral-600/60 dark:data-selected:ring-neutral-300/40',
+              'data-selected:ring-[1.7px]',
             )}
             onClick={() => onQuestionClick(i)}
             key={`question-nav-${i}`}>

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -10,12 +10,14 @@ export default function QuestionNavigationMenu({
   onQuestionClick,
   className,
   children,
+  questionStatus,
 }: {
   questions: Question[]
   currentQuestionIndex: number
   onQuestionClick: (index: number) => void
   className?: string
   children?: React.ReactNode
+  questionStatus?: (question: Question, index: number) => 'correct' | 'incorrect' | 'partly-correct' | 'unanswered'
 }) {
   return (
     <div className={cn('flex h-fit min-w-72 flex-col justify-evenly gap-3 rounded-md p-4 ring-[1.5px] ring-ring-subtle dark:ring-neutral-600', className)}>
@@ -24,11 +26,23 @@ export default function QuestionNavigationMenu({
         {questions.map((_, i) => (
           <button
             data-selected={i === currentQuestionIndex || undefined}
+            data-status-correct={questionStatus?.(_, i) === 'correct' || undefined}
+            data-status-incorrect={questionStatus?.(_, i) === 'incorrect' || undefined}
+            data-status-partly-correct={questionStatus?.(_, i) === 'partly-correct' || undefined}
+            data-status-unanswered={questionStatus?.(_, i) === 'unanswered' || undefined}
             className={cn(
               'ring-ring dark:ring-ring',
               'flex size-7 items-center justify-center rounded-lg p-1 text-sm ring-1 hover:cursor-pointer hover:bg-neutral-300/60 hover:ring-ring-hover data-selected:hover:cursor-default dark:hover:bg-neutral-600/80 dark:hover:ring-ring-hover',
-              'data-selected:bg-neutral-300 data-selected:ring-neutral-600/60 dark:data-selected:bg-neutral-600/60 dark:data-selected:ring-neutral-300/40',
-              'data-selected:ring-[1.7px]',
+              'data-selected:data-status-unanswered:bg-neutral-300 data-selected:data-status-unanswered:ring-neutral-600/60 dark:data-selected:data-status-unanswered:bg-neutral-600/60 dark:data-selected:data-status-unanswered:ring-neutral-300/40',
+
+              'data-status-correct:bg-linear-to-bl data-status-correct:from-neutral-100 data-status-correct:to-success-300/20 data-status-correct:to-60% data-status-correct:ring-success-400/40 dark:data-status-correct:from-neutral-700 dark:data-status-correct:to-success/40 dark:data-status-correct:to-50% dark:data-status-correct:ring-success/60',
+
+              'data-status-incorrect:bg-linear-to-bl data-status-incorrect:from-neutral-100 data-status-incorrect:to-destructive-300/20 data-status-incorrect:to-60% data-status-incorrect:ring-destructive-400/40 dark:data-status-incorrect:from-neutral-700 dark:data-status-incorrect:to-destructive/40 dark:data-status-incorrect:to-50% dark:data-status-incorrect:ring-destructive/60',
+
+              'data-status-partly-correct:bg-linear-to-bl data-status-partly-correct:from-neutral-100 data-status-partly-correct:to-warning-200/20 data-status-partly-correct:to-60% data-status-partly-correct:ring-warning-400/40 dark:data-status-partly-correct:from-neutral-700 dark:data-status-partly-correct:to-warning/40 dark:data-status-partly-correct:to-50% dark:data-status-partly-correct:ring-warning/60',
+
+              'not-data-status-unanswered:hover:bg-current/10 not-data-status-unanswered:hover:ring-2 dark:hover:bg-current/10',
+              'not-data-status-unanswered:data-selected:ring-2 data-status-unanswered:data-selected:ring-[1.7px]',
             )}
             onClick={() => onQuestionClick(i)}
             key={`question-nav-${i}`}>

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -35,13 +35,13 @@ export default function QuestionNavigationMenu({
               'flex size-7 items-center justify-center rounded-lg p-1 text-sm ring-1 hover:cursor-pointer hover:bg-neutral-300/60 hover:ring-ring-hover data-selected:hover:cursor-default dark:hover:bg-neutral-600/80 dark:hover:ring-ring-hover',
               'data-selected:data-status-unanswered:bg-neutral-300 data-selected:data-status-unanswered:ring-neutral-600/60 dark:data-selected:data-status-unanswered:bg-neutral-600/60 dark:data-selected:data-status-unanswered:ring-neutral-300/40',
 
-              'data-status-correct:bg-linear-to-bl data-status-correct:from-neutral-100 data-status-correct:to-success-300/20 data-status-correct:to-60% data-status-correct:ring-success-400/40 dark:data-status-correct:from-neutral-700 dark:data-status-correct:to-success/40 dark:data-status-correct:to-50% dark:data-status-correct:ring-success/60',
+              'data-status-correct:bg-linear-to-bl data-status-correct:from-neutral-100 data-status-correct:to-success-300/20 data-status-correct:to-60% data-status-correct:ring-success-400/40 dark:data-status-correct:from-neutral-700 dark:data-status-correct:to-success/30 dark:data-status-correct:to-50% dark:data-status-correct:ring-success/40',
 
-              'data-status-incorrect:bg-linear-to-bl data-status-incorrect:from-neutral-100 data-status-incorrect:to-destructive-300/20 data-status-incorrect:to-60% data-status-incorrect:ring-destructive-400/40 dark:data-status-incorrect:from-neutral-700 dark:data-status-incorrect:to-destructive/40 dark:data-status-incorrect:to-50% dark:data-status-incorrect:ring-destructive/60',
+              'data-status-incorrect:bg-linear-to-bl data-status-incorrect:from-neutral-100 data-status-incorrect:to-destructive-300/20 data-status-incorrect:to-60% data-status-incorrect:ring-destructive-400/40 dark:data-status-incorrect:from-neutral-700 dark:data-status-incorrect:to-destructive/30 dark:data-status-incorrect:to-50% dark:data-status-incorrect:ring-destructive/40',
 
-              'data-status-partly-correct:bg-linear-to-bl data-status-partly-correct:from-neutral-100 data-status-partly-correct:to-warning-200/20 data-status-partly-correct:to-60% data-status-partly-correct:ring-warning-400/40 dark:data-status-partly-correct:from-neutral-700 dark:data-status-partly-correct:to-warning/40 dark:data-status-partly-correct:to-50% dark:data-status-partly-correct:ring-warning/60',
+              'data-status-partly-correct:bg-linear-to-bl data-status-partly-correct:from-neutral-100 data-status-partly-correct:to-warning-200/20 data-status-partly-correct:to-60% data-status-partly-correct:ring-warning-400/40 dark:data-status-partly-correct:from-neutral-700 dark:data-status-partly-correct:to-warning/30 dark:data-status-partly-correct:to-50% dark:data-status-partly-correct:ring-warning/40',
 
-              'not-data-status-unanswered:hover:bg-current/10 not-data-status-unanswered:hover:ring-2 dark:hover:bg-current/10',
+              'not-data-status-unanswered:hover:bg-current/15 not-data-status-unanswered:hover:ring-2 dark:hover:bg-current/10',
               'not-data-status-unanswered:data-selected:ring-2 data-status-unanswered:data-selected:ring-[1.7px]',
             )}
             onClick={() => onQuestionClick(i)}

--- a/src/components/checks/[share_token]/ExamQuestionNavigationMenu.tsx
+++ b/src/components/checks/[share_token]/ExamQuestionNavigationMenu.tsx
@@ -7,7 +7,7 @@ import ExamFinishDialog from '@/src/components/checks/[share_token]/ExamFinishDi
 import { useExaminationStore } from '@/src/components/checks/[share_token]/ExaminationStoreProvider'
 import { useNavigationAbort } from '@/src/components/navigation-abortion/NavigationAbortProvider'
 import { Button } from '@/src/components/shadcn/button'
-import { TimeTicker } from '@/src/components/Shared/TimeTicker'
+import { CountdownTime } from '@/src/components/Shared/CountdownTime'
 import { useLogger } from '@/src/hooks/log/useLogger'
 import finishExaminationAttempt from '@/src/lib/checks/[share_token]/FinishExaminationAttempt'
 import { validateExaminationSchema } from '@/src/schemas/ExaminationSchema'
@@ -21,7 +21,7 @@ export function ExamQuestionNavigationMenu({ className }: { className?: string }
     <>
       <QuestionNavigationMenu className={className} currentQuestionIndex={currentQuestionIndex} questions={knowledgeCheck.questions} onQuestionClick={(index) => setCurrentQuestionIndex(index)}>
         <span className='text-sm text-neutral-500 dark:text-neutral-400'>
-          <TimeTicker
+          <CountdownTime
             onTimeUp={() =>
               finishExaminationAttempt(validateExaminationSchema({ knowledgeCheck, startedAt, ...examinationState }))
                 .catch((e) => {

--- a/src/components/checks/[share_token]/practice/FeedbackText.tsx
+++ b/src/components/checks/[share_token]/practice/FeedbackText.tsx
@@ -23,10 +23,10 @@ export default function DisplayFeedbackText({ feedback, pinned: isPinned, childr
       content={
         <div className='flex flex-col gap-1'>
           <h2 className='text-sm font-medium'>Feedback for Answer {answerIndex + 1}</h2>
-          <p>{feedback}</p>
+          <p className='text-pretty'>{feedback}</p>
         </div>
       }
-      className='max-w-[50vw] text-wrap lg:max-w-[25vw]'
+      className='max-w-80 lg:max-w-[25vw]'
       config={{
         open,
         onOpenChange: (next) => {

--- a/src/components/checks/[share_token]/practice/PracticeQuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/practice/PracticeQuestionNavigation.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { SquareIcon } from 'lucide-react'
+import { redirect, RedirectType } from 'next/navigation'
 import QuestionNavigationMenu from '@/src/components/checks/[share_token]/(shared)/QuestionNavigation'
 import { usePracticeStore } from '@/src/components/checks/[share_token]/practice/PracticeStoreProvider'
 import { Button } from '@/src/components/shadcn/button'
+import ConfirmationDialog from '@/src/components/Shared/ConfirmationDialog/ConfirmationDialog'
 import { StopwatchTime } from '@/src/components/Shared/StopwatchTime'
 
 export function PracticeQuestionNavigation() {
@@ -20,10 +22,16 @@ export function PracticeQuestionNavigation() {
         </div>
 
         <div className='-mb-2 flex justify-end border-t pt-1'>
-          <Button variant='ghost' type='button' size='sm' rippleClassname='bg-destructive/60' className='text-muted-foreground ring-ring-subtle/80 dark:ring-ring-subtle/80'>
-            <SquareIcon className='text-destructive/70' />
-            End Practice
-          </Button>
+          <ConfirmationDialog
+            confirmAction={() => {
+              //! For testing purposes users can navigate back to the practice-page when the app is not in production.
+              redirect('/checks', process.env.NEXT_PUBLIC_MODE !== 'production' ? RedirectType.push : RedirectType.replace)
+            }}>
+            <Button variant='link' type='button' size='sm' rippleClassname='bg-destructive/60' className='text-muted-foreground ring-ring-subtle/80 dark:ring-ring-subtle/80'>
+              <SquareIcon className='text-destructive/70' />
+              End Practice
+            </Button>
+          </ConfirmationDialog>
         </div>
       </QuestionNavigationMenu>
     </>

--- a/src/components/checks/[share_token]/practice/PracticeQuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/practice/PracticeQuestionNavigation.tsx
@@ -7,13 +7,29 @@ import { usePracticeStore } from '@/src/components/checks/[share_token]/practice
 import { Button } from '@/src/components/shadcn/button'
 import ConfirmationDialog from '@/src/components/Shared/ConfirmationDialog/ConfirmationDialog'
 import { StopwatchTime } from '@/src/components/Shared/StopwatchTime'
+import { computeQuestionInputScore } from '@/src/lib/checks/computeQuestionScore'
 
 export function PracticeQuestionNavigation() {
-  const { practiceQuestions, navigateToQuestion, currentQuestionIndex, startedAt } = usePracticeStore((store) => store)
+  const { practiceQuestions, navigateToQuestion, currentQuestionIndex, startedAt, results } = usePracticeStore((store) => store)
 
   return (
     <>
-      <QuestionNavigationMenu questions={practiceQuestions} currentQuestionIndex={currentQuestionIndex} onQuestionClick={navigateToQuestion}>
+      <QuestionNavigationMenu
+        questionStatus={(q) => {
+          const userInput = results.find((r) => r.question_id === q.id)
+          if (!userInput) return 'unanswered'
+
+          const score = computeQuestionInputScore(q, userInput)
+          if (score === null) return 'unanswered'
+
+          if (score === 0) return 'incorrect'
+          if (score >= q.points * 0.9) return 'correct'
+
+          return 'partly-correct'
+        }}
+        questions={practiceQuestions}
+        currentQuestionIndex={currentQuestionIndex}
+        onQuestionClick={navigateToQuestion}>
         <div className='flex gap-1 text-xs text-neutral-500 dark:text-neutral-400'>
           <span>Session </span>
           <span className=''>

--- a/src/components/checks/[share_token]/practice/PracticeQuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/practice/PracticeQuestionNavigation.tsx
@@ -1,39 +1,31 @@
 'use client'
 
+import { SquareIcon } from 'lucide-react'
+import QuestionNavigationMenu from '@/src/components/checks/[share_token]/(shared)/QuestionNavigation'
 import { usePracticeStore } from '@/src/components/checks/[share_token]/practice/PracticeStoreProvider'
-import { cn } from '@/src/lib/Shared/utils'
+import { Button } from '@/src/components/shadcn/button'
+import { StopwatchTime } from '@/src/components/Shared/StopwatchTime'
 
 export function PracticeQuestionNavigation() {
-  const { practiceQuestions, navigateToQuestion, currentQuestionIndex } = usePracticeStore((store) => store)
+  const { practiceQuestions, navigateToQuestion, currentQuestionIndex, startedAt } = usePracticeStore((store) => store)
 
   return (
-    <div id='practice-question-steps' className='mx-4 mb-8 grid grid-cols-[repeat(auto-fill,minmax(64,1fr))] gap-x-5 gap-y-10 lg:gap-x-12'>
-      {practiceQuestions.map((q, i) => (
-        <button
-          aria-label={`select question ${i}`}
-          type='button'
-          data-selected={currentQuestionIndex === i}
-          disabled={currentQuestionIndex === i}
-          key={q.id}
-          className={cn('group relative w-fit enabled:hover:cursor-pointer disabled:hover:cursor-auto')}
-          onClick={() => navigateToQuestion(i)}>
-          <span
-            className={cn(
-              'absolute right-0 bottom-2 left-0 text-center text-sm group-enabled:group-hover:font-semibold group-data-[selected="true"]:font-semibold',
-              'text-neutral-600 dark:text-neutral-300',
-            )}>
-            {i + 1}
+    <>
+      <QuestionNavigationMenu questions={practiceQuestions} currentQuestionIndex={currentQuestionIndex} onQuestionClick={navigateToQuestion}>
+        <div className='flex gap-1 text-xs text-neutral-500 dark:text-neutral-400'>
+          <span>Session </span>
+          <span className=''>
+            <StopwatchTime start={startedAt} delimiter=', ' />
           </span>
-          <div
-            className={cn(
-              'h-2 w-16 rounded-xl group-data-[selected="true"]:shadow-sm',
-              'bg-neutral-400/60 shadow-neutral-400 group-data-[selected="true"]:bg-neutral-500/80 dark:bg-neutral-600 dark:shadow-neutral-500 dark:group-data-[selected="true"]:bg-neutral-400',
-              'group-enabled:group-hover:bg-neutral-500/80 group-enabled:group-active:bg-neutral-500 dark:group-enabled:group-hover:bg-neutral-400 dark:group-enabled:group-active:bg-neutral-500/60',
-            )}
-            children=''
-          />
-        </button>
-      ))}
-    </div>
+        </div>
+
+        <div className='-mb-2 flex justify-end border-t pt-1'>
+          <Button variant='ghost' type='button' size='sm' rippleClassname='bg-destructive/60' className='text-muted-foreground ring-ring-subtle/80 dark:ring-ring-subtle/80'>
+            <SquareIcon className='text-destructive/70' />
+            End Practice
+          </Button>
+        </div>
+      </QuestionNavigationMenu>
+    </>
   )
 }

--- a/src/components/checks/[share_token]/practice/PracticeQuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/practice/PracticeQuestionNavigation.tsx
@@ -7,10 +7,12 @@ import { usePracticeStore } from '@/src/components/checks/[share_token]/practice
 import { Button } from '@/src/components/shadcn/button'
 import ConfirmationDialog from '@/src/components/Shared/ConfirmationDialog/ConfirmationDialog'
 import { StopwatchTime } from '@/src/components/Shared/StopwatchTime'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 import { computeQuestionInputScore } from '@/src/lib/checks/computeQuestionScore'
 
 export function PracticeQuestionNavigation() {
   const { practiceQuestions, navigateToQuestion, currentQuestionIndex, startedAt, results } = usePracticeStore((store) => store)
+  const t = useScopedI18n('Practice.PracticeQuestionNavigation')
 
   return (
     <>
@@ -31,7 +33,7 @@ export function PracticeQuestionNavigation() {
         currentQuestionIndex={currentQuestionIndex}
         onQuestionClick={navigateToQuestion}>
         <div className='flex gap-1 text-xs text-neutral-500 dark:text-neutral-400'>
-          <span>Session </span>
+          <span>{t('session_timer_label')}</span>
           <span className=''>
             <StopwatchTime start={startedAt} delimiter=', ' />
           </span>
@@ -39,13 +41,17 @@ export function PracticeQuestionNavigation() {
 
         <div className='-mb-2 flex justify-end border-t pt-1'>
           <ConfirmationDialog
+            confirmLabel={t('EndPractice_ConfirmDialog.confirm_button_label')}
+            cancelLabel={t('EndPractice_ConfirmDialog.cancel_button_label')}
+            title={t('EndPractice_ConfirmDialog.title')}
+            body={t('EndPractice_ConfirmDialog.body')}
             confirmAction={() => {
               //! For testing purposes users can navigate back to the practice-page when the app is not in production.
               redirect('/checks', process.env.NEXT_PUBLIC_MODE !== 'production' ? RedirectType.push : RedirectType.replace)
             }}>
             <Button variant='link' type='button' size='sm' rippleClassname='bg-destructive/60' className='text-muted-foreground ring-ring-subtle/80 dark:ring-ring-subtle/80'>
               <SquareIcon className='text-destructive/70' />
-              End Practice
+              {t('EndPractice_button_label')}
             </Button>
           </ConfirmationDialog>
         </div>

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import React, { HTMLProps } from 'react'
 import { motion, Variants } from 'framer-motion'
+import cloneDeep from 'lodash/cloneDeep'
 import { MessageCircleQuestionIcon } from 'lucide-react'
 import { CheckIcon, XIcon } from 'lucide-react'
 import { notFound, redirect, usePathname } from 'next/navigation'
@@ -68,7 +69,7 @@ export function RenderPracticeQuestion() {
     logger.verbose('Submitting practice answer...', _data)
     runServerValidation(_data)
 
-    storeAnswer({ ...form.getValues(), question_id: question.id })
+    storeAnswer(cloneDeep({ ...form.getValues(), question_id: question.id }))
     console.info(`[Submit] '${question.question}' has been answered & submitted`)
   }
 

--- a/src/components/shadcn/ripple-button.tsx
+++ b/src/components/shadcn/ripple-button.tsx
@@ -16,9 +16,10 @@ interface Ripple {
 interface RippleButtonProps extends Omit<HTMLMotionProps<'button'>, 'children'>, SimpleButtonProps {
   scale?: number
   transition?: Transition
+  rippleClassname?: string
 }
 
-function RippleButton({ ref, isLoading, children, onClick, className, variant, size, scale = 10, transition = { duration: 0.6, ease: 'easeOut' }, ...props }: RippleButtonProps) {
+function RippleButton({ ref, isLoading, children, onClick, className, variant, size, scale = 10, transition = { duration: 0.6, ease: 'easeOut' }, rippleClassname, ...props }: RippleButtonProps) {
   const [ripples, setRipples] = React.useState<Ripple[]>([])
   const buttonRef = React.useRef<HTMLButtonElement>(null)
 
@@ -67,7 +68,7 @@ function RippleButton({ ref, isLoading, children, onClick, className, variant, s
           initial={{ scale: 0, opacity: 0.5 }}
           animate={{ scale, opacity: 0 }}
           transition={transition}
-          className='pointer-events-none absolute size-5 rounded-full bg-current/60'
+          className={cn('pointer-events-none absolute size-5 rounded-full bg-current/60', rippleClassname)}
           style={{
             top: ripple.y - 10,
             left: ripple.x - 10,

--- a/src/hooks/Shared/zustand/useStoreCaching.ts
+++ b/src/hooks/Shared/zustand/useStoreCaching.ts
@@ -1,4 +1,3 @@
-import cloneDeep from 'lodash/cloneDeep'
 import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
 import { StoreInitializer } from '@/src/hooks/Shared/zustand/createZustandStore'
 import { StoreCachingOptions } from '@/types/Shared/ZustandStore'
@@ -32,7 +31,7 @@ export default function useStoreCaching<StoreProps extends object>({ set, option
       else update = { ...prev, ...modifications }
 
       storeTimer = setTimeout(() => {
-        if (!disableCache) storeSessionValue(cacheKey, cloneDeep(update))
+        if (!disableCache) storeSessionValue(cacheKey, update)
       }, debounceTime)
 
       return update

--- a/src/hooks/Shared/zustand/useStoreCaching.ts
+++ b/src/hooks/Shared/zustand/useStoreCaching.ts
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash/cloneDeep'
 import { useSessionStorageContext } from '@/src/hooks/root/SessionStorage'
 import { StoreInitializer } from '@/src/hooks/Shared/zustand/createZustandStore'
 import { StoreCachingOptions } from '@/types/Shared/ZustandStore'
@@ -31,7 +32,7 @@ export default function useStoreCaching<StoreProps extends object>({ set, option
       else update = { ...prev, ...modifications }
 
       storeTimer = setTimeout(() => {
-        if (!disableCache) storeSessionValue(cacheKey, { ...update })
+        if (!disableCache) storeSessionValue(cacheKey, cloneDeep(update))
       }, debounceTime)
 
       return update

--- a/src/hooks/checks/[share_token]/practice/PracticeStore.ts
+++ b/src/hooks/checks/[share_token]/practice/PracticeStore.ts
@@ -1,4 +1,3 @@
-import cloneDeep from 'lodash/cloneDeep'
 import { savePracticeResults } from '@/database/practice'
 import { createZustandStore } from '@/src/hooks/Shared/zustand/createZustandStore'
 import { instantiatePracticeData, PracticeData } from '@/src/schemas/practice/PracticeSchema'
@@ -68,12 +67,11 @@ export const createPracticeStore: WithCaching<ZustandStore<PracticeStore, Partia
         navigateToQuestion: (index) => set((prev) => ({ currentQuestionIndex: index < prev.practiceQuestions.length && index >= 0 ? index : prev.currentQuestionIndex })),
         storeAnswer: (question) =>
           set((prev) => {
-            const safeQuestion = cloneDeep(question)
-            const exists = prev.results.find((r) => r.question_id === safeQuestion.question_id)
+            const exists = prev.results.find((r) => r.question_id === question.question_id)
 
             const update: typeof prev = {
               ...prev,
-              results: exists ? prev.results.map((r) => (r.question_id === safeQuestion.question_id ? safeQuestion : r)) : prev.results.concat([safeQuestion]),
+              results: exists ? prev.results.map((r) => (r.question_id === question.question_id ? question : r)) : prev.results.concat([question]),
             }
             savePracticeResults({ knowledgeCheckId: update.checkId, results: update.results, startedAt: update.startedAt, score: 0 })
 

--- a/src/hooks/checks/[share_token]/practice/PracticeStore.ts
+++ b/src/hooks/checks/[share_token]/practice/PracticeStore.ts
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash/cloneDeep'
 import { savePracticeResults } from '@/database/practice'
 import { createZustandStore } from '@/src/hooks/Shared/zustand/createZustandStore'
 import { instantiatePracticeData, PracticeData } from '@/src/schemas/practice/PracticeSchema'
@@ -67,11 +68,12 @@ export const createPracticeStore: WithCaching<ZustandStore<PracticeStore, Partia
         navigateToQuestion: (index) => set((prev) => ({ currentQuestionIndex: index < prev.practiceQuestions.length && index >= 0 ? index : prev.currentQuestionIndex })),
         storeAnswer: (question) =>
           set((prev) => {
-            const exists = prev.results.find((r) => r.question_id === question.question_id)
+            const safeQuestion = cloneDeep(question)
+            const exists = prev.results.find((r) => r.question_id === safeQuestion.question_id)
 
             const update: typeof prev = {
               ...prev,
-              results: exists ? prev.results.map((r) => (r.question_id === question.question_id ? question : r)) : prev.results.concat([question]),
+              results: exists ? prev.results.map((r) => (r.question_id === safeQuestion.question_id ? safeQuestion : r)) : prev.results.concat([safeQuestion]),
             }
             savePracticeResults({ knowledgeCheckId: update.checkId, results: update.results, startedAt: update.startedAt, score: 0 })
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -404,6 +404,14 @@
         "column_sort_button_aria_label": "Sortieren nach {columnId}",
         "dropdown_sr_only_trigger_label": "Sortiermenü öffnen"
       }
+    },
+    "QuestionNavigation": {
+      "title": "Übungsfragen",
+      "question_aria_label": "Frage {index} ist {status}",
+      "question_status_correct": "richtig",
+      "question_status_incorrect": "falsch",
+      "question_status_partly-correct": "fast richtig",
+      "question_status_unanswered": "unbeantwortet"
     }
   },
   "AccountPage": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -291,6 +291,16 @@
       "disabled": "Das Üben dieses KnowledgeChecks ist deaktiviert. Versuchen Sie es später erneut oder wenden Sie sich an den Besitzer des KnowledgeChecks, um das Üben zu aktivieren.",
       "title": "Üben nicht erlaubt",
       "toManyAttempts": "Leider haben Sie für diese Prüfung die zulässige Anzahl an Übungsversuchen von {allowedAttemptCount} erreicht."
+    },
+    "PracticeQuestionNavigation": {
+      "session_timer_label": "Sitzung",
+      "EndPractice_button_label": "Üben beenden",
+      "EndPractice_ConfirmDialog": {
+        "confirm_button_label": "Beenden",
+        "cancel_button_label": "Fortsezten",
+        "title": "Mit dem Üben aufhören?",
+        "body": "Nachdem Sie Ihren aktuellen Übungsversuch beendet haben, werden Ihre Ergebnisse übermittelt und sind für andere zugänglich. \nBitte beachten Sie, dass Sie genau diesen Übungsversuch nicht fortsetzen können, nachdem Sie sie beendet haben."
+      }
     }
   },
   "Components": {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -151,8 +151,7 @@ export default {
     },
     Discover: {
       title: 'Entdecken Sie neue Wissenschecks',
-      no_checks_found_base: 'Keine Wissensüberprüfungen gefunden. \n' +
-        'Erstellen Sie Ihren eigenen KnowledgeCheck',
+      no_checks_found_base: 'Keine Wissensüberprüfungen gefunden. \n' + 'Erstellen Sie Ihren eigenen KnowledgeCheck',
       no_checks_found_link: 'hier',
       FilterFields: {
         filter_operand_menu_label: 'Filter Operatoren',
@@ -301,7 +300,8 @@ export default {
         confirm_button_label: 'Beenden',
         cancel_button_label: 'Fortsezten',
         title: 'Mit dem Üben aufhören?',
-        body: 'Nachdem Sie Ihren aktuellen Übungsversuch beendet haben, werden Ihre Ergebnisse übermittelt und sind für andere zugänglich. \n' +
+        body:
+          'Nachdem Sie Ihren aktuellen Übungsversuch beendet haben, werden Ihre Ergebnisse übermittelt und sind für andere zugänglich. \n' +
           'Bitte beachten Sie, dass Sie genau diesen Übungsversuch nicht fortsetzen können, nachdem Sie sie beendet haben.'
       }
     }
@@ -361,15 +361,14 @@ export default {
       },
       remove_share_token: {
         tooltip: 'Dieser Check hat keinen Freigabe schlüssel.',
-        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
-          'Dadurch wird das Share-Token dauerhaft aus diesem KnowledgeCheck gelöscht.',
+        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird das Share-Token dauerhaft aus diesem KnowledgeCheck gelöscht.',
         toast_deletion_successful: 'Freigabe token erfolgreich gelöscht',
         toast_deletion_failure: 'Löschen des freigabge tokens fehlgeschlagen!'
       },
       delete_knowledgeCheck: {
         label: 'Check löschen',
-        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
-          'Dadurch wird dieser KnowledCheck dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
+        confirmation_dialog_body:
+          'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird dieser KnowledCheck dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
         toast_deletion_successful: 'KnowledgeCheck erfolgreich gelöscht',
         toast_deletion_failure: 'Löschen des KnowledgeChecks fehlgeschlagen!'
       },
@@ -380,8 +379,7 @@ export default {
     },
     ConfirmationDialog: {
       default_title: 'Bist du absolut sicher?',
-      default_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
-        'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
+      default_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
       default_cancel_label: 'Abbrechen',
       default_confirm_label: 'Weiter'
     },
@@ -410,6 +408,14 @@ export default {
         column_sort_button_aria_label: 'Sortieren nach {columnId}',
         dropdown_sr_only_trigger_label: 'Sortiermenü öffnen'
       }
+    },
+    QuestionNavigation: {
+      title: 'Übungsfragen',
+      question_aria_label: 'Frage {index} ist {status}',
+      question_status_correct: 'richtig',
+      question_status_incorrect: 'falsch',
+      'question_status_partly-correct': 'fast richtig',
+      question_status_unanswered: 'unbeantwortet'
     }
   },
   AccountPage: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -151,7 +151,8 @@ export default {
     },
     Discover: {
       title: 'Entdecken Sie neue Wissenschecks',
-      no_checks_found_base: 'Keine Wissensüberprüfungen gefunden. \n' + 'Erstellen Sie Ihren eigenen KnowledgeCheck',
+      no_checks_found_base: 'Keine Wissensüberprüfungen gefunden. \n' +
+        'Erstellen Sie Ihren eigenen KnowledgeCheck',
       no_checks_found_link: 'hier',
       FilterFields: {
         filter_operand_menu_label: 'Filter Operatoren',
@@ -292,6 +293,17 @@ export default {
       disabled: 'Das Üben dieses KnowledgeChecks ist deaktiviert. Versuchen Sie es später erneut oder wenden Sie sich an den Besitzer des KnowledgeChecks, um das Üben zu aktivieren.',
       title: 'Üben nicht erlaubt',
       toManyAttempts: 'Leider haben Sie für diese Prüfung die zulässige Anzahl an Übungsversuchen von {allowedAttemptCount} erreicht.'
+    },
+    PracticeQuestionNavigation: {
+      session_timer_label: 'Sitzung',
+      EndPractice_button_label: 'Üben beenden',
+      EndPractice_ConfirmDialog: {
+        confirm_button_label: 'Beenden',
+        cancel_button_label: 'Fortsezten',
+        title: 'Mit dem Üben aufhören?',
+        body: 'Nachdem Sie Ihren aktuellen Übungsversuch beendet haben, werden Ihre Ergebnisse übermittelt und sind für andere zugänglich. \n' +
+          'Bitte beachten Sie, dass Sie genau diesen Übungsversuch nicht fortsetzen können, nachdem Sie sie beendet haben.'
+      }
     }
   },
   Components: {
@@ -349,14 +361,15 @@ export default {
       },
       remove_share_token: {
         tooltip: 'Dieser Check hat keinen Freigabe schlüssel.',
-        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird das Share-Token dauerhaft aus diesem KnowledgeCheck gelöscht.',
+        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
+          'Dadurch wird das Share-Token dauerhaft aus diesem KnowledgeCheck gelöscht.',
         toast_deletion_successful: 'Freigabe token erfolgreich gelöscht',
         toast_deletion_failure: 'Löschen des freigabge tokens fehlgeschlagen!'
       },
       delete_knowledgeCheck: {
         label: 'Check löschen',
-        confirmation_dialog_body:
-          'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird dieser KnowledCheck dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
+        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
+          'Dadurch wird dieser KnowledCheck dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
         toast_deletion_successful: 'KnowledgeCheck erfolgreich gelöscht',
         toast_deletion_failure: 'Löschen des KnowledgeChecks fehlgeschlagen!'
       },
@@ -367,7 +380,8 @@ export default {
     },
     ConfirmationDialog: {
       default_title: 'Bist du absolut sicher?',
-      default_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
+      default_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
+        'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
       default_cancel_label: 'Abbrechen',
       default_confirm_label: 'Weiter'
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -300,6 +300,16 @@
       "title": "Practicing not allowed",
       "disabled": "Practicing is disabled for this check, try again later or contact the owner of this check to enable practicing.",
       "toManyAttempts": "You have unfortunately reached the allowed practice attempt count of {allowedAttemptCount} for this check."
+    },
+    "PracticeQuestionNavigation": {
+      "session_timer_label": "Session",
+      "EndPractice_button_label": "End Practice",
+      "EndPractice_ConfirmDialog": {
+        "confirm_button_label": "Finish",
+        "cancel_button_label": "Continue",
+        "title": "Do you want to stop Practicing?",
+        "body": "After stopping your current practice attempt, your results are being submitted and accessible by others. Please note that you cannot resume this exact practice session after submitting it."
+      }
     }
   },
   "Components": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -413,6 +413,14 @@
         "dropdown_sr_only_trigger_label": "Open sort menu",
         "column_sort_button_aria_label": "Sort by {columnId}"
       }
+    },
+    "QuestionNavigation": {
+      "title": "Questions",
+      "question_aria_label": "Question {index} is {status}",
+      "question_status_correct": "correct",
+      "question_status_incorrect": "incorrect",
+      "question_status_partly-correct": "partly-correct",
+      "question_status_unanswered": "unanswered"
     }
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -301,6 +301,16 @@ export default {
       title: 'Practicing not allowed',
       disabled: 'Practicing is disabled for this check, try again later or contact the owner of this check to enable practicing.',
       toManyAttempts: 'You have unfortunately reached the allowed practice attempt count of {allowedAttemptCount} for this check.'
+    },
+    PracticeQuestionNavigation: {
+      session_timer_label: 'Session',
+      EndPractice_button_label: 'End Practice',
+      EndPractice_ConfirmDialog: {
+        confirm_button_label: 'Finish',
+        cancel_button_label: 'Continue',
+        title: 'Do you want to stop Practicing?',
+        body: 'After stopping your current practice attempt, your results are being submitted and accessible by others. Please note that you cannot resume this exact practice-sessions after stopping it.'
+      }
     }
   },
   Components: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -309,7 +309,7 @@ export default {
         confirm_button_label: 'Finish',
         cancel_button_label: 'Continue',
         title: 'Do you want to stop Practicing?',
-        body: 'After stopping your current practice attempt, your results are being submitted and accessible by others. Please note that you cannot resume this exact practice-sessions after stopping it.'
+        body: 'After stopping your current practice attempt, your results are being submitted and accessible by others. Please note that you cannot resume this exact practice session after submitting it.'
       }
     }
   },
@@ -414,6 +414,14 @@ export default {
         dropdown_sr_only_trigger_label: 'Open sort menu',
         column_sort_button_aria_label: 'Sort by {columnId}'
       }
+    },
+    QuestionNavigation: {
+      title: 'Questions',
+      question_aria_label: 'Question {index} is {status}',
+      question_status_correct: 'correct',
+      question_status_incorrect: 'incorrect',
+      'question_status_partly-correct': 'partly-correct',
+      question_status_unanswered: 'unanswered'
     }
   }
 } as const

--- a/src/lib/checks/computeQuestionScore.ts
+++ b/src/lib/checks/computeQuestionScore.ts
@@ -9,7 +9,8 @@ export function computeQuestionInputScore(question: Question, answer: QuestionIn
     onSingleQuestion: function (singleChoice: SingleChoice, input) {
       const correctAnswer = singleChoice.answers.find((a) => a.correct)
       if (!correctAnswer) {
-        console.log('[copmuteQInputScore]: Correct answer for single-choice question not found...')
+        console.warn('[copmuteQInputScore]: Correct answer for single-choice question not found...')
+        console.log(singleChoice)
         return 0
       }
 

--- a/src/lib/checks/computeQuestionScore.ts
+++ b/src/lib/checks/computeQuestionScore.ts
@@ -7,9 +7,13 @@ export function computeQuestionInputScore(question: Question, answer: QuestionIn
 
   const answerScore = handleQuestionType(question, answer, {
     onSingleQuestion: function (singleChoice: SingleChoice, input) {
-      const correctAnswerId = singleChoice.answers.find((a) => a.correct)!.id
+      const correctAnswer = singleChoice.answers.find((a) => a.correct)
+      if (!correctAnswer) {
+        console.log('[copmuteQInputScore]: Correct answer for single-choice question not found...')
+        return 0
+      }
 
-      return input.selection === correctAnswerId ? singleChoice.points : 0
+      return input.selection === correctAnswer.id ? singleChoice.points : 0
     },
     onMultipleChoice: function (multipleChoice: MultipleChoice, input) {
       const correctAnswers = multipleChoice.answers.filter((a) => a.correct)

--- a/src/tests/e2e/checks/[share_token]/QuestionAccessibility.cy.tsx
+++ b/src/tests/e2e/checks/[share_token]/QuestionAccessibility.cy.tsx
@@ -38,7 +38,7 @@ describe('Accessibility of questions: ', () => {
         const url = page === 'practice' ? practiceUrl : examUrl
         cy.visit(url)
 
-        const navigationMenuId = page === 'examination' ? '#exam-question-navigation' : '#practice-question-steps'
+        const navigationMenuId = '#question-navigation'
         cy.get(navigationMenuId)
           .should('exist')
           .and('be.visible')

--- a/src/tests/e2e/checks/[share_token]/ShareCheckPage.cy.tsx
+++ b/src/tests/e2e/checks/[share_token]/ShareCheckPage.cy.tsx
@@ -20,7 +20,7 @@ describe('Verify sharing of KnowledgeChecks', () => {
 
     cy.visit(`/checks/${dummyShareToken}`)
     cy.get('main #page-heading').should('contain', dummyCheck.name)
-    cy.get('nav[id="exam-question-navigation"]').should('exist').children().should('have.length', dummyCheck.questions.length)
+    cy.get('nav[id="question-navigation"]').should('exist').children().should('have.length', dummyCheck.questions.length)
   })
 
   it('Verify that a share-token can be generated and used by the owner', () => {

--- a/src/tests/e2e/checks/[share_token]/practice/PracticeCategories.cy.tsx
+++ b/src/tests/e2e/checks/[share_token]/practice/PracticeCategories.cy.tsx
@@ -47,7 +47,7 @@ describe('Verify selection of practice questions by category', () => {
 
       cy.url({ timeout: 5 * 1000 }).should('eq', `${baseURL}/checks/${dummyCheck.share_key}/practice?category=${categorySelection === 'random' ? selection : '_none_'}`)
 
-      cy.get('#practice-question-steps')
+      cy.get('#question-navigation')
         .children()
         .should('have.length', categorySelection === 'all' ? dummyCheck.questions.length : dummyCheck.questions.filter((q) => q.category === selection).length)
     }),
@@ -82,7 +82,7 @@ describe('Verify selection of practice questions by category', () => {
     cy.url().should('not.eq', `${baseURL}/checks/${dummyCheck.share_key}/practice/category`)
     cy.url().should('eq', `${baseURL}/checks/${dummyCheck.share_key}/practice`)
 
-    cy.get('#practice-question-steps').children().should('have.length', dummyCheck.questions.length)
+    cy.get('#question-navigation').children().should('have.length', dummyCheck.questions.length)
   })
 
   ParameterizedTest([{ categorySelection: 'random' }, { categorySelection: 'all' }] as const, ({ categorySelection }) =>
@@ -123,7 +123,7 @@ describe('Verify selection of practice questions by category', () => {
 
       cy.url({ timeout: 5 * 1000 }).should('eq', `${baseURL}/checks/${dummyCheck.share_key}/practice?category=${categorySelection === 'random' ? selection : '_none_'}`)
 
-      cy.get('#practice-question-steps')
+      cy.get('#question-navigation')
         .children()
         .should('have.length', categorySelection === 'all' ? dummyCheck.questions.length : dummyCheck.questions.filter((q) => q.category === selection).length)
 
@@ -153,7 +153,7 @@ describe('Verify selection of practice questions by category', () => {
       cy.url({ timeout: 5 * 1000 }).should('eq', `${baseURL}/checks/${dummyCheck.share_key}/practice?category=${breadcrumbSelection === 'all' ? '_none_' : breadcrumbSelection}`)
       cy.wait(250)
 
-      cy.get('#practice-question-steps')
+      cy.get('#question-navigation')
         .children()
         .should('have.length', breadcrumbSelection === 'all' ? dummyCheck.questions.length : dummyCheck.questions.filter((q) => q.category === breadcrumbSelection).length)
     }),
@@ -196,14 +196,14 @@ describe('Verify selection of practice questions by category', () => {
 
     cy.url({ timeout: 5 * 1000 }).should('eq', `${baseURL}/checks/${dummyCheck.share_key}/practice?category=${randomSelection}`)
 
-    cy.get('#practice-question-steps')
+    cy.get('#question-navigation')
       .children()
       .should('have.length', dummyCheck.questions.filter((q) => q.category === randomSelection).length)
 
     cy.wait(500)
     cy.reload()
     cy.url({ timeout: 5 * 1000 }).should('eq', `${baseURL}/checks/${dummyCheck.share_key}/practice?category=${randomSelection}`)
-    cy.get('#practice-question-steps')
+    cy.get('#question-navigation')
       .children()
       .should('have.length', dummyCheck.questions.filter((q) => q.category === randomSelection).length)
   })

--- a/src/tests/e2e/checks/[share_token]/practice/PracticeCheck.cy.tsx
+++ b/src/tests/e2e/checks/[share_token]/practice/PracticeCheck.cy.tsx
@@ -33,7 +33,7 @@ describe('RenderPracticeQuestion Test Suite', { viewportWidth: 1280, viewportHei
   const verifyQuestionIsDisplayedCorrectly = (question: Question, questionCount: number) => {
     cy.get('#practice-form h2').contains(question.question).should('exist').and('be.visible')
     cy.get('#practice-form ').should('exist').should('have.attr', 'data-question-type', question.type).and('have.attr', 'data-question-id', question.id)
-    cy.get('#practice-question-steps').should('exist').children().should('have.length', questionCount)
+    cy.get('#question-navigation').should('exist').children().should('have.length', questionCount)
 
     switch (question.type) {
       case 'single-choice':


### PR DESCRIPTION
> [!Note]
> This pull request unifies the appearance of the practice page to use the same layout as the examination page. The reason for this is for one that this way users are not irritated when starting an examination-attempt after practicing a given check due to the different layout. Similarly, this way users have a dedicated `end-practice` button that shows a confirmation dialog upon click and will redirect users to a overview / statistics page on confirm, in the future. 
>
> This is what the practice page now looks like:
> ![Unified Practice page Appearance](https://github.com/user-attachments/assets/64b4c4cb-f706-4935-9c0f-ad6fa3c97d4f)


## Summary 

* **New Features**
  * Introduced `StopwatchTime` component that displays time-passed, e.g. during practice attempts
  * Redesigned practice page layout to mimic examination page layout
  * Introduced end-practice button wrapped in confirmation dialog to prevent accidental practice-session exits
  * Visual question status indicators showing correct, incorrect, unanswered, and partially-correct answers

* **Bug Fixes**
  * Preemptively resolved category-selection edge-case to show all practice questions when no category is selected.
  * Resolved practice-question reference mutation issue for (`selection` property of multiple-choice questions). 

* **Improvements**
  * Added `rippleClassname` arg to `RippleButton` to customize the ripple-effect background.
  * Renamed `TimeTicker` component to `CountdownTime` to be more explicit. 
  *  Added safe-guard to `computeQuestionScore` to prevent exceptions when solutions are cleared from the given question. 
  * Added `data-selected` argument to `QuestionNavigation` element to use tailwind selectors for styling.
  * Added question correctness data attributes to `QuestionNavigation` to color easily question-nav elements.
  * Added `questionStatus` argument to `QuestionNavigation` used to style question-nav elements, respectively. 
  * Unified `QuestionNavigation` test locator-selectors to use the same id for practice and exam pages.

* **Styles**
  * Updated `max-w-` constraints in `DisplayFeedbackText` to feel more natural on smaller screens.
  * Added various shades to `destructive`, `success`, `warning` variables between (`100` and `900`).

* **Localization**
  * Added German and English translations for practice navigation and session controls

---
### Detailed Changelog 

<details>
<summary>Changelog</summary>

[](https://google.com)
- **Features**:
  - Created `StopwatchTime` component ([`52e6709d`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/52e6709d))
     This component can be used to show e.g. the time-spent on a page.
  
  - Redesigned `PracticeQuestionNavigation` ([`9e606350`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/9e606350))
     This way the practice-question-navigation menu looks very similar to the one shown during examination. This way users can familiarize themselves with this menu, so that they are not surprised to see the same menu during examinations.
  
  - Redesigned practice page layout to mimic exam ([`8074229b`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/8074229b))
     This way the examination and practice layout is very similar, almost identical. This way users are able to familiarize themselves with the layout so that they are not surprised by the examination layout.
  

- **Fixes**:
  - Resolved practice category edge-case ([`1dbabce6`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/1dbabce6))
     Previously when the users were on the practice page, but without selecting any category-option. Then, this would cause the `practiceQuestions` to unset (empty). Hence, the practiceQuestions are set to be all questions, when no selection is made too.
  
  - Resoled reference mutation issue with selection array ([`da26afa0`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/da26afa0))
     Due to the objects / arrays are stored in js the selection-array was mutated when the practice-form got reset. Thereby, causing the session-storage to be overridden once the session-storage got updated (after being debounced).
  

- **Refactors**:
  - Added `rippleClassname` arg to button ([`979d840d`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/979d840d))
     This way the ripple-effect can be customized by e.g. setting the ripple-background color.
  
  - Declared use-client explicitly in `QuestionNav` ([`a926c669`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/a926c669))
     
  - Renamed `TimeTicker` to `CountdownTime` ([`3e251b0c`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/3e251b0c))
     The reason for this is that this way the components use-case is more clear and less confusing.
  
  - Wrapped end-practice btn in `ConfirmDialog` ([`8cbe2071`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/8cbe2071))
     
  - Added safe-guard to `computeQInputScore` ([`6189fa74`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/6189fa74))
     When a single-choice question has no correct-answer, e.g. because it was stripped to prevent data-leakage. Then, the score computation will throw an error. By checking if a correct-answer exists first, this issue is resolved.
  
  - Enabled question solutions to evaluate correctness ([`5bcd21ec`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/5bcd21ec))
     
  - Added safe-guard if solutions are stripped ([`0528e7a9`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/0528e7a9))
     
  - Supplied `questionStatus` in `PracticeQNav` ([`3c8b1afb`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/3c8b1afb))
     This way the question-navigation items are colored depending on their previous submission (correct, incorrect, partly-correct, unanswered).
  
  - Added translations to `PracticeQNavigation` ([`2fd3fdb3`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/2fd3fdb3))
     
  - Moved deep-cloning when obj is passed to store ([`6804a874`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/6804a874))
     This way the object that is being passed to store is no longer uses the same references as the object used within the `RenderPracticeQuestion` component.
  
  - Unified `QuestionNavigation` test selectors ([`96e898c0`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/96e898c0))
     Previously the practice and examination pages used different ids for their question-navigation menu. Since both now use the same `QuestionNavigation` component the ids can be unified.
  
  - Improved practice category filtering conditions ([`5ec5797a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/5ec5797a))
     During the re-design of this logic the redirect to the category-selection when there are categories available but nothing was selected, got lost. This commit re-introduces this edge-case and restructures these conditions to improve readability.
  
  - Simplified status computation in `QuestionNav` ([`837bc1b7`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/837bc1b7))
     
  - Added aria-label to `QuestionNav` buttons ([`78570b06`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/78570b06))
     
  - Localized `QuestionNavigation` fields ([`c2ac7957`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/c2ac7957))
     
  - Improved practice question filtering conditions ([`3ca37a85`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/3ca37a85))
     By using a switch-statement multiple conditions / cases can use the same implementation in a more structured manner than if-statements.
  

- **Styles**:
  - Added max-w restriction to `PractiveQNav` ([`72471f8a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/72471f8a))
     
  - Updated practice feedback tooltip max-w ([`ba8eb502`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/ba8eb502))
     The tooltip that renders the feedback text has now a smaller max-width on large screens and an absolute max-width on smaller screens. Also the formatting of the feedback-paragraph is now better aligned, using `text-prettier`.
  
  - Added success, warning, destructive intensities ([`91d711c0`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/91d711c0))
     By adding intensities between 100-900 for the `success`, `warning` and `destructive` css variables, these styles can be better used for less prominent elements.
  
  - Applied data-selected attr in `QuestionNav` ([`01fe26e7`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/01fe26e7))
     This way the individual question-navigation items can be easily styled using this new `data-selected` attribute, without the need to compare indices.
  
  - Added question correctness styles ([`96b8ef7e`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/96b8ef7e))
     This way the question navigation elements are styled based on the correctness of the respective question.
  
  - Reduced `QuestionNav` dark color intensity ([`c46ac5aa`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/c46ac5aa))
     
  - Emphasized `QuestionNav` selection styles ([`189d792a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/189d792a))
     This way the selected question navigation item is both emphasized through a more prominent ring and by a pulse animation.
  
  - Introduced moving border as selected indicator ([`6edef38a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/6edef38a))
     This way the selected indicator is less prominent than the previously used increased ring and pulse-animation.
  


</details>
