### PR TITLE
Chore: Migrate codebase and utility functions to use zod@4

### DIFF
--- a/database/drizzle/schema.ts
+++ b/database/drizzle/schema.ts
@@ -155,22 +155,22 @@ export const db_knowledgeCheckSettings = mysqlTable(
     knowledgecheckId: varchar('knowledgecheck_id', { length: 36 }).notNull(),
     allowAnonymous: tinyint('allow_anonymous')
       .notNull()
-      .default(KnowledgeCheckSettingsSchema.shape.examination.shape.allowAnonymous._def.defaultValue() ? 1 : 0),
+      .default(KnowledgeCheckSettingsSchema.shape.examination.shape.allowAnonymous._zod.def.defaultValue ? 1 : 0),
     allowFreeNavigation: tinyint('allow_free_navigation')
       .notNull()
-      .default(KnowledgeCheckSettingsSchema.shape.examination.shape.allowFreeNavigation._def.defaultValue() ? 1 : 0),
-    questionOrder: mysqlEnum(['create-order', 'random']).notNull().default(KnowledgeCheckSettingsSchema.shape.examination.shape.questionOrder._def.defaultValue()),
-    answerOrder: mysqlEnum(['create-order', 'random']).notNull().default(KnowledgeCheckSettingsSchema.shape.examination.shape.answerOrder._def.defaultValue()),
-    examTimeFrameSeconds: int().notNull().default(KnowledgeCheckSettingsSchema.shape.examination.shape.examTimeFrameSeconds._def.defaultValue()),
-    examinationAttemptCount: int().notNull().default(KnowledgeCheckSettingsSchema.shape.examination.shape.examinationAttemptCount._def.defaultValue()),
+      .default(KnowledgeCheckSettingsSchema.shape.examination.shape.allowFreeNavigation._zod.def.defaultValue ? 1 : 0),
+    questionOrder: mysqlEnum(['create-order', 'random']).notNull().default(KnowledgeCheckSettingsSchema.shape.examination.shape.questionOrder._zod.def.defaultValue),
+    answerOrder: mysqlEnum(['create-order', 'random']).notNull().default(KnowledgeCheckSettingsSchema.shape.examination.shape.answerOrder._zod.def.defaultValue),
+    examTimeFrameSeconds: int().notNull().default(KnowledgeCheckSettingsSchema.shape.examination.shape.examTimeFrameSeconds._zod.def.defaultValue),
+    examinationAttemptCount: int().notNull().default(KnowledgeCheckSettingsSchema.shape.examination.shape.examinationAttemptCount._zod.def.defaultValue),
     shareAccessibility: int()
       .notNull()
-      .default(KnowledgeCheckSettingsSchema.shape.shareAccessibility._def.defaultValue() ? 1 : 0),
+      .default(KnowledgeCheckSettingsSchema.shape.shareAccessibility._zod.def.defaultValue ? 1 : 0),
 
     // -----
     enableExaminations: int()
       .notNull()
-      .default(KnowledgeCheckSettingsSchema.shape.examination.shape.enableExaminations._def.defaultValue() ? 1 : 0),
+      .default(KnowledgeCheckSettingsSchema.shape.examination.shape.enableExaminations._zod.def.defaultValue ? 1 : 0),
     startDate: datetime({ mode: 'string' })
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`)
@@ -181,7 +181,7 @@ export const db_knowledgeCheckSettings = mysqlTable(
 
     enablePracticing: int()
       .notNull()
-      .default(KnowledgeCheckSettingsSchema.shape.practice.shape.enablePracticing._def.defaultValue() ? 1 : 0),
+      .default(KnowledgeCheckSettingsSchema.shape.practice.shape.enablePracticing._zod.def.defaultValue ? 1 : 0),
 
     allowedPracticeCount: int().default(sql`NULL`),
   },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,8 +12,14 @@ const config: Config = {
   testMatch: [
     '<rootDir>/src/tests/unit/**/*.test.tsx',
     '<rootDir>/src/tests/unit/**/*.test.ts',
+    '<rootDir>/src/tests/unit/**/*.tsx',
+    '<rootDir>/src/tests/unit/**/*.ts',
+
     '<rootDir>/src/tests/integration/**/*.test.tsx',
     '<rootDir>/src/tests/integration/**/*.test.ts',
+    '<rootDir>/src/tests/integration/**/*.tsx',
+    '<rootDir>/src/tests/integration/**/*.ts',
+
     '<rootDir>/config/**/tests/*.test.ts',
   ],
   testEnvironment: 'node',

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@heroui/system": "^2.4.12",
     "@heroui/theme": "^2.4.12",
     "@heroui/tooltip": "^2.2.13",
-    "@hookform/resolvers": "^4.1.3",
+    "@hookform/resolvers": "^5.2.2",
     "@jest/globals": "^30.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-checkbox": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "vaul": "^1.1.2",
     "winston": "^3.19.0",
     "winston-daily-rotate-file": "^5.0.0",
-    "zod": "^3.24.2",
+    "zod": "^4.3.6",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/src/components/account/login/CredentialProviderForm.tsx
+++ b/src/components/account/login/CredentialProviderForm.tsx
@@ -10,7 +10,7 @@ import useRHF from '@/src/hooks/Shared/form/useRHF'
 import { cn } from '@/src/lib/Shared/utils'
 import { LoginSchema } from '@/src/schemas/AuthenticationSchema'
 
-export default function CredentialProviderForm<Schema extends z.ZodSchema = typeof LoginSchema>({
+export default function CredentialProviderForm<Schema extends z.ZodObject = typeof LoginSchema>({
   schema,
   formAction,
   formProps,

--- a/src/components/account/login/CredentialProviderForm.tsx
+++ b/src/components/account/login/CredentialProviderForm.tsx
@@ -20,10 +20,10 @@ export default function CredentialProviderForm<Schema extends z.ZodSchema = type
 }: {
   currentMode: 'signUp' | 'login'
   schema: Schema
-  formProps?: UseRHFFormProps<z.infer<Schema>>
-  formAction: RHFServerAction<z.infer<Schema>>
+  formProps?: UseRHFFormProps<z.output<Schema>>
+  formAction: RHFServerAction<z.output<Schema>>
   refererCallbackUrl?: string
-  renderFields: (args: { form: RHFBaseReturn<z.infer<Schema>>['form'] }) => React.ReactNode
+  renderFields: (args: { form: RHFBaseReturn<z.output<Schema>>['form'] }) => React.ReactNode
 }) {
   const { form, runServerValidation, isServerValidationPending } = useRHF<Schema>(
     schema,
@@ -40,7 +40,7 @@ export default function CredentialProviderForm<Schema extends z.ZodSchema = type
     formState: { isValid, isLoading, isSubmitting, isValidating, errors },
   } = form
 
-  const onSubmit = (data: z.infer<Schema>) => runServerValidation(data)
+  const onSubmit = (data: z.output<Schema>) => runServerValidation(data)
 
   return (
     <Form {...form}>

--- a/src/components/checks/[share_token]/ExaminationAttemptTable.tsx
+++ b/src/components/checks/[share_token]/ExaminationAttemptTable.tsx
@@ -32,7 +32,7 @@ const ExamAttemptItemSchema = z.object({
   totalCheckScore: z.number(),
 })
 
-type ExamAttemptItem = z.infer<typeof ExamAttemptItemSchema>
+type ExamAttemptItem = z.output<typeof ExamAttemptItemSchema>
 
 export function ExaminationAttemptTable({ data: initialData }: { data: ExamAttemptItem[] }) {
   const currentLocale = useCurrentLocale()
@@ -189,7 +189,7 @@ function DrawerActionTableCell({ item, children }: { item: ExamAttemptItem; chil
     <Drawer direction={isMobile ? 'bottom' : 'right'}>
       <DrawerTrigger asChild>{children}</DrawerTrigger>
       <DrawerContent className='data-[vaul-drawer-direction=right]:*:data-close:flex'>
-        <div data-close className='absolute top-0 bottom-0 -left-2.5 hidden items-center'>
+        <div data-close className='absolute inset-y-0 -left-2.5 hidden items-center'>
           <DrawerClose asChild>
             <Button variant='ghost' size='icon' className='size-4 bg-background text-neutral-600 hover:scale-115 dark:text-neutral-300'>
               <ChevronRightIcon className='' />

--- a/src/components/checks/[share_token]/RenderExamQuestion.tsx
+++ b/src/components/checks/[share_token]/RenderExamQuestion.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useIsFirstRender } from '@uidotdev/usehooks'
-import { useForm, useFormContext, useWatch } from 'react-hook-form'
+import { Resolver, useForm, useFormContext, useWatch } from 'react-hook-form'
 import DisplayChoiceQuestionAnswer from '@/src/components/checks/[share_token]/(shared)/(questions)/ChoiceQuestionAnswer'
 import { OpenQuestionAnswer } from '@/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer'
 import { useExaminationStore } from '@/src/components/checks/[share_token]/ExaminationStoreProvider'
@@ -24,7 +24,7 @@ export default function RenderExamQuestion() {
   const question = state.knowledgeCheck.questions.at(currentQuestionIndex)!
 
   const form = useForm<QuestionInput>({
-    resolver: zodResolver(QuestionInputSchema),
+    resolver: zodResolver(QuestionInputSchema) as unknown as Resolver<QuestionInput>,
     defaultValues: {
       ...state.results[currentQuestionIndex],
       question_id: question.id,

--- a/src/components/checks/create/(create-question)/CreateQuestionDialog.tsx
+++ b/src/components/checks/create/(create-question)/CreateQuestionDialog.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import isEmpty from 'lodash/isEmpty'
 import isEqual from 'lodash/isEqual'
 import { ArrowDown, ArrowUp, Check, Plus, Trash2, X } from 'lucide-react'
-import { FormState, useFieldArray, UseFieldArrayReturn, useForm, useFormContext, UseFormReturn } from 'react-hook-form'
+import { FormState, Resolver, useFieldArray, UseFieldArrayReturn, useForm, useFormContext, UseFormReturn } from 'react-hook-form'
 import { twMerge } from 'tailwind-merge'
 import { useCheckStore } from '@/components/checks/create/CreateCheckProvider'
 import { Button } from '@/src/components/shadcn/button'
@@ -77,7 +77,7 @@ export default function CreateQuestionDialog({ children, initialValues }: { chil
   const mode: 'edit' | 'create' = isEmpty(initialValues) ? 'create' : 'edit'
 
   const form = useForm<Question>({
-    resolver: zodResolver(QuestionSchema),
+    resolver: zodResolver(QuestionSchema) as unknown as Resolver<Question>,
     defaultValues: computeFormDefaults(),
     mode: 'onChange',
     delayError: DELAY_ERROR_TIME,

--- a/src/components/checks/create/(create-question)/CreateQuestionDialog.tsx
+++ b/src/components/checks/create/(create-question)/CreateQuestionDialog.tsx
@@ -4,8 +4,9 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import isEmpty from 'lodash/isEmpty'
 import isEqual from 'lodash/isEqual'
 import { ArrowDown, ArrowUp, Check, Plus, Trash2, X } from 'lucide-react'
-import { FormState, Resolver, useFieldArray, UseFieldArrayReturn, useForm, useFormContext, UseFormReturn } from 'react-hook-form'
+import { FieldValues, FormState, Resolver, useFieldArray, UseFieldArrayReturn, useForm, useFormContext, UseFormReturn } from 'react-hook-form'
 import { twMerge } from 'tailwind-merge'
+import z from 'zod'
 import { useCheckStore } from '@/components/checks/create/CreateCheckProvider'
 import { Button } from '@/src/components/shadcn/button'
 import { Form } from '@/src/components/shadcn/form'
@@ -77,7 +78,7 @@ export default function CreateQuestionDialog({ children, initialValues }: { chil
   const mode: 'edit' | 'create' = isEmpty(initialValues) ? 'create' : 'edit'
 
   const form = useForm<Question>({
-    resolver: zodResolver(QuestionSchema) as unknown as Resolver<Question>,
+    resolver: zodResolver(QuestionSchema as z.ZodType<Question, FieldValues>) as unknown as Resolver<Question>,
     defaultValues: computeFormDefaults(),
     mode: 'onChange',
     delayError: DELAY_ERROR_TIME,

--- a/src/components/checks/create/(sections)/GeneralSection.tsx
+++ b/src/components/checks/create/(sections)/GeneralSection.tsx
@@ -70,15 +70,16 @@ export default function GeneralSection({ jumpBackButton, ...config }: { jumpBack
 
           const { success, error } = safeParseKnowledgeCheck(values)
           if (!success) {
-            for (const [key, messages] of Object.entries(error.formErrors.fieldErrors)) {
-              if (!messages) continue
+            for (const [, issue] of Object.entries(error.issues)) {
+              if (!issue) continue
+              const fieldName = issue.path.at(-1) as unknown as (typeof FIELDS)[number]
 
-              if (!FIELDS.includes(key as keyof KnowledgeCheck)) {
-                console.warn(`[Form]: Detected error for '${key}' but is not part of relevant fields`, FIELDS, ', ignoring error.')
+              if (!FIELDS.includes(fieldName)) {
+                console.warn(`[Form]: Detected error for '${fieldName}' but is not part of relevant fields`, FIELDS, ', ignoring error.', issue.message)
                 continue
               }
 
-              for (const msg of messages) form.setError(key as Any, { message: msg, type: 'custom' })
+              form.setError(fieldName as Any, { message: issue.message, type: issue.code })
             }
 
             return

--- a/src/hooks/Shared/form/useRHF.ts
+++ b/src/hooks/Shared/form/useRHF.ts
@@ -37,21 +37,21 @@ function useServerValidation<Type extends object>(options?: UseRHFOptions<Type>)
 }
 
 // prettier-ignore
-export default function useRHF<TSchema extends z.ZodSchema >( schema: TSchema, formProps?: UseRHFFormProps<z.infer<TSchema>>): RHFBaseReturn<z.infer<TSchema>>
+export default function useRHF<TSchema extends z.ZodType<X>, X extends object = object>( schema: TSchema, formProps?: UseRHFFormProps<z.output<TSchema>>): RHFBaseReturn<z.output<TSchema>>
 
 // prettier-ignore
-export default function useRHF<TSchema extends z.ZodSchema >( schema: TSchema, formProps: UseRHFFormProps<z.infer<TSchema>> | undefined, options: UseRHFOptions<z.infer<TSchema>>): RHFWithServerReturn<z.infer<TSchema>>
+export default function useRHF<TSchema extends z.ZodType<X>, X extends object = object>( schema: TSchema, formProps: UseRHFFormProps<z.output<TSchema>> | undefined, options: UseRHFOptions<z.output<TSchema>>): RHFWithServerReturn<z.output<TSchema>>
 
 /**
  * Combines react-hook-form initialization with Zod schema validation + schema descriptions.
  * Optionally wires up a Next.js server action (useActionState) for server-side validation.
  */
-export default function useRHF<TSchema extends z.ZodSchema>(schema: TSchema, formProps?: UseRHFFormProps<z.infer<TSchema>>, options?: UseRHFOptions<z.infer<TSchema>>) {
+export default function useRHF<TSchema extends z.ZodType<X>, X extends object = object>(schema: TSchema, formProps?: UseRHFFormProps<z.output<TSchema>>, options?: UseRHFOptions<z.output<TSchema>>) {
   const descriptions = useMemo(() => extractDescriptionMap(schema), [schema])
-  const { hasServerValidation, ...serverReturnProps } = useServerValidation<z.infer<TSchema>>(options)
+  const { hasServerValidation, ...serverReturnProps } = useServerValidation<z.output<TSchema>>(options)
   const { instantiate } = schemaUtilities(schema)
 
-  const form = useForm<z.infer<TSchema>>({
+  const form = useForm<z.output<TSchema>>({
     resolver: zodResolver(schema),
     ...formProps,
     defaultValues:
@@ -64,7 +64,7 @@ export default function useRHF<TSchema extends z.ZodSchema>(schema: TSchema, for
 
   if (!hasServerValidation) return base
 
-  const serverReturn: RHFWithServerReturn<z.infer<TSchema>> = {
+  const serverReturn: RHFWithServerReturn<z.output<TSchema>> = {
     ...base,
     ...serverReturnProps,
     isValidationComplete:

--- a/src/hooks/Shared/form/useRHF.ts
+++ b/src/hooks/Shared/form/useRHF.ts
@@ -1,6 +1,6 @@
 import { useActionState, useCallback, useMemo, useTransition } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useForm } from 'react-hook-form'
+import { Resolver, useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { RHFBaseReturn, RHFServerAction, RHFServerReturn, RHFServerState, RHFWithServerReturn, UseRHFFormProps, UseRHFOptions } from '@/src/hooks/Shared/form/react-hook-form/type'
 import { buildBaseReturn, createNoopServerAction, isServerAction, useServerValidationResults } from '@/src/hooks/Shared/form/react-hook-form/utilts'
@@ -52,7 +52,7 @@ export default function useRHF<TSchema extends z.ZodType<X>, X extends object = 
   const { instantiate } = schemaUtilities(schema)
 
   const form = useForm<z.output<TSchema>>({
-    resolver: zodResolver(schema),
+    resolver: zodResolver(schema) as unknown as Resolver<z.output<TSchema>>,
     ...formProps,
     defaultValues:
       typeof formProps?.defaultValues === 'function' ? formProps.defaultValues(serverReturnProps.state.values, instantiate({ stripDefaultValues: true, generateRandomNumbers: false })) : undefined,

--- a/src/hooks/Shared/form/useRHF.ts
+++ b/src/hooks/Shared/form/useRHF.ts
@@ -1,6 +1,6 @@
 import { useActionState, useCallback, useMemo, useTransition } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Resolver, useForm } from 'react-hook-form'
+import { FieldValues, Resolver, useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { RHFBaseReturn, RHFServerAction, RHFServerReturn, RHFServerState, RHFWithServerReturn, UseRHFFormProps, UseRHFOptions } from '@/src/hooks/Shared/form/react-hook-form/type'
 import { buildBaseReturn, createNoopServerAction, isServerAction, useServerValidationResults } from '@/src/hooks/Shared/form/react-hook-form/utilts'
@@ -52,7 +52,7 @@ export default function useRHF<TSchema extends z.ZodType<X>, X extends object = 
   const { instantiate } = schemaUtilities(schema)
 
   const form = useForm<z.output<TSchema>>({
-    resolver: zodResolver(schema) as unknown as Resolver<z.output<TSchema>>,
+    resolver: zodResolver(schema as z.ZodType<X, FieldValues>) as unknown as Resolver<z.output<TSchema>>,
     ...formProps,
     defaultValues:
       typeof formProps?.defaultValues === 'function' ? formProps.defaultValues(serverReturnProps.state.values, instantiate({ stripDefaultValues: true, generateRandomNumbers: false })) : undefined,

--- a/src/lib/Shared/Env.ts
+++ b/src/lib/Shared/Env.ts
@@ -47,7 +47,7 @@ export const envSchema = z
     DEX_CLIENT_ID: z.string().optional().default('nextjs-client').catch('nextjs-client'),
     DEX_CLIENT_SECRET: z.string().optional().default('dev-secret').catch('dev-secret'),
     CAPTURE_CLIENT_LOGS: z.stringbool().optional(),
-    ENABLE_FILE_LOGGING: z.stringbool().default(true).optional(),
+    ENABLE_FILE_LOGGING: z.stringbool().optional().default(true),
   })
   .superRefine((env, ctx) => {
     if (env.NEXT_PUBLIC_MODE === 'test') {

--- a/src/lib/Shared/Env.ts
+++ b/src/lib/Shared/Env.ts
@@ -11,7 +11,7 @@ export const envSchema = z
 
     DATABASE_HOST: z.union([
       z.string().regex(/^\S*$/, { message: 'When using the service-name as the database host, make sure that it does not contain any spaces! (Alternatively provide a valid URL / IP)' }),
-      z.string().ip({ message: 'Please provide a valid database host url / ip / service-name' }),
+      z.ipv4({ message: 'Please provide a valid database host url / ip / service-name' }),
       z.string().url({ message: 'Please provide a valid database host url / ip / service-name' }),
       // .min(1, 'The database host must not be empty!')
     ]),
@@ -40,21 +40,14 @@ export const envSchema = z
     DEX_PROVIDER_URL: z
       .union([
         z.string().regex(/^\S*$/, { message: 'When using the service-name as the host, make sure that it does not contain any spaces! (Alternatively provide a valid URL / IP)' }),
-        z.string().ip({ message: 'Please provide a valid host url / ip / service-name' }),
+        z.ipv4({ message: 'Please provide a valid host url / ip / service-name' }),
         z.string().url({ message: 'Please provide a valid host url / ip / service-name' }),
       ])
       .optional(),
     DEX_CLIENT_ID: z.string().optional().default('nextjs-client').catch('nextjs-client'),
     DEX_CLIENT_SECRET: z.string().optional().default('dev-secret').catch('dev-secret'),
-    CAPTURE_CLIENT_LOGS: z
-      .string()
-      .optional()
-      .transform((val) => val?.toString().toLowerCase().trim() === 'true'),
-    ENABLE_FILE_LOGGING: z
-      .string()
-      .transform((val) => val.toLowerCase().trim() === 'true')
-      .optional()
-      .default('true'),
+    CAPTURE_CLIENT_LOGS: z.stringbool().optional(),
+    ENABLE_FILE_LOGGING: z.stringbool().default(true).optional(),
   })
   .superRefine((env, ctx) => {
     if (env.NEXT_PUBLIC_MODE === 'test') {

--- a/src/lib/Shared/Env.ts
+++ b/src/lib/Shared/Env.ts
@@ -54,7 +54,7 @@ export const envSchema = z
       // DEX_PROVIDER_URL required in test
       if (!env.DEX_PROVIDER_URL) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           path: ['DEX_PROVIDER_URL'],
           message: 'DEX_PROVIDER_URL is required when MODE is "test".',
         })
@@ -63,7 +63,7 @@ export const envSchema = z
       // DEX_CLIENT_ID required in test
       if (!env.DEX_CLIENT_ID) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           path: ['DEX_CLIENT_ID'],
           message: 'DEX_CLIENT_ID is required when MODE is "test".',
         })
@@ -72,7 +72,7 @@ export const envSchema = z
       // DEX_CLIENT_SECRET required in test
       if (!env.DEX_CLIENT_SECRET) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           path: ['DEX_CLIENT_SECRET'],
           message: 'DEX_CLIENT_SECRET is required when MODE is "test".',
         })
@@ -104,7 +104,7 @@ export const envSchema = z
         if (!hasSecret) console.info(`[.env] ${p.name} sign-in disabled (missing ${p.secretKey}).`)
 
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           path: [!hasId ? p.idKey : p.secretKey],
           message: `${p.name} auth requires BOTH ${p.idKey} and ${p.secretKey} (either set both or leave both empty).`,
         })

--- a/src/lib/dummy/getDummyUsers.tsx
+++ b/src/lib/dummy/getDummyUsers.tsx
@@ -43,7 +43,7 @@ export const DummyUserSchema = z
       name: `${user.name.first} ${user.name.last}`,
     }),
   )
-export type DummyUser = z.infer<typeof DummyUserSchema>
+export type DummyUser = z.output<typeof DummyUserSchema>
 
 const { validate: validateDummyUser, instantiate } = schemaUtilities(DummyUserSchema)
 

--- a/src/lib/log/type.ts
+++ b/src/lib/log/type.ts
@@ -22,4 +22,4 @@ export const LogSchema = z.object({
   messages: z.array(z.unknown()).default([]),
 })
 
-export type LoggerOptions = z.infer<typeof LogSchema>
+export type LoggerOptions = z.output<typeof LogSchema>

--- a/src/schemas/AuthenticationSchema.ts
+++ b/src/schemas/AuthenticationSchema.ts
@@ -7,7 +7,7 @@ const baseSchema = z.object({
   callbackURL: z.string().optional().default('/'),
 })
 
-export type LoginProps = z.infer<typeof baseSchema>
+export type LoginProps = z.output<typeof baseSchema>
 export const LoginSchema = baseSchema
 const { validate: validateLoginProps, instantiate: instantiateLoginProps, safeParse: safeParseLoginProps } = schemaUtilities(LoginSchema)
 export { instantiateLoginProps, safeParseLoginProps, validateLoginProps }
@@ -15,6 +15,6 @@ export { instantiateLoginProps, safeParseLoginProps, validateLoginProps }
 export const SignupSchema = baseSchema.extend({
   name: z.string().trim().min(1, { message: 'The name must be at least 1 characters long.' }),
 })
-export type SignupProps = z.infer<typeof SignupSchema>
+export type SignupProps = z.output<typeof SignupSchema>
 const { validate: validateSignupProps, instantiate: instantiateSignupProps, safeParse: safeParseSignupProps } = schemaUtilities(SignupSchema)
 export { instantiateSignupProps, safeParseSignupProps, validateSignupProps }

--- a/src/schemas/CategorySchema.ts
+++ b/src/schemas/CategorySchema.ts
@@ -3,10 +3,7 @@ import { getUUID } from '@/src/lib/Shared/getUUID'
 import { schemaUtilities } from '@/src/schemas/utils/schemaUtilities'
 
 export const CategorySchema = z.object({
-  id: z
-    .string()
-    .uuid()
-    .default(() => getUUID()),
+  id: z.uuidv4().default(() => getUUID()),
   name: z.string(),
   prequisiteCategoryId: z.string().min(1, 'A prerequisite category may not be empty!').nullable().default(null),
   skipOnMissingPrequisite: z.boolean().default(false),

--- a/src/schemas/CategorySchema.ts
+++ b/src/schemas/CategorySchema.ts
@@ -15,4 +15,4 @@ export const CategorySchema = z.object({
 const { instantiate: instantiateCategory, validate: validateCategory, safeParse: safeParseCategory } = schemaUtilities(CategorySchema)
 export { instantiateCategory, validateCategory, safeParseCategory }
 
-export type CategorySchema = z.infer<typeof CategorySchema>
+export type CategorySchema = z.output<typeof CategorySchema>

--- a/src/schemas/ExaminationSchema.ts
+++ b/src/schemas/ExaminationSchema.ts
@@ -13,7 +13,7 @@ export const ExaminationSchema = z.object({
   results: z.array(QuestionInputSchema).default([]),
 })
 
-export type ExaminationSchema = z.infer<typeof ExaminationSchema>
+export type ExaminationSchema = z.output<typeof ExaminationSchema>
 
 const { validate: validateExaminationSchema, instantiate: instantiateExaminationSchema, safeParse: safeParseExaminationSchema } = schemaUtilities(ExaminationSchema)
 export { instantiateExaminationSchema, safeParseExaminationSchema, validateExaminationSchema }

--- a/src/schemas/KnowledgeCheck.ts
+++ b/src/schemas/KnowledgeCheck.ts
@@ -10,10 +10,7 @@ import { QuestionSchema } from '@/src/schemas/QuestionSchema'
 
 export const KnowledgeCheckSchema = z
   .object({
-    id: z
-      .string()
-      .uuid()
-      .default(() => getUUID()),
+    id: z.uuidv4().default(() => getUUID()),
 
     name: z.string().default('Knowledge Check').describe('The name under which the created check is associated with.'),
 

--- a/src/schemas/KnowledgeCheck.ts
+++ b/src/schemas/KnowledgeCheck.ts
@@ -104,7 +104,7 @@ export const KnowledgeCheckSchema = z
     }
   })
 
-export type KnowledgeCheck = z.infer<typeof KnowledgeCheckSchema>
+export type KnowledgeCheck = z.output<typeof KnowledgeCheckSchema>
 
 const { validate: validateKnowledgeCheck, instantiate: instantiateKnowledgeCheck, safeParse: safeParseKnowledgeCheck } = schemaUtilities(KnowledgeCheckSchema)
 export { instantiateKnowledgeCheck, safeParseKnowledgeCheck, validateKnowledgeCheck }

--- a/src/schemas/KnowledgeCheckSettingsSchema.ts
+++ b/src/schemas/KnowledgeCheckSettingsSchema.ts
@@ -89,7 +89,7 @@ export const KnowledgeCheckSettingsSchema = z.object({
     .describe('Defines whether this check is publicly accessible, thus whether users can discover this check.'),
 })
 
-export type KnowledgeCheckSettings = z.infer<typeof KnowledgeCheckSettingsSchema>
+export type KnowledgeCheckSettings = z.output<typeof KnowledgeCheckSettingsSchema>
 
 const { validate: validateKnowledgeCheckSettings, instantiate: instantiateKnowledgeCheckSettings, safeParse: safeParseKnowledgeCheckSettings } = schemaUtilities(KnowledgeCheckSettingsSchema)
 export { instantiateKnowledgeCheckSettings, safeParseKnowledgeCheckSettings, validateKnowledgeCheckSettings }

--- a/src/schemas/KnowledgeCheckSettingsSchema.ts
+++ b/src/schemas/KnowledgeCheckSettingsSchema.ts
@@ -5,10 +5,7 @@ import { getUUID } from '@/src/lib/Shared/getUUID'
 import { schemaUtilities } from '@/src/schemas/utils/schemaUtilities'
 
 export const KnowledgeCheckSettingsSchema = z.object({
-  id: z
-    .string()
-    .uuid()
-    .default(() => getUUID()),
+  id: z.uuidv4().default(() => getUUID()),
 
   practice: z.object({
     enablePracticing: z

--- a/src/schemas/KnowledgeCheckSettingsSchema.ts
+++ b/src/schemas/KnowledgeCheckSettingsSchema.ts
@@ -39,18 +39,18 @@ export const KnowledgeCheckSettingsSchema = z.object({
     startDate: z
       .date()
       .or(z.string())
+      .default(() => format(new Date(Date.now()), 'yyyy-MM-dd HH:mm:ss'))
       .transform((date) => (typeof date === 'string' ? new Date(date) : date))
       .refine((check) => !isNaN(check.getTime()), 'Invalid date value provided')
-      .default(() => format(new Date(Date.now()), 'yyyy-MM-dd HH:mm:ss'))
       .describe('The start-date on which users can start examinations.'),
 
     endDate: z
       .date()
       .or(z.string())
+      .default(() => format(addYears(new Date(Date.now()), 1), 'yyyy-MM-dd 00:00:00'))
       .transform((date) => (typeof date === 'string' ? new Date(date) : date))
       .refine((check) => !isNaN(check.getTime()), 'Invalid date value provided')
       .nullable()
-      .default(() => format(addYears(new Date(Date.now()), 1), 'yyyy-MM-dd 00:00:00'))
       .describe('The end-date after which users can no longer start examinations. When set to null no end constraints are set.'),
 
     questionOrder: z.enum(['create-order', 'random']).default('random').describe('Defines how questions are ordered during practice / exams.'),

--- a/src/schemas/QuestionSchema.ts
+++ b/src/schemas/QuestionSchema.ts
@@ -160,7 +160,7 @@ const questionAnswerTypes = z.discriminatedUnion('type', [singleChoiceAnswerSche
 
 export const QuestionSchema = z.intersection(baseQuestion, questionAnswerTypes).default(() => generateRandomQuestion())
 
-export type Question = z.infer<typeof QuestionSchema>
+export type Question = z.output<typeof QuestionSchema>
 
 const { validate: validateQuestion, instantiate: instantiateQuestion, safeParse: safeParseQuestion } = schemaUtilities(QuestionSchema)
 export { instantiateQuestion, safeParseQuestion, validateQuestion }
@@ -183,7 +183,7 @@ const { validate: validateDragDropQuestion, instantiate: instantiateDragDropQues
 export { instantiateDragDropQuestion, safeParseDragDropQuestion, validateDragDropQuestion }
 
 // #region Dummy Data
-function generateRandomQuestion(): z.infer<typeof baseQuestion> & z.infer<typeof questionAnswerTypes> {
+function generateRandomQuestion(): z.output<typeof baseQuestion> & z.output<typeof questionAnswerTypes> {
   return {
     id: getUUID(),
     category: 'general',
@@ -193,8 +193,8 @@ function generateRandomQuestion(): z.infer<typeof baseQuestion> & z.infer<typeof
   }
 }
 
-function generateRandomQuestionType(): z.infer<typeof questionAnswerTypes> & Pick<z.infer<typeof baseQuestion>, 'question'> {
-  const dummyQuestions: (z.infer<typeof questionAnswerTypes> & Pick<z.infer<typeof baseQuestion>, 'question'> & Partial<z.infer<typeof baseQuestion>>)[] = [
+function generateRandomQuestionType(): z.output<typeof questionAnswerTypes> & Pick<z.output<typeof baseQuestion>, 'question'> {
+  const dummyQuestions: (z.output<typeof questionAnswerTypes> & Pick<z.output<typeof baseQuestion>, 'question'> & Partial<z.output<typeof baseQuestion>>)[] = [
     {
       type: 'multiple-choice',
       question: 'In the PAYDAY series, who betrayed the PAYDAY gang that got Hoxton arrested?',

--- a/src/schemas/QuestionSchema.ts
+++ b/src/schemas/QuestionSchema.ts
@@ -1,4 +1,4 @@
-import { z, ZodIssueCode } from 'zod'
+import { z } from 'zod'
 import { schemaUtilities } from '@/schemas/utils/schemaUtilities'
 import { getUUID } from '@/src/lib/Shared/getUUID'
 import lorem from '@/src/lib/Shared/Lorem'
@@ -123,7 +123,7 @@ const dragDropAnswerSchema = z.object({
       answers.forEach((answer, i) => {
         if (seen.has(answer.position)) {
           ctx.addIssue({
-            code: ZodIssueCode.custom,
+            code: 'custom',
             message: `[drag-drop] duplicate position: ${answer.position}`,
             path: [i, 'position'],
           })
@@ -135,7 +135,7 @@ const dragDropAnswerSchema = z.object({
       for (let pos = 0; pos <= n - 1; pos++) {
         if (!seen.has(pos)) {
           ctx.addIssue({
-            code: ZodIssueCode.custom,
+            code: 'custom',
             message: `[drag-drop] positions must form a continuous range: [0...${n - 1}]; received: [${answers.map((a) => a.position).join(', ')}]. Position ${pos} is missing!`,
           })
 

--- a/src/schemas/QuestionSchema.ts
+++ b/src/schemas/QuestionSchema.ts
@@ -11,7 +11,7 @@ const AnswerId = z
 
 const baseQuestion = z.object({
   id: z.string().uuid(),
-  points: z.number().positive(),
+  points: z.number().positive('Number must be greater than 0'),
   category: z.string().default('general'),
 
   question: z

--- a/src/schemas/QuestionSchema.ts
+++ b/src/schemas/QuestionSchema.ts
@@ -109,7 +109,8 @@ const dragDropAnswerSchema = z.object({
 
       if (minPos !== 0) {
         ctx.addIssue({
-          code: ZodIssueCode.too_small,
+          code: 'too_small',
+          origin: 'number',
           minimum: 0,
           type: 'number',
           inclusive: true,

--- a/src/schemas/QuestionSchema.ts
+++ b/src/schemas/QuestionSchema.ts
@@ -10,7 +10,7 @@ const AnswerId = z
   .catch(() => getUUID())
 
 const baseQuestion = z.object({
-  id: z.string().uuid(),
+  id: z.uuidv4(),
   points: z.number().positive('Number must be greater than 0'),
   category: z.string().default('general'),
 

--- a/src/schemas/UserQuestionInputSchema.ts
+++ b/src/schemas/UserQuestionInputSchema.ts
@@ -2,12 +2,12 @@ import { z } from 'zod'
 import { schemaUtilities } from '@/src/schemas/utils/schemaUtilities'
 
 const baseSchema = z.object({
-  question_id: z.string().uuid(),
+  question_id: z.uuidv4(),
 })
 
 const SingleChoiceInputSchema = z.object({
   type: z.literal('single-choice'),
-  selection: z.string().uuid().nonempty('Please select an answer'),
+  selection: z.uuidv4().nonempty('Please select an answer'),
 })
 
 const MultipleChoiceInputSchema = z.object({
@@ -16,8 +16,7 @@ const MultipleChoiceInputSchema = z.object({
   selection: z
     .array(
       z
-        .string()
-        .uuid()
+        .uuidv4()
         .or(z.literal(false))
         .optional()
         .transform((v) => (v === false || v === undefined ? null : v))

--- a/src/schemas/UserQuestionInputSchema.ts
+++ b/src/schemas/UserQuestionInputSchema.ts
@@ -41,7 +41,7 @@ const userInputSchema = z.discriminatedUnion('type', [SingleChoiceInputSchema, M
 
 export const QuestionInputSchema = z.intersection(baseSchema, userInputSchema)
 
-export type QuestionInput = z.infer<typeof QuestionInputSchema>
+export type QuestionInput = z.output<typeof QuestionInputSchema>
 
 const { validate: validateQuestionInput, instantiate: instantiateQuestionInput, safeParse: safeParseQuestionInput } = schemaUtilities(QuestionInputSchema)
 export { instantiateQuestionInput, safeParseQuestionInput, validateQuestionInput }

--- a/src/schemas/practice/PracticeSchema.ts
+++ b/src/schemas/practice/PracticeSchema.ts
@@ -14,7 +14,7 @@ export const PracticeSchema = z.object({
   results: z.array(QuestionInputSchema).default([]),
 })
 
-export type PracticeData = z.infer<typeof PracticeSchema>
+export type PracticeData = z.output<typeof PracticeSchema>
 
 const { validate: validatePracticeData, instantiate: instantiatePracticeData, safeParse: safeParsePracticeData } = schemaUtilities(PracticeSchema)
 export { instantiatePracticeData, safeParsePracticeData, validatePracticeData }

--- a/src/schemas/utils/createConvertToDatabase.ts
+++ b/src/schemas/utils/createConvertToDatabase.ts
@@ -153,7 +153,7 @@ export default function createConvertToDatabase<Schema extends z.ZodTypeAny, Tab
    * @typeParam Obj - Inferred from the passed object; do not annotate unless necessary.
    * @param obj - The object to convert.
    */
-  return function convertToDatabase<const Type extends z.infer<Schema>>(obj: Type): DbConversionResult<Type, Table> {
+  return function convertToDatabase<const Type extends z.output<Schema>>(obj: Type): DbConversionResult<Type, Table> {
     const out: Record<string, unknown> = {}
     const columns = getTableColumns(table)
 

--- a/src/schemas/utils/extractDescriptions.ts
+++ b/src/schemas/utils/extractDescriptions.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { Any } from '@/types'
 
 export type DescriptionMap = Record<string, string | undefined>
 
@@ -87,7 +88,7 @@ export function getDescriptionForRhfName(map: DescriptionMap, rhfName: string, w
  * - Writes description for the current node at `path` (if any).
  * - Traverses children using an unwrapped view for structural correctness.
  */
-function walk(schema: AnySchema, path: string, out: DescriptionMap, opt: Required<ExtractDescriptionMapOptions>): void {
+function walk(schema: Any, path: string, out: DescriptionMap, opt: Required<ExtractDescriptionMapOptions>): void {
   // Description is read from the *outer wrapper chain* (not the unwrapped traversal schema).
   write(out, path, findDescription(schema), opt.prefer)
 
@@ -107,8 +108,8 @@ function walk(schema: AnySchema, path: string, out: DescriptionMap, opt: Require
     const leftMap: DescriptionMap = {}
     const rightMap: DescriptionMap = {}
 
-    walk(structural._def.left, path, leftMap, opt)
-    walk(structural._def.right, path, rightMap, opt)
+    walk(structural._zod.def.left, path, leftMap, opt)
+    walk(structural._zod.def.right, path, rightMap, opt)
 
     merge(out, leftMap, opt.prefer)
     merge(out, rightMap, opt.prefer)
@@ -116,7 +117,7 @@ function walk(schema: AnySchema, path: string, out: DescriptionMap, opt: Require
   }
 
   if (structural instanceof z.ZodDiscriminatedUnion || structural instanceof z.ZodUnion) {
-    const options = (structural._def.options as AnySchema[]) ?? []
+    const options = (structural._zod.def.options as AnySchema[]) ?? []
 
     for (const variant of options) {
       const variantMap: DescriptionMap = {}
@@ -128,13 +129,13 @@ function walk(schema: AnySchema, path: string, out: DescriptionMap, opt: Require
 
   if (structural instanceof z.ZodArray) {
     // Any index: `items.*`
-    walk(structural._def.type, join(path, opt.wildcard), out, opt)
+    walk(structural._zod.def.type, join(path, opt.wildcard), out, opt)
     return
   }
 
   if (structural instanceof z.ZodTuple) {
     // Tuple indices are fixed: `tuple.0`, `tuple.1`, ...
-    ;(structural._def.items as AnySchema[]).forEach((item, idx) => {
+    ;(structural._zod.def.items as AnySchema[]).forEach((item, idx) => {
       walk(item, join(path, String(idx)), out, opt)
     })
     return
@@ -142,7 +143,7 @@ function walk(schema: AnySchema, path: string, out: DescriptionMap, opt: Require
 
   if (structural instanceof z.ZodRecord) {
     // Any key: `record.*`
-    walk(structural._def.valueType, join(path, opt.wildcard), out, opt)
+    walk(structural._zod.def.valueType, join(path, opt.wildcard), out, opt)
     return
   }
 
@@ -153,16 +154,14 @@ function walk(schema: AnySchema, path: string, out: DescriptionMap, opt: Require
  * Returns the *first* description found while walking outer → inner across wrapper schemas.
  * This is intentionally separate from traversal unwrapping so we don't lose metadata.
  */
-function findDescription(schema: AnySchema): string | undefined {
+function findDescription(schema: Any): string | undefined {
   const own = readDescription(schema)
   if (own) return own
 
-  if (schema instanceof z.ZodEffects) return findDescription(schema._def.schema)
   if (schema instanceof z.ZodOptional || schema instanceof z.ZodNullable) return findDescription(schema.unwrap())
-  if (schema instanceof z.ZodDefault) return findDescription(schema._def.innerType)
-  if (schema instanceof z.ZodCatch) return findDescription(schema._def.innerType)
-  if (schema instanceof z.ZodReadonly) return findDescription(schema._def.innerType)
-  if (schema instanceof z.ZodBranded) return findDescription(schema._def.type)
+  if (schema instanceof z.ZodDefault) return findDescription(schema._zod.def.innerType)
+  if (schema instanceof z.ZodCatch) return findDescription(schema._zod.def.innerType)
+  if (schema instanceof z.ZodReadonly) return findDescription(schema._zod.def.innerType)
 
   // Add wrapper types you use here (pipeline, lazy, promise, etc.) if needed.
   return undefined
@@ -172,20 +171,19 @@ function findDescription(schema: AnySchema): string | undefined {
  * Unwraps wrappers solely for structural traversal (to reach objects/arrays/unions/etc.).
  * This intentionally does *not* attempt to preserve descriptions; that's handled by findDescription().
  */
-function unwrapForTraversal(schema: AnySchema): AnySchema {
-  if (schema instanceof z.ZodEffects) return unwrapForTraversal(schema._def.schema)
+function unwrapForTraversal(schema: Any): Any {
+  if (schema instanceof z.ZodPipe) return unwrapForTraversal(schema._zod.def.in)
   if (schema instanceof z.ZodOptional || schema instanceof z.ZodNullable) return unwrapForTraversal(schema.unwrap())
-  if (schema instanceof z.ZodDefault) return unwrapForTraversal(schema._def.innerType)
-  if (schema instanceof z.ZodCatch) return unwrapForTraversal(schema._def.innerType)
-  if (schema instanceof z.ZodReadonly) return unwrapForTraversal(schema._def.innerType)
-  if (schema instanceof z.ZodBranded) return unwrapForTraversal(schema._def.type)
+  if (schema instanceof z.ZodDefault) return unwrapForTraversal(schema._zod.def.innerType)
+  if (schema instanceof z.ZodCatch) return unwrapForTraversal(schema._zod.def.innerType)
+  if (schema instanceof z.ZodReadonly) return unwrapForTraversal(schema._zod.def.innerType)
 
   return schema
 }
 
 /**
  * Reads the schema's own description in a way that works across Zod versions.
- * Prefer the public `.description` accessor when available, fall back to `_def.description`.
+ * Prefer the public `.description` accessor when available, fall back to `_zod.def.description`.
  */
 function readDescription(schema: AnySchema): string | undefined {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/schemas/utils/refinements/IdentifyDuplicateFields.ts
+++ b/src/schemas/utils/refinements/IdentifyDuplicateFields.ts
@@ -1,4 +1,4 @@
-import { z, ZodIssueCode } from 'zod'
+import { z } from 'zod'
 
 type MarkMode = 'last' | 'both'
 
@@ -43,14 +43,14 @@ export default function identifyDuplicateFields<T, K extends string | number>(
     const firstIndex = firstIndexByKey.get(k)
     if (firstIndex !== undefined) {
       ctx.addIssue({
-        code: ZodIssueCode.custom,
+        code: 'custom',
         message: message(raw),
         path: [i, field],
       })
 
       if (mark === 'both') {
         ctx.addIssue({
-          code: ZodIssueCode.custom,
+          code: 'custom',
           message: message(raw),
           path: [firstIndex, field],
         })

--- a/src/schemas/utils/schemaDefaults.ts
+++ b/src/schemas/utils/schemaDefaults.ts
@@ -22,22 +22,30 @@ export interface SchemaOptionalProps {
   generateRandomNumbers?: boolean
   overrideArraySize?: number
 }
+type ResolvedOptions = Readonly<Required<SchemaOptionalProps>>
+/**
+ * Internal sentinel used to mean "do not materialize this property".
+ *
+ * This is useful for optional object keys: omitting a key is usually more
+ * correct than explicitly assigning `undefined`.
+ */
+
+const DEFAULT_OPTIONS: ResolvedOptions = {
+  instantiate_Optional_PrimitiveProps: true,
+  instantiate_Nullable_PrimitiveProps: true,
+  instantiate_Optional_Objects: true,
+  instantiate_Nullable_Objects: true,
+  stripDefaultValues: false,
+  generateRandomNumbers: true,
+  overrideArraySize: DEFAULT_ARRAY_SIZE,
+}
 
 /**
  * Returns a default values for a given schema.
  * @param schema The schema to generate default values for.
  */
-export default function schemaDefaults<Schema extends z.ZodTypeAny>(
-  schema: Schema,
-  options: SchemaOptionalProps = {
-    instantiate_Optional_PrimitiveProps: true,
-    instantiate_Optional_Objects: true,
-    instantiate_Nullable_PrimitiveProps: true,
-    instantiate_Nullable_Objects: true,
-    generateRandomNumbers: true,
-  },
-): z.output<Schema> {
-  if (options.instantiate_Optional_PrimitiveProps === undefined) options.instantiate_Optional_PrimitiveProps = true
+export default function schemaDefaults<Schema extends z.ZodTypeAny>(schema: Schema, userOptions?: SchemaOptionalProps): z.output<Schema> {
+  const options = resolveOptions(userOptions)
 
   const getDef = (s: any) => {
     if (s === undefined) {
@@ -275,4 +283,24 @@ export default function schemaDefaults<Schema extends z.ZodTypeAny>(
 
 function unwrapPipe<TSchema extends z.ZodPipe>(pipedSchema: TSchema): TSchema['in'] {
   return pipedSchema.in
+}
+
+/**
+ * joins custom options with default options into an immutable options object
+ * that way default values are not lost when users provide options
+ */
+function resolveOptions(options: SchemaOptionalProps = {}): ResolvedOptions {
+  return {
+    ...DEFAULT_OPTIONS,
+    ...options,
+    overrideArraySize: normalizeArraySize(options.overrideArraySize ?? DEFAULT_OPTIONS.overrideArraySize),
+  }
+}
+
+/**
+ * normalize array sizes to a finite, thus non-negative integer.
+ */
+function normalizeArraySize(size: number): number {
+  if (!Number.isFinite(size) || size < 0) return DEFAULT_ARRAY_SIZE
+  return Math.floor(size)
 }

--- a/src/schemas/utils/schemaDefaults.ts
+++ b/src/schemas/utils/schemaDefaults.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { z, ZodTypeAny } from 'zod'
+import { z } from 'zod'
 import { getUUID } from '@/src/lib/Shared/getUUID'
+import { Any } from '@/types'
 
 /**
  * The default size of an array.
@@ -25,7 +26,7 @@ export interface SchemaOptionalProps {
  * Returns a default values for a given schema.
  * @param schema The schema to generate default values for.
  */
-export default function schemaDefaults<Schema extends z.ZodFirstPartySchemaTypes>(
+export default function schemaDefaults<Schema extends z.ZodTypeAny>(
   schema: Schema,
   options: SchemaOptionalProps = {
     instantiate_Optional_PrimitiveProps: true,
@@ -34,144 +35,242 @@ export default function schemaDefaults<Schema extends z.ZodFirstPartySchemaTypes
     instantiate_Nullable_Objects: true,
     generateRandomNumbers: true,
   },
-): z.TypeOf<Schema> {
+): z.output<Schema> {
   if (options.instantiate_Optional_PrimitiveProps === undefined) options.instantiate_Optional_PrimitiveProps = true
 
-  switch (schema._def.typeName) {
-    case z.ZodFirstPartyTypeKind.ZodDefault:
-      return schema._def.defaultValue()
-
-    case z.ZodFirstPartyTypeKind.ZodObject:
-      return Object.fromEntries(Object.entries((schema as z.SomeZodObject).shape).map(([key, value]) => [key, schemaDefaults(value, options)]))
-
-    case z.ZodFirstPartyTypeKind.ZodString:
-      const schemaChecks = schema._def.checks
-
-      let value = ''
-      if (options.stripDefaultValues) return value
-
-      if (schemaChecks.some((check: any) => check.kind === 'uuid')) value = getUUID()
-
-      return value
-
-    case z.ZodFirstPartyTypeKind.ZodNull:
-      return null
-
-    case z.ZodFirstPartyTypeKind.ZodNullable:
-      const strippedNullableSchema = (schema as z.ZodNullable<ZodTypeAny>).unwrap()
-
-      switch (strippedNullableSchema._def.typeName) {
-        case z.ZodFirstPartyTypeKind.ZodObject:
-          return options.instantiate_Nullable_Objects ? schemaDefaults(strippedNullableSchema, options) : undefined
-
-        case z.ZodFirstPartyTypeKind.ZodArray:
-          return options.instantiate_Nullable_Objects ? schemaDefaults(strippedNullableSchema, options) : undefined
-      }
-
-      return options.instantiate_Nullable_PrimitiveProps ? schemaDefaults(strippedNullableSchema, options) : undefined
-
-    case z.ZodFirstPartyTypeKind.ZodUndefined:
+  const getDef = (s: any) => {
+    if (s === undefined) {
+      console.warn("Couldn't find schema definition... because schema was undefined...")
       return undefined
+    }
+    const typeDef = s?._zod?.def ?? s?.def ?? s?._def
+    if (typeDef?.type) return typeDef
 
-    case z.ZodFirstPartyTypeKind.ZodUnknown:
-      return undefined
+    if (s.type === 'pipe') {
+      return s.in.def
+    }
+  }
+  const getType = (s: any) => {
+    const def = getDef(s)
+    return def?.type
+  }
 
-    case z.ZodFirstPartyTypeKind.ZodArray: {
-      const arraySchema = schema as z.ZodArray<any>
-      const elementSchema = arraySchema.element
+  const unwrapInner = (s: any) => {
+    const def = getDef(s)
+    return def?.innerType ?? def?.inner ?? def?.schema
+  }
 
-      const elements = Array.from({ length: options.overrideArraySize ?? DEFAULT_ARRAY_SIZE }).map(() => schemaDefaults(elementSchema, options)) as z.TypeOf<Schema>
-      return elements
+  const asChecks = (s: any): any[] => {
+    const def = getDef(s)
+    return Array.isArray(def?.checks) ? def.checks : []
+  }
+
+  const isUUIDish = (s: any): boolean => {
+    const def = getDef(s)
+
+    // some string-format schemas (e.g. z.uuid()) may encode the format on the schema def.
+    if (typeof def?.format === 'string' && def.format.toLowerCase() === 'uuid') return true
+
+    // Otherwise go over attached checks
+    for (const chk of asChecks(s)) {
+      const cdef = chk?._zod?.def ?? chk?.def ?? chk?._def
+      if (!cdef) continue
+
+      // Common Zod v4 pattern: string formats are checks with check === "string_format" and format === "uuid".
+      if (cdef.check === 'string_format' && typeof cdef.format === 'string' && cdef.format.toLowerCase() === 'uuid') return true
+
+      // fallbacks for custom / transitional shapes.
+      if (cdef.check === 'uuid') return true
+      if (cdef.kind === 'uuid') return true
     }
 
-    case z.ZodFirstPartyTypeKind.ZodOptional:
-      const strippedOptionalSchema = (schema as z.ZodOptional<ZodTypeAny>).unwrap()
+    return false
+  }
 
-      switch (strippedOptionalSchema._def.typeName) {
-        case z.ZodFirstPartyTypeKind.ZodObject:
-          return options.instantiate_Optional_Objects ? schemaDefaults(strippedOptionalSchema, options) : undefined
+  const type = getType(schema)
 
-        case z.ZodFirstPartyTypeKind.ZodArray:
-          return options.instantiate_Optional_Objects ? schemaDefaults(strippedOptionalSchema, options) : undefined
+  switch (type) {
+    case 'default': {
+      const def = getDef(schema)
+      const dv = def?.defaultValue
+      // defaultValue may be a function
+      return (typeof dv === 'function' ? dv() : dv) as z.output<Schema>
+    }
+
+    case 'object': {
+      const def = getDef(schema)
+      const shape = (schema as any).shape ?? def?.shape
+
+      // Most commonly: a record of { [key]: schema }
+      if (shape && typeof shape === 'object' && !Array.isArray(shape)) {
+        return Object.fromEntries(Object.entries(shape).map(([key, value]) => [key, schemaDefaults(value as any, options)])) as z.output<Schema>
       }
 
-      return options.instantiate_Optional_PrimitiveProps ? schemaDefaults(strippedOptionalSchema, options) : undefined
+      // preemptive fallback: some internal structures may be an array
+      if (Array.isArray(shape)) {
+        return Object.fromEntries(shape.map((p: any) => [p.key, schemaDefaults(p.value, options)])) as z.output<Schema>
+      }
 
-    case z.ZodFirstPartyTypeKind.ZodNumber:
-      const checks = schema._def.checks
+      return {} as z.output<Schema>
+    }
+
+    case 'string': {
+      let value = ''
+      if (options.stripDefaultValues) return value as z.output<Schema>
+
+      if (isUUIDish(schema)) value = getUUID()
+
+      return value as z.output<Schema>
+    }
+
+    case 'null':
+      return null as z.output<Schema>
+
+    case 'nullable': {
+      const inner = unwrapInner(schema)
+      const innerType = getType(inner)
+
+      if (innerType === 'object' || innerType === 'array') {
+        return (options.instantiate_Nullable_Objects ? schemaDefaults(inner, options) : undefined) as z.output<Schema>
+      }
+
+      return (options.instantiate_Nullable_PrimitiveProps ? schemaDefaults(inner, options) : undefined) as z.output<Schema>
+    }
+
+    case 'optional': {
+      const inner = unwrapInner(schema)
+      const innerType = getType(inner)
+
+      if (innerType === 'object' || innerType === 'array') {
+        return (options.instantiate_Optional_Objects ? schemaDefaults(inner, options) : undefined) as z.output<Schema>
+      }
+
+      return (options.instantiate_Optional_PrimitiveProps ? schemaDefaults(inner, options) : undefined) as z.output<Schema>
+    }
+
+    case 'undefined':
+    case 'unknown':
+    case 'any':
+      console.log('unknown schema type...')
+      return undefined as z.output<Schema>
+
+    case 'array': {
+      const def = getDef(schema)
+      const element = (schema as any).element ?? def?.element ?? def?.items
+      const len = options.overrideArraySize ?? DEFAULT_ARRAY_SIZE
+
+      const elements = Array.from({ length: len }).map(() => schemaDefaults(element, options))
+      return elements as z.output<Schema>
+    }
+
+    case 'number': {
       const numberConstraints = {
         min: 0,
         max: 100,
       }
 
-      checks.forEach((check: any) => {
-        if (check.kind === 'min') numberConstraints.min = check.value + (check.inclusive ? 0 : 1)
-        if (check.kind === 'max') numberConstraints.max = check.value - (check.inclusive ? 0 : 1)
-      })
+      for (const chk of asChecks(schema)) {
+        const cdef = chk?._zod?.def ?? chk?.def ?? chk?._def
+        if (!cdef) continue
 
-      if (!options.generateRandomNumbers) {
-        return numberConstraints.min
+        if (cdef.check === 'greater_than' && typeof cdef.value === 'number') {
+          numberConstraints.min = cdef.value + (cdef.inclusive ? 0 : 1)
+        }
+        if (cdef.check === 'less_than' && typeof cdef.value === 'number') {
+          numberConstraints.max = cdef.value - (cdef.inclusive ? 0 : 1)
+        }
       }
 
-      return Math.floor(((Math.random() * 100) % Math.abs(numberConstraints.max - numberConstraints.min)) + numberConstraints.min) as z.TypeOf<Schema>
+      if (!options.generateRandomNumbers) {
+        return numberConstraints.min as z.output<Schema>
+      }
 
-    case z.ZodFirstPartyTypeKind.ZodBoolean:
-      return false
+      const span = Math.abs(numberConstraints.max - numberConstraints.min)
+      if (span === 0) return numberConstraints.min as z.output<Schema>
 
-    case z.ZodFirstPartyTypeKind.ZodAny:
-      return undefined
-
-    case z.ZodFirstPartyTypeKind.ZodCatch:
-      return schema._def.catchValue.call(null, {} as any)
-
-    case z.ZodFirstPartyTypeKind.ZodEffects:
-      return schemaDefaults((schema as any)._def.schema, options)
-
-    case z.ZodFirstPartyTypeKind.ZodUnion: {
-      const unionSchema = schema as z.ZodUnion<any>
-      const unionOptions = unionSchema._def.options
-
-      const randomOptionIndex = Math.floor(Math.random() * unionOptions.length)
-      return schemaDefaults(unionOptions[randomOptionIndex], options)
+      return Math.floor(((Math.random() * 100) % span) + numberConstraints.min) as unknown as z.output<Schema>
     }
 
-    case z.ZodFirstPartyTypeKind.ZodDate:
-      return new Date()
+    case 'boolean':
+      return false as z.output<Schema>
 
-    case z.ZodFirstPartyTypeKind.ZodLiteral: {
-      return schema._def.value
+    case 'catch': {
+      const def = getDef(schema)
+      const cv = def?.catchValue
+      return (typeof cv === 'function' ? cv.call(null, {} as any) : cv) as z.output<Schema>
     }
 
-    case z.ZodFirstPartyTypeKind.ZodEnum: {
-      const enumSchema = schema as z.ZodEnum<any>
-      const enumValues = enumSchema._def.values
-      const randomIndex = Math.floor(Math.random() * enumValues.length)
-      return enumValues[randomIndex]
+    case 'transform': {
+      const inner = unwrapInner(schema)
+      return schemaDefaults(inner, options) as z.output<Schema>
     }
 
-    case z.ZodFirstPartyTypeKind.ZodTuple: {
-      const tupleSchema = schema as z.ZodTuple<any>
-      const tupleItems = tupleSchema._def.items
-      return tupleItems.map((item: ZodTypeAny) => schemaDefaults(item, options)) as unknown as z.TypeOf<Schema>
+    case 'pipe': {
+      const inner = unwrapPipe(schema as Any)
+      return schemaDefaults(inner, options) as z.output<Schema>
     }
 
-    case z.ZodFirstPartyTypeKind.ZodIntersection: {
-      const intersectionSchema = schema as z.ZodIntersection<ZodTypeAny, ZodTypeAny>
-      const leftDefaults = schemaDefaults(intersectionSchema._def.left, options)
-      const rightDefaults = schemaDefaults(intersectionSchema._def.right, options)
-      // Merge the left and right results (right properties override left if overlapping)
-      return { ...leftDefaults, ...rightDefaults } as z.TypeOf<Schema>
-    }
-
-    case (z.ZodFirstPartyTypeKind as any).ZodDiscriminatedUnion: {
-      // The discriminated union internally stores a tuple of options just like a union.
-      const discUnion = schema as any // ZodDiscriminatedUnion<any, any>
-      const optionsArr = discUnion._def.options
+    case 'union': {
+      const def = getDef(schema)
+      const optionsArr: any[] = def?.options ?? def?.elements ?? []
       const randomOptionIndex = Math.floor(Math.random() * optionsArr.length)
-      return schemaDefaults(optionsArr[randomOptionIndex], options)
+      return schemaDefaults(optionsArr[randomOptionIndex], options) as z.output<Schema>
     }
+
+    case 'discriminated_union': {
+      const def = getDef(schema)
+      const optionsArr: any[] = def?.options ?? def?.elements ?? []
+      const randomOptionIndex = Math.floor(Math.random() * optionsArr.length)
+      return schemaDefaults(optionsArr[randomOptionIndex], options) as z.output<Schema>
+    }
+
+    case 'date':
+      return new Date() as z.output<Schema>
+
+    case 'literal': {
+      const def = getDef(schema)
+      return def?.value as z.output<Schema>
+    }
+
+    case 'enum': {
+      const def = getDef(schema)
+      const values: any[] = def?.values ?? def?.options ?? def?.entries ?? []
+      const randomIndex = Math.floor(Math.random() * values.length)
+      return values[randomIndex] as z.output<Schema>
+    }
+
+    case 'tuple': {
+      const def = getDef(schema)
+      const items: any[] = def?.items ?? def?.prefixItems ?? []
+      return items.map((item: any) => schemaDefaults(item, options)) as unknown as z.output<Schema>
+    }
+
+    case 'intersection': {
+      const def = getDef(schema)
+      const left = def?.left
+      const right = def?.right
+      const leftDefaults = schemaDefaults(left, options)
+      const rightDefaults = schemaDefaults(right, options)
+      return { ...(leftDefaults as any), ...(rightDefaults as any) } as z.output<Schema>
+    }
+
+    // wrappers that can appear during composition
+    case 'readonly':
+    case 'nonoptional': {
+      const inner = unwrapInner(schema)
+      return schemaDefaults(inner, options) as z.output<Schema>
+    }
+
+    case undefined:
+      console.log('type is undefined...', type)
+      return undefined as z.output<Schema>
 
     default:
-      throw new Error(`[SchemaDefaults]: Unsupported type ${(schema as any)._def.typeName}`)
+      console.log(type)
+      throw new Error(`[SchemaDefaults]: Unsupported type ${String(type)}`)
   }
+}
+
+function unwrapPipe<TSchema extends z.ZodPipe>(pipedSchema: TSchema): TSchema['in'] {
+  return pipedSchema.in
 }

--- a/src/schemas/utils/schemaDefaults.ts
+++ b/src/schemas/utils/schemaDefaults.ts
@@ -238,7 +238,7 @@ export default function schemaDefaults<Schema extends z.ZodTypeAny>(schema: Sche
 
     case 'literal': {
       const def = getDef(schema)
-      return def?.value as z.output<Schema>
+      return def?.values?.at(0) as z.output<Schema>
     }
 
     case 'enum': {

--- a/src/schemas/utils/schemaDefaults.ts
+++ b/src/schemas/utils/schemaDefaults.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod'
 import { getUUID } from '@/src/lib/Shared/getUUID'
-import getKeys from '@/src/lib/Shared/Keys'
 import { Any } from '@/types'
 
 /**
@@ -244,7 +243,9 @@ export default function schemaDefaults<Schema extends z.ZodTypeAny>(schema: Sche
     case 'enum': {
       const def = getDef(schema)
       // def.entries holds the enum values as an object e.g. {male: 'male', female: 'female' }
-      const values: any[] = (def?.values ?? def?.options ?? def?.entries) ? getKeys(def.entries) : []
+      const values: any[] = (def?.values ?? def?.options ?? def?.entries) ? Object.values(def.entries) : []
+      if (values.length === 0) return undefined as z.output<Schema>
+
       const randomIndex = Math.round((Math.random() * values.length) % (values.length - 1))
       return values[randomIndex] as z.output<Schema>
     }

--- a/src/schemas/utils/schemaDefaults.ts
+++ b/src/schemas/utils/schemaDefaults.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod'
 import { getUUID } from '@/src/lib/Shared/getUUID'
+import getKeys from '@/src/lib/Shared/Keys'
 import { Any } from '@/types'
 
 /**
@@ -234,8 +235,9 @@ export default function schemaDefaults<Schema extends z.ZodTypeAny>(
 
     case 'enum': {
       const def = getDef(schema)
-      const values: any[] = def?.values ?? def?.options ?? def?.entries ?? []
-      const randomIndex = Math.floor(Math.random() * values.length)
+      // def.entries holds the enum values as an object e.g. {male: 'male', female: 'female' }
+      const values: any[] = (def?.values ?? def?.options ?? def?.entries) ? getKeys(def.entries) : []
+      const randomIndex = Math.round((Math.random() * values.length) % (values.length - 1))
       return values[randomIndex] as z.output<Schema>
     }
 

--- a/src/schemas/utils/schemaUtilities.ts
+++ b/src/schemas/utils/schemaUtilities.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { SafeParseReturnType, z } from 'zod'
+import { z } from 'zod'
 import schemaDefaults, { SchemaOptionalProps } from '@/schemas/utils/schemaDefaults'
 import { stripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 
@@ -30,7 +30,7 @@ export function schemaUtilities<Schema extends z.ZodTypeAny>(schema: Schema) {
    * Safely parses an object against its schema and returns the result of the zod.safeParse method
    * @param object - The object to be parsed / validated
    */
-  const safeParse = (object: any): z.SafeParseReturnType<any, z.output<Schema>> => stripZodDefault(schema).safeParse(object) as SafeParseReturnType<any, z.output<Schema>>
+  const safeParse = (object: any): z.ZodSafeParseResult<z.output<Schema>> => stripZodDefault(schema).safeParse(object)
 
   return {
     instantiate,

--- a/src/schemas/utils/schemaUtilities.ts
+++ b/src/schemas/utils/schemaUtilities.ts
@@ -14,13 +14,13 @@ export function schemaUtilities<Schema extends z.ZodTypeAny>(schema: Schema) {
    * Validates a given object against a given schema. Throws an error if the object is invalid
    * @param object - The object to be validated
    */
-  const validate = (object: any): z.infer<Schema> | never => stripZodDefault(schema).parse(object)
+  const validate = (object: any): z.output<Schema> | never => stripZodDefault(schema).parse(object)
 
   /**
    * Returns a dummy object based on a given schema
    * @param options - Defines how optional properties should be handled in terms of their instantiation (undefined / value)
    */
-  function instantiate(options?: SchemaOptionalProps & { validate?: boolean }): z.infer<Schema> {
+  function instantiate(options?: SchemaOptionalProps & { validate?: boolean }): z.output<Schema> {
     const dummyData = schemaDefaults(options?.stripDefaultValues ? stripZodDefault(schema) : schema, options)
     //* ensure that generated dummy data satisfies with schema constraints
     return options?.validate ? validate(dummyData) : dummyData
@@ -30,7 +30,7 @@ export function schemaUtilities<Schema extends z.ZodTypeAny>(schema: Schema) {
    * Safely parses an object against its schema and returns the result of the zod.safeParse method
    * @param object - The object to be parsed / validated
    */
-  const safeParse = (object: any): z.SafeParseReturnType<any, z.infer<Schema>> => stripZodDefault(schema).safeParse(object) as SafeParseReturnType<any, z.infer<Schema>>
+  const safeParse = (object: any): z.SafeParseReturnType<any, z.output<Schema>> => stripZodDefault(schema).safeParse(object) as SafeParseReturnType<any, z.output<Schema>>
 
   return {
     instantiate,

--- a/src/schemas/utils/schemaUtilities.ts
+++ b/src/schemas/utils/schemaUtilities.ts
@@ -21,7 +21,8 @@ export function schemaUtilities<Schema extends z.ZodTypeAny>(schema: Schema) {
    * @param options - Defines how optional properties should be handled in terms of their instantiation (undefined / value)
    */
   function instantiate(options?: SchemaOptionalProps & { validate?: boolean }): z.output<Schema> {
-    const dummyData = schemaDefaults(options?.stripDefaultValues ? stripZodDefault(schema) : schema, options)
+    const dummyData = schemaDefaults(options?.stripDefaultValues ? stripZodDefault(schema) : schema, options) as z.output<Schema>
+
     //* ensure that generated dummy data satisfies with schema constraints
     return options?.validate ? validate(dummyData) : dummyData
   }

--- a/src/schemas/utils/stripEffects.ts
+++ b/src/schemas/utils/stripEffects.ts
@@ -125,9 +125,8 @@ export function stripEffects<T extends z.ZodTypeAny>(schema: T, opts: StripOptio
     if (type === 'default') {
       const def = getDef(s)
       const inner = unwrapInner(s)
-      const base = go(inner)
-      const dv = def?.defaultValue
-      const out = (base as any).default(typeof dv === 'function' ? dv() : dv)
+      const stripped = go(inner)
+      const out = stripped.default(def?.defaultValue)
       memo.set(s, out)
       return out
     }

--- a/src/schemas/utils/stripEffects.ts
+++ b/src/schemas/utils/stripEffects.ts
@@ -21,21 +21,27 @@ export type StripEffects<T extends z.ZodTypeAny> =
           ? z.ZodCatch<StripEffects<U>>
           : T extends z.ZodReadonly<infer U extends z.ZodTypeAny>
             ? z.ZodReadonly<StripEffects<U>>
-            : T extends z.ZodObject<infer Shape extends z.ZodRawShape, infer Config>
-              ? z.ZodObject<{ [K in keyof Shape]: Shape[K] extends z.ZodTypeAny ? StripEffects<Shape[K]> : Shape[K] }, Config>
-              : T extends z.ZodArray<infer U extends z.ZodTypeAny>
-                ? z.ZodArray<StripEffects<U>>
-                : T extends z.ZodTuple<infer Items>
-                  ? Items extends readonly z.ZodTypeAny[]
-                    ? z.ZodTuple<MapTuple<Items>>
-                    : T
-                  : T extends z.ZodUnion<infer Options>
-                    ? Options extends readonly z.ZodTypeAny[]
-                      ? z.ZodUnion<MapTuple<Options>>
+            : T extends z.ZodPipe<infer In, infer Out>
+              ? In extends z.ZodTypeAny
+                ? StripEffects<In>
+                : Out extends z.ZodTypeAny
+                  ? StripEffects<Out>
+                  : T
+              : T extends z.ZodObject<infer Shape extends z.ZodRawShape, infer Config>
+                ? z.ZodObject<{ [K in keyof Shape]: Shape[K] extends z.ZodTypeAny ? StripEffects<Shape[K]> : Shape[K] }, Config>
+                : T extends z.ZodArray<infer U extends z.ZodTypeAny>
+                  ? z.ZodArray<StripEffects<U>>
+                  : T extends z.ZodTuple<infer Items>
+                    ? Items extends readonly z.ZodTypeAny[]
+                      ? z.ZodTuple<MapTuple<Items>>
                       : T
-                    : T extends z.ZodIntersection<infer A extends z.ZodTypeAny, infer B extends z.ZodTypeAny>
-                      ? z.ZodIntersection<StripEffects<A>, StripEffects<B>>
-                      : T
+                    : T extends z.ZodUnion<infer Options>
+                      ? Options extends readonly z.ZodTypeAny[]
+                        ? z.ZodUnion<MapTuple<Options>>
+                        : T
+                      : T extends z.ZodIntersection<infer A extends z.ZodTypeAny, infer B extends z.ZodTypeAny>
+                        ? z.ZodIntersection<StripEffects<A>, StripEffects<B>>
+                        : T
 
 export function stripEffects<T extends z.ZodTypeAny>(schema: T, opts: StripOptions = {}): StripEffects<T> {
   const strip = opts.strip ?? 'effects-only'

--- a/src/schemas/utils/stripEffects.ts
+++ b/src/schemas/utils/stripEffects.ts
@@ -178,6 +178,8 @@ export function stripEffects<T extends z.ZodTypeAny>(schema: T, opts: StripOptio
         // todo re-apply non-effects like (min, max) note that def.checks includes refinments as `type: 'custom'`
         // for (const check of def?.checks ?? []) out = out.check(check)
 
+        console.warn('Warning stripping all checks and effects from array.')
+
         memo.set(s, out)
         return out
       }

--- a/src/schemas/utils/stripEffects.ts
+++ b/src/schemas/utils/stripEffects.ts
@@ -1,278 +1,319 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-import * as z from 'zod'
-import { Any } from '@/types'
+/* eslint-disable @typescript-eslint/ban-ts-comment,@typescript-eslint/no-explicit-any */
+import { z } from 'zod'
 
 type StripOptions = {
   /** Remove only refinements/transforms (effects), or also drop built-in checks like .min/.max/.regex */
   strip?: 'effects-only' | 'all'
-  /** Omit these keys from ALL ZodObject shapes (e.g., ["correctness"]) */
+  /** Omit these keys from ALL (nested) ZodObject (e.g., ["correctness"]) */
   omitKeys?: readonly string[]
 }
 
-export type StripEffects<T extends z.ZodTypeAny, OmitKeys extends readonly PropertyKey[] = [], Mode extends 'effects-only' | 'all' = 'effects-only'> =
-  // Unwrap effects
-  T extends z.ZodEffects<infer U, Any, Any>
-    ? StripEffects<U, OmitKeys, Mode>
-    : // Preserve wrappers, relax inner
-      T extends z.ZodOptional<infer U>
-      ? z.ZodOptional<StripEffects<U, OmitKeys, Mode>>
-      : T extends z.ZodNullable<infer U>
-        ? z.ZodNullable<StripEffects<U, OmitKeys, Mode>>
-        : T extends z.ZodDefault<infer U>
-          ? z.ZodDefault<StripEffects<U, OmitKeys, Mode>>
-          : T extends z.ZodCatch<infer U>
-            ? z.ZodCatch<StripEffects<U, OmitKeys, Mode>>
-            : T extends z.ZodReadonly<infer U>
-              ? z.ZodReadonly<StripEffects<U, OmitKeys, Mode>>
-              : // Objects (omit keys + recurse)
-                T extends z.ZodObject<infer Shape, infer UnknownKeys, infer Catchall, Any, Any>
-                ? z.ZodObject<
-                    {
-                      [K in keyof Shape as K extends OmitKeys[number] ? never : K]: Shape[K] extends z.ZodTypeAny ? StripEffects<Shape[K], OmitKeys, Mode> : Shape[K]
-                    },
-                    UnknownKeys,
-                    Catchall extends z.ZodTypeAny ? StripEffects<Catchall, OmitKeys, Mode> : Catchall
-                  >
-                : // Arrays / Tuples
-                  T extends z.ZodArray<infer U, infer Card>
-                  ? z.ZodArray<StripEffects<U, OmitKeys, Mode>, Card>
-                  : T extends z.ZodTuple<infer Items, infer Rest>
-                    ? z.ZodTuple<
-                        //@ts-expect-error
-                        { [I in keyof Items]: Items[I] extends z.ZodTypeAny ? StripEffects<Items[I], OmitKeys, Mode> : Items[I] },
-                        Rest extends z.ZodTypeAny ? StripEffects<Rest, OmitKeys, Mode> : Rest
-                      >
-                    : // Records / Maps / Sets
-                      T extends z.ZodRecord<infer K, infer V>
-                      ? //@ts-expect-error
-                        z.ZodRecord<StripEffects<K, OmitKeys, Mode>, StripEffects<V, OmitKeys, Mode>>
-                      : T extends z.ZodMap<infer K, infer V>
-                        ? z.ZodMap<StripEffects<K, OmitKeys, Mode>, StripEffects<V, OmitKeys, Mode>>
-                        : T extends z.ZodSet<infer V>
-                          ? z.ZodSet<StripEffects<V, OmitKeys, Mode>>
-                          : // Unions / Discriminated unions / Intersections
-                            T extends z.ZodUnion<infer Options>
-                            ? z.ZodUnion<{ [I in keyof Options]: Options[I] extends z.ZodTypeAny ? StripEffects<Options[I], OmitKeys, Mode> : Options[I] }>
-                            : T extends z.ZodDiscriminatedUnion<infer Disc, infer Options>
-                              ? //@ts-expect-error
-                                z.ZodDiscriminatedUnion<Disc, { [I in keyof Options]: Options[I] extends z.ZodTypeAny ? StripEffects<Options[I], OmitKeys, Mode> : Options[I] }>
-                              : T extends z.ZodIntersection<infer A, infer B>
-                                ? z.ZodIntersection<StripEffects<A, OmitKeys, Mode>, StripEffects<B, OmitKeys, Mode>>
-                                : // Lazy / Promise / Pipeline
-                                  T extends z.ZodLazy<infer U>
-                                  ? z.ZodLazy<StripEffects<U, OmitKeys, Mode>>
-                                  : T extends z.ZodPromise<infer U>
-                                    ? z.ZodPromise<StripEffects<U, OmitKeys, Mode>>
-                                    : T extends z.ZodPipeline<infer In, infer Out>
-                                      ? z.ZodPipeline<StripEffects<In, OmitKeys, Mode>, StripEffects<Out, OmitKeys, Mode>>
-                                      : // Literals / Enums
-                                        T extends z.ZodLiteral<infer V>
-                                        ? z.ZodLiteral<V>
-                                        : T extends z.ZodEnum<infer Values>
-                                          ? z.ZodEnum<Values>
-                                          : T extends z.ZodNativeEnum<infer E>
-                                            ? z.ZodNativeEnum<E>
-                                            : // Branding (kept, since your runtime doesn't strip it)
-                                              T extends z.ZodBranded<infer U, infer B>
-                                              ? z.ZodBranded<StripEffects<U, OmitKeys, Mode>, B>
-                                              : // Primitives & other structure-only nodes — unchanged
-                                                T
+type MapTuple<T extends readonly z.ZodTypeAny[]> = { [K in keyof T]: StripEffects<T[K]> }
 
-export function stripEffects<T extends z.ZodTypeAny, OmitKeys extends readonly PropertyKey[] = [], Mode extends 'effects-only' | 'all' = 'effects-only'>(
-  schema: T,
-  opts: StripOptions = {},
-): StripEffects<T, OmitKeys, Mode> {
+export type StripEffects<T extends z.ZodTypeAny> =
+  T extends z.ZodDefault<infer U extends z.ZodTypeAny>
+    ? z.ZodDefault<StripEffects<U>>
+    : T extends z.ZodOptional<infer U extends z.ZodTypeAny>
+      ? z.ZodOptional<StripEffects<U>>
+      : T extends z.ZodNullable<infer U extends z.ZodTypeAny>
+        ? z.ZodNullable<StripEffects<U>>
+        : T extends z.ZodCatch<infer U extends z.ZodTypeAny>
+          ? z.ZodCatch<StripEffects<U>>
+          : T extends z.ZodReadonly<infer U extends z.ZodTypeAny>
+            ? z.ZodReadonly<StripEffects<U>>
+            : T extends z.ZodObject<infer Shape extends z.ZodRawShape, infer Config>
+              ? z.ZodObject<{ [K in keyof Shape]: Shape[K] extends z.ZodTypeAny ? StripEffects<Shape[K]> : Shape[K] }, Config>
+              : T extends z.ZodArray<infer U extends z.ZodTypeAny>
+                ? z.ZodArray<StripEffects<U>>
+                : T extends z.ZodTuple<infer Items>
+                  ? Items extends readonly z.ZodTypeAny[]
+                    ? z.ZodTuple<MapTuple<Items>>
+                    : T
+                  : T extends z.ZodUnion<infer Options>
+                    ? Options extends readonly z.ZodTypeAny[]
+                      ? z.ZodUnion<MapTuple<Options>>
+                      : T
+                    : T extends z.ZodIntersection<infer A extends z.ZodTypeAny, infer B extends z.ZodTypeAny>
+                      ? z.ZodIntersection<StripEffects<A>, StripEffects<B>>
+                      : T
+
+export function stripEffects<T extends z.ZodTypeAny>(schema: T, opts: StripOptions = {}): StripEffects<T> {
   const strip = opts.strip ?? 'effects-only'
   const omitSet = new Set(opts.omitKeys ?? [])
   const memo = new WeakMap<z.ZodTypeAny, z.ZodTypeAny>()
 
-  const isV4 = (s: Any) => s && typeof s === 'object' && '_zod' in s
-  if (isV4(schema)) {
-    throw new Error('stripEffects: This utility expects Zod v3 schemas. You passed a v4 schema.')
+  const getDef = (s: any) => s?._zod?.def ?? s?.def ?? s?._def
+  const getType = (s: any): string | undefined => {
+    const def = getDef(s)
+    return typeof def?.type === 'string' ? def.type : undefined
+  }
+  const unwrapInner = (s: any) => {
+    const def = getDef(s)
+    return def?.innerType ?? def?.inner ?? def?.schema
+  }
+
+  const copyUnknownKeysAndCatchall = (src: any, dest: any) => {
+    const def = getDef(src)
+    // unknown key policy
+    const uk = def?.unknownKeys
+    if (uk === 'passthrough' && typeof dest.passthrough === 'function') dest = dest.passthrough()
+    if (uk === 'strict' && typeof dest.strict === 'function') dest = dest.strict()
+
+    // catchall
+    const catchall = def?.catchall
+    if (catchall && getType(catchall) !== 'never' && typeof dest.catchall === 'function') {
+      dest = dest.catchall(go(catchall))
+    }
+
+    return dest
   }
 
   const go = (s: z.ZodTypeAny): z.ZodTypeAny => {
-    if (memo.has(s)) return memo.get(s)!
+    const cached = memo.get(s)
+    if (cached) return cached
 
-    // Effects (refine/superRefine/transform/preprocess) — unwrap
-    if (s instanceof (z as Any).ZodEffects) {
-      const inner = (s as Any)._def.schema as z.ZodTypeAny
+    const type = getType(s)
+
+    if (type === 'transform') {
+      const inner = unwrapInner(s)
       const out = go(inner)
       memo.set(s, out)
       return out
     }
 
-    // Optional / Nullable / Default / Catch / Readonly wrappers — preserve wrapper, relax inner
-    if (s instanceof z.ZodOptional) {
-      const out = go((s as Any)._def.innerType).optional()
-      memo.set(s, out)
-      return out
-    }
-    if (s instanceof z.ZodNullable) {
-      const out = go((s as Any)._def.innerType).nullable()
-      memo.set(s, out)
-      return out
-    }
-    if ((z as Any).ZodDefault && s instanceof (z as Any).ZodDefault) {
-      const def = (s as Any)._def
-      const out = (go(def.innerType) as Any).default(def.defaultValue())
-      memo.set(s, out)
-      return out
-    }
-    if ((z as Any).ZodCatch && s instanceof (z as Any).ZodCatch) {
-      const out = (go((s as Any)._def.innerType) as Any).catch((s as Any)._def.catchValue)
-      memo.set(s, out)
-      return out
-    }
-    if ((z as Any).ZodReadonly && s instanceof (z as Any).ZodReadonly) {
-      const out = (go((s as Any)._def.innerType) as Any).readonly()
-      memo.set(s, out)
-      return out
-    }
-
-    // Objects
-    if (s instanceof z.ZodObject) {
-      const shape: Record<string, z.ZodTypeAny> = {}
-      for (const [k, v] of Object.entries((s as Any).shape)) {
-        if (!omitSet.has(k)) shape[k] = go(v as z.ZodTypeAny)
+    if (type === 'pipe') {
+      const def = getDef(s)
+      const input = def?.in ?? def?.input ?? def?.left
+      const output = def?.out ?? def?.output ?? def?.right ?? def?.to
+      if (input && output && typeof (z as any).pipe === 'function') {
+        const out = go(input)
+        memo.set(s, out)
+        return out
       }
-      let obj = z.object(shape)
 
-      // Preserve unknown key policy & catchall
-      const def = (s as Any)._def
-      //@ts-expect-error
-      if (def.unknownKeys === 'passthrough') obj = obj.passthrough()
-      //@ts-expect-error
-      if (def.unknownKeys === 'strict') obj = obj.strict()
-      if (def.catchall && !(def.catchall instanceof z.ZodNever)) {
-        obj = obj.catchall(go(def.catchall))
+      if (output) {
+        const out = go(output)
+        memo.set(s, out)
+        return out
       }
-      memo.set(s, obj)
-      return obj
-    }
-
-    // Arrays (drop min/max/length by recreating clean array)
-    if (s instanceof z.ZodArray) {
-      const out = z.array(go((s as Any)._def.type))
+      const inner = unwrapInner(s)
+      const out = go(inner)
       memo.set(s, out)
       return out
     }
 
-    // Tuples
-    if (s instanceof z.ZodTuple) {
-      const def = (s as Any)._def
-      const items = (def.items as z.ZodTypeAny[]).map(go)
-      let out = z.tuple(items as Any)
-      if (def.rest) out = (out as Any).rest(go(def.rest))
+    if (type === 'optional') {
+      const inner = unwrapInner(s)
+      const out = go(inner).optional()
       memo.set(s, out)
       return out
     }
 
-    // Records / Maps / Sets
-    if (s instanceof z.ZodRecord) {
-      const def = (s as Any)._def
-      const out = z.record(go(def.keyType) as Any, go(def.valueType))
-      memo.set(s, out)
-      return out
-    }
-    if (s instanceof z.ZodMap) {
-      const def = (s as Any)._def
-      const out = z.map(go(def.keyType), go(def.valueType))
-      memo.set(s, out)
-      return out
-    }
-    if (s instanceof z.ZodSet) {
-      const out = z.set(go((s as Any)._def.valueType))
+    if (type === 'nullable') {
+      const inner = unwrapInner(s)
+      const out = go(inner).nullable()
       memo.set(s, out)
       return out
     }
 
-    // Unions / Discriminated unions / Intersections
-    if (s instanceof z.ZodUnion) {
-      const out = z.union(((s as Any)._def.options as z.ZodTypeAny[]).map(go) as Any)
-      memo.set(s, out)
-      return out
-    }
-    if ((z as Any).ZodDiscriminatedUnion && s instanceof (z as Any).ZodDiscriminatedUnion) {
-      const def = (s as Any)._def
-      const out = (z as Any).discriminatedUnion(def.discriminator, def.options.map(go))
-      memo.set(s, out)
-      return out
-    }
-    if (s instanceof z.ZodIntersection) {
-      const def = (s as Any)._def
-      const out = z.intersection(go(def.left), go(def.right))
+    if (type === 'default') {
+      const def = getDef(s)
+      const inner = unwrapInner(s)
+      const base = go(inner)
+      const dv = def?.defaultValue
+      const out = (base as any).default(typeof dv === 'function' ? dv() : dv)
       memo.set(s, out)
       return out
     }
 
-    // Lazy / Promise / Pipeline (.pipe)
-    if (s instanceof z.ZodLazy) {
-      const out = z.lazy(() => go((s as Any)._def.getter()))
-      memo.set(s, out)
-      return out
-    }
-    if (s instanceof z.ZodPromise) {
-      const out = z.promise(go((s as Any)._def.type))
-      memo.set(s, out)
-      return out
-    }
-    if ((z as Any).ZodPipeline && s instanceof (z as Any).ZodPipeline) {
-      const def = (s as Any)._def
-      const out = (z as Any).ZodPipeline.create({ in: go(def.in), out: go(def.out) })
+    if (type === 'catch') {
+      const def = getDef(s)
+      const inner = unwrapInner(s)
+      const base = go(inner)
+      const out = (base as any).catch(def?.catchValue)
       memo.set(s, out)
       return out
     }
 
-    // Literals / Enums
-    if (s instanceof z.ZodLiteral) {
-      const out = z.literal((s as Any)._def.value)
-      memo.set(s, out)
-      return out
-    }
-    if (s instanceof z.ZodEnum) {
-      const vals = [...(s as Any)._def.values] as [string, ...string[]]
-      const out = z.enum(vals)
-      memo.set(s, out)
-      return out
-    }
-    if (s instanceof z.ZodNativeEnum) {
-      const out = z.nativeEnum((s as Any)._def.values)
+    if (type === 'readonly') {
+      const inner = unwrapInner(s)
+      const base = go(inner)
+      const out = (base as any).readonly()
       memo.set(s, out)
       return out
     }
 
-    // Primitives (drop built-in checks only when strip === "all")
-    if (s instanceof z.ZodString) {
+    if (type === 'object') {
+      const def = getDef(s)
+      const shape = (s as any).shape ?? def?.shape
+      const newShape: Record<string, z.ZodTypeAny> = {}
+
+      if (shape && typeof shape === 'object' && !Array.isArray(shape)) {
+        for (const [k, v] of Object.entries(shape)) {
+          if (!omitSet.has(k)) newShape[k] = go(v as any)
+        }
+      } else if (Array.isArray(shape)) {
+        for (const p of shape) {
+          if (!omitSet.has(p.key)) newShape[p.key] = go(p.value)
+        }
+      }
+
+      let out: any = z.object(newShape)
+      out = copyUnknownKeysAndCatchall(s, out)
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'array') {
+      const def = getDef(s)
+      const element = (s as any).element ?? def?.element ?? def?.items
+      // Recreate a clean array => drops built-in checks (min/max/length) when strip === 'all'.
+      // If strip === 'effects-only', we keep the original array schema (but with stripped inner effects).
+      if (strip === 'effects-only') {
+        const out = s as any
+        memo.set(s, out)
+        return out
+      }
+      const out = z.array(go(element))
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'tuple') {
+      const def = getDef(s)
+      const items = (def?.items ?? def?.prefixItems ?? []) as z.ZodTypeAny[]
+      const strippedItems = items.map(go)
+      // @ts-ignore - z.tuple wants a tuple type at compile time
+      const out = z.tuple(strippedItems)
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'union') {
+      const def = getDef(s)
+      const options = (def?.options ?? def?.elements ?? []) as z.ZodTypeAny[]
+      const strippedOptions = options.map(go)
+      // @ts-ignore - z.union wants a tuple type at compile time
+      const out = z.union(strippedOptions)
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'discriminated_union') {
+      const def = getDef(s)
+      const discriminator = def?.discriminator
+      const options = (def?.options ?? def?.elements ?? []) as z.ZodTypeAny[]
+      const strippedOptions = options.map(go)
+      // Zod requires a tuple in typings; runtime accepts array.
+      const out = (z as any).discriminatedUnion(discriminator, strippedOptions)
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'intersection') {
+      const def = getDef(s)
+      const out = z.intersection(go(def?.left), go(def?.right))
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'record') {
+      const def = getDef(s)
+      const key = def?.keyType ?? def?.key
+      const value = def?.valueType ?? def?.value
+      const out = z.record(go(key) as any, go(value))
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'map') {
+      const def = getDef(s)
+      const out = z.map(go(def?.keyType), go(def?.valueType))
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'set') {
+      const def = getDef(s)
+      const out = z.set(go(def?.valueType))
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'lazy') {
+      const def = getDef(s)
+      const getter = def?.getter ?? def?.get
+      const out = z.lazy(() => go(getter()))
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'promise') {
+      const def = getDef(s)
+      const inner = def?.type ?? def?.innerType ?? unwrapInner(s)
+      const out = z.promise(go(inner))
+      memo.set(s, out)
+      return out
+    }
+
+    if (type === 'string') {
       const out = strip === 'all' ? z.string() : s
       memo.set(s, out)
       return out
     }
-    if (s instanceof z.ZodNumber) {
+    if (type === 'number') {
       const out = strip === 'all' ? z.number() : s
       memo.set(s, out)
       return out
     }
-    if (s instanceof z.ZodBigInt) {
+    if (type === 'bigint') {
       const out = strip === 'all' ? z.bigint() : s
       memo.set(s, out)
       return out
     }
-    if (s instanceof z.ZodDate) {
+    if (type === 'date') {
       const out = strip === 'all' ? z.date() : s
       memo.set(s, out)
       return out
     }
 
-    // “Structure-only” primitives — safe to return as-is
-    if (s instanceof z.ZodBoolean || s instanceof z.ZodAny || s instanceof z.ZodUnknown || s instanceof z.ZodNever || s instanceof z.ZodVoid || s instanceof z.ZodNull || s instanceof z.ZodUndefined) {
+    if (type === 'boolean') {
+      memo.set(s, strip === 'all' ? z.boolean() : s)
+      return memo.get(s)!
+    }
+    if (type === 'any') {
+      memo.set(s, z.any())
+      return memo.get(s)!
+    }
+    if (type === 'unknown') {
+      memo.set(s, z.unknown())
+      return memo.get(s)!
+    }
+    if (type === 'null') {
+      memo.set(s, z.null())
+      return memo.get(s)!
+    }
+    if (type === 'undefined') {
+      memo.set(s, z.undefined())
+      return memo.get(s)!
+    }
+    if (type === 'never') {
+      memo.set(s, z.never())
+      return memo.get(s)!
+    }
+    if (type === 'void') {
+      memo.set(s, z.void())
+      return memo.get(s)!
+    }
+
+    if (type === 'literal' || type === 'enum' || type === 'native_enum') {
       memo.set(s, s)
       return s
     }
 
-    memo.set(s, s)
+    if (s !== undefined) memo.set(s, s)
     return s
   }
 
-  return go(schema) as Any
+  return go(schema) as any
 }

--- a/src/schemas/utils/stripEffects.ts
+++ b/src/schemas/utils/stripEffects.ts
@@ -172,10 +172,12 @@ export function stripEffects<T extends z.ZodTypeAny>(schema: T, opts: StripOptio
     if (type === 'array') {
       const def = getDef(s)
       const element = (s as any).element ?? def?.element ?? def?.items
-      // Recreate a clean array => drops built-in checks (min/max/length) when strip === 'all'.
-      // If strip === 'effects-only', we keep the original array schema (but with stripped inner effects).
+
       if (strip === 'effects-only') {
-        const out = s as any
+        const out = z.array(go(element))
+        // todo re-apply non-effects like (min, max) note that def.checks includes refinments as `type: 'custom'`
+        // for (const check of def?.checks ?? []) out = out.check(check)
+
         memo.set(s, out)
         return out
       }

--- a/src/schemas/utils/stripZodDefaultValues.ts
+++ b/src/schemas/utils/stripZodDefaultValues.ts
@@ -161,10 +161,11 @@ export function stripZodDefault<Schema extends z.ZodTypeAny>(schema: Schema): St
     case 'pipe': {
       const def = getDef(schema)
       const out = def?.out ?? def?.output ?? def?.right ?? def?.to
-      if (out.type !== 'transform') return stripZodDefault(out) as StripZodDefault<Schema>
 
       const inner = unwrapPipe(schema as Any)
-      return z.pipe(stripZodDefault(inner), out) as unknown as StripZodDefault<Schema>
+      if (!out) return stripZodDefault(inner) as StripZodDefault<Schema>
+
+      return z.pipe(stripZodDefault(inner), stripZodDefault(out)) as unknown as StripZodDefault<Schema>
     }
 
     case 'intersection': {

--- a/src/schemas/utils/stripZodDefaultValues.ts
+++ b/src/schemas/utils/stripZodDefaultValues.ts
@@ -165,7 +165,7 @@ export function stripZodDefault<Schema extends z.ZodTypeAny>(schema: Schema): St
       const inner = unwrapPipe(schema as Any)
       if (!out) return stripZodDefault(inner) as StripZodDefault<Schema>
 
-      return z.pipe(stripZodDefault(inner), stripZodDefault(out)) as unknown as StripZodDefault<Schema>
+      return z.pipe(stripZodDefault(inner), out.type !== 'transform' ? stripZodDefault(out) : out) as unknown as StripZodDefault<Schema>
     }
 
     case 'intersection': {

--- a/src/schemas/utils/stripZodDefaultValues.ts
+++ b/src/schemas/utils/stripZodDefaultValues.ts
@@ -104,6 +104,7 @@ export function stripZodDefault<Schema extends z.ZodTypeAny>(schema: Schema): St
       const def = getDef(schema)
       const element = (schema as any).element ?? def?.element ?? def?.items
       const elementStripped = stripZodDefault(element)
+      console.warn('Warning stripping all checks and effects from array, while removing nested default-values.')
       return z.array(elementStripped) as StripZodDefault<Schema>
     }
 

--- a/src/schemas/utils/stripZodDefaultValues.ts
+++ b/src/schemas/utils/stripZodDefaultValues.ts
@@ -164,7 +164,7 @@ export function stripZodDefault<Schema extends z.ZodTypeAny>(schema: Schema): St
       if (out.type !== 'transform') return stripZodDefault(out) as StripZodDefault<Schema>
 
       const inner = unwrapPipe(schema as Any)
-      return stripZodDefault(inner) as StripZodDefault<Schema>
+      return z.pipe(stripZodDefault(inner), out) as unknown as StripZodDefault<Schema>
     }
 
     case 'intersection': {

--- a/src/schemas/utils/stripZodDefaultValues.ts
+++ b/src/schemas/utils/stripZodDefaultValues.ts
@@ -1,16 +1,21 @@
-/* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/ban-ts-comment */
-import { z } from 'zod'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import z from 'zod'
+import { Any } from '@/types'
 
+/**
+ * Type-level helper that unwraps ZodDefault recursively and preserves schema structure.
+ */
 type StripZodDefault<T extends z.ZodTypeAny> =
-  T extends z.ZodDefault<infer Inner>
+  // Ensure inferred schema types remain constrained to ZodTypeAny
+  T extends z.ZodDefault<infer Inner extends z.ZodTypeAny>
     ? StripZodDefault<Inner>
-    : T extends z.ZodObject<infer Shape, infer UnknownKeys, infer Catchall>
-      ? z.ZodObject<{ [K in keyof Shape]: StripZodDefault<Shape[K]> }, UnknownKeys, Catchall>
-      : T extends z.ZodArray<infer Element, infer ArrayCardinality>
-        ? z.ZodArray<StripZodDefault<Element>, ArrayCardinality>
-        : T extends z.ZodOptional<infer InnerOpt>
+    : T extends z.ZodObject<infer Shape extends z.ZodRawShape, infer Config>
+      ? z.ZodObject<{ [K in keyof Shape]: Shape[K] extends z.ZodTypeAny ? StripZodDefault<Shape[K]> : Shape[K] }, Config>
+      : T extends z.ZodArray<infer Element extends z.ZodTypeAny>
+        ? z.ZodArray<StripZodDefault<Element>>
+        : T extends z.ZodOptional<infer InnerOpt extends z.ZodTypeAny>
           ? z.ZodOptional<StripZodDefault<InnerOpt>>
-          : T extends z.ZodNullable<infer InnerNull>
+          : T extends z.ZodNullable<infer InnerNull extends z.ZodTypeAny>
             ? z.ZodNullable<StripZodDefault<InnerNull>>
             : T extends z.ZodUnion<infer Options>
               ? Options extends readonly [z.ZodTypeAny, ...z.ZodTypeAny[]]
@@ -20,137 +25,191 @@ type StripZodDefault<T extends z.ZodTypeAny> =
                 ? Items extends readonly [z.ZodTypeAny, ...z.ZodTypeAny[]]
                   ? z.ZodTuple<MapTuple<Items>>
                   : never
-                : T extends z.ZodIntersection<infer Left, infer Right>
+                : T extends z.ZodIntersection<infer Left extends z.ZodTypeAny, infer Right extends z.ZodTypeAny>
                   ? z.ZodIntersection<StripZodDefault<Left>, StripZodDefault<Right>>
-                  : T extends z.ZodDiscriminatedUnion<infer Disc, infer Options>
-                    ? Options extends readonly [z.ZodTypeAny, ...z.ZodTypeAny[]]
-                      ? z.ZodDiscriminatedUnion<Disc, MapTuple<Options>>
-                      : never
+                  : T extends z.ZodDiscriminatedUnion<infer A, infer B>
+                    ? // Some Zod v4 builds use <Discriminator, Options>, others use <Options, Discriminator>
+                      B extends string
+                      ? A extends readonly [z.ZodTypeAny, ...z.ZodTypeAny[]]
+                        ? z.ZodDiscriminatedUnion<MapTuple<A>, B>
+                        : z.ZodDiscriminatedUnion<any, B>
+                      : T
                     : T
 
-type MapTuple<T extends readonly any[]> = T extends readonly [any, ...any[]] ? { [K in keyof T]: StripZodDefault<T[K]> } : never
+type MapTuple<T extends readonly z.ZodTypeAny[]> = { [K in keyof T]: StripZodDefault<T[K]> }
 
 /**
  * Recursively unwraps ZodDefault<T> and returns a schema with the same shape but without the `.default()` wrapper.
- * @param schema
+ *
  * @internal
  */
 export function stripZodDefault<Schema extends z.ZodTypeAny>(schema: Schema): StripZodDefault<Schema> {
-  switch (schema._def.typeName) {
-    // Unwrap ZodDefault by stripping its inner type.
-    case z.ZodFirstPartyTypeKind.ZodDefault: {
-      const inner = (schema as unknown as z.ZodDefault<z.ZodTypeAny>)._def.innerType
+  const getDef = (s: any) => {
+    if (s === undefined) {
+      console.warn("Couldn't find schema definition... because schema was undefined...")
+      return undefined
+    }
+    const typeDef = s?._zod?.def ?? s?.def ?? s?._def
+    if (typeDef?.type) return typeDef
+
+    if (s.type === 'pipe') {
+      return s.in.def
+    }
+  }
+  const getType = (s: any): string | undefined => {
+    const def = getDef(s)
+    return typeof def?.type === 'string' ? def.type : undefined
+  }
+  const unwrapInner = (s: any) => {
+    const def = getDef(s)
+    return def?.innerType ?? def?.inner ?? def?.schema
+  }
+
+  const type = getType(schema)
+
+  switch (type) {
+    case 'default': {
+      const inner = unwrapInner(schema)
       return stripZodDefault(inner) as StripZodDefault<Schema>
     }
 
-    // For objects, recursively strip each property.
-    case z.ZodFirstPartyTypeKind.ZodObject: {
-      const objSchema = schema as unknown as z.ZodObject<any>
+    case 'object': {
+      const def = getDef(schema)
+      const shape = (schema as any).shape ?? def?.shape
       const newShape: Record<string, z.ZodTypeAny> = {}
-      for (const key in objSchema.shape) {
-        newShape[key] = stripZodDefault(objSchema.shape[key])
+
+      if (shape && typeof shape === 'object' && !Array.isArray(shape)) {
+        for (const key of Object.keys(shape)) {
+          newShape[key] = stripZodDefault(shape[key])
+        }
+
+        // @ts-expect-error - type 'unknown' for object properties does not align with generic Schema
+        return z.object(newShape) as StripZodDefault<Schema>
       }
-      return z.object(newShape) as StripZodDefault<Schema>
+
+      // Defensive fallback: some internal shapes can be arrays of { key, value }
+      if (Array.isArray(shape)) {
+        for (const p of shape) {
+          newShape[p.key] = stripZodDefault(p.value)
+        }
+
+        // @ts-expect-error - type 'unknown' for object properties does not align with generic Schema
+        return z.object(newShape) as StripZodDefault<Schema>
+      }
+
+      return z.object({}) as StripZodDefault<Schema>
     }
 
-    // For arrays, strip the element type.
-    case z.ZodFirstPartyTypeKind.ZodArray: {
-      const arrSchema = schema as unknown as z.ZodArray<z.ZodTypeAny>
-      const elementStripped = stripZodDefault(arrSchema.element)
+    case 'array': {
+      const def = getDef(schema)
+      const element = (schema as any).element ?? def?.element ?? def?.items
+      const elementStripped = stripZodDefault(element)
       return z.array(elementStripped) as StripZodDefault<Schema>
     }
 
-    // For optional types, strip the inner type then reapply optional.
-    case z.ZodFirstPartyTypeKind.ZodOptional: {
-      const unwrapped = (schema as unknown as z.ZodOptional<z.ZodTypeAny>).unwrap()
-      const strippedInner = stripZodDefault(unwrapped)
+    case 'optional': {
+      const inner = unwrapInner(schema)
+      const strippedInner = stripZodDefault(inner)
       return z.optional(strippedInner) as StripZodDefault<Schema>
     }
 
-    // For nullable types, strip the inner type then reapply nullable.
-    case z.ZodFirstPartyTypeKind.ZodNullable: {
-      const unwrapped = (schema as unknown as z.ZodNullable<z.ZodTypeAny>).unwrap()
-      const strippedInner = stripZodDefault(unwrapped)
+    case 'nullable': {
+      const inner = unwrapInner(schema)
+      const strippedInner = stripZodDefault(inner)
       return z.nullable(strippedInner) as StripZodDefault<Schema>
     }
 
-    // For unions, strip each option and rebuild the union.
-    case z.ZodFirstPartyTypeKind.ZodUnion: {
-      const unionSchema = schema as unknown as z.ZodUnion<[z.ZodTypeAny, ...z.ZodTypeAny[]]>
-      const strippedOptions = unionSchema._def.options.map((option: z.ZodTypeAny) => stripZodDefault(option))
+    case 'union': {
+      const def = getDef(schema)
+      const options = (def?.options ?? def?.elements) as z.ZodTypeAny[]
+      const strippedOptions = options.map((opt) => stripZodDefault(opt))
 
-      // @ts-ignore
+      // @ts-ignore - z.union expects a tuple type at compile time
       return z.union(strippedOptions) as unknown as StripZodDefault<Schema>
     }
 
-    // For tuples, strip each element and rebuild the tuple.
-    case z.ZodFirstPartyTypeKind.ZodTuple: {
-      const tupleSchema = schema as unknown as z.ZodTuple<[z.ZodTypeAny, ...z.ZodTypeAny[]]>
-      const strippedItems = tupleSchema._def.items.map((item: z.ZodTypeAny) => stripZodDefault(item))
+    case 'tuple': {
+      const def = getDef(schema)
+      const items = (def?.items ?? def?.prefixItems) as z.ZodTypeAny[]
+      const strippedItems = items.map((item) => stripZodDefault(item))
 
-      // @ts-ignore
-      return z.tuple(strippedItems) as StripZodDefault<Schema>
+      // @ts-ignore - z.tuple expects a tuple type at compile time
+      return z.tuple(strippedItems) as unknown as StripZodDefault<Schema>
     }
-    // For literal types, no default wrapper is applied, so just return the schema.
-    case z.ZodFirstPartyTypeKind.ZodLiteral: {
+
+    case 'literal':
+    case 'enum':
       return schema as StripZodDefault<Schema>
+
+    case 'catch': {
+      const def = getDef(schema)
+      const inner = unwrapInner(schema)
+      const strippedInner = stripZodDefault(inner)
+
+      // Preserve catch fallback
+      const catchValue = def?.catchValue
+      return (strippedInner as any).catch(catchValue) as StripZodDefault<Schema>
     }
 
-    // For enum types, return the schema as-is.
-    case z.ZodFirstPartyTypeKind.ZodEnum: {
-      return schema as StripZodDefault<Schema>
+    case 'transform': {
+      // Unwrap and then reapply the transform/refinement/preprocess
+      const inner = unwrapInner(schema)
+      const base = stripZodDefault(inner)
+      return reapplyEffects(schema as any, base as any) as StripZodDefault<Schema>
     }
 
-    // For catch wrappers, remove the catch and use the inner type.
-    case z.ZodFirstPartyTypeKind.ZodCatch: {
-      const catchSchema = schema as unknown as z.ZodCatch<z.ZodTypeAny>
-      const inner = catchSchema._def.innerType
+    case 'pipe': {
+      const def = getDef(schema)
+      const out = def?.out ?? def?.output ?? def?.right ?? def?.to
+      if (out.type !== 'transform') return stripZodDefault(out) as StripZodDefault<Schema>
 
-      //? Re-apply catch value to ensure fallback values are preserved
-      return stripZodDefault(inner).catch(catchSchema._def.catchValue) as unknown as StripZodDefault<Schema>
+      const inner = unwrapPipe(schema as Any)
+      return stripZodDefault(inner) as StripZodDefault<Schema>
     }
 
-    // For effects wrappers, remove the effects and return the underlying schema.
-    case z.ZodFirstPartyTypeKind.ZodEffects: {
-      const effectsSchema = schema as unknown as z.ZodEffects<z.ZodTypeAny>
-      return reapplyEffects(effectsSchema, stripZodDefault(effectsSchema._def.schema)) as StripZodDefault<Schema>
-    }
-
-    case z.ZodFirstPartyTypeKind.ZodIntersection: {
-      const intersectionSchema = schema as unknown as z.ZodIntersection<z.ZodTypeAny, z.ZodTypeAny>
-      const leftStripped = stripZodDefault(intersectionSchema._def.left)
-      const rightStripped = stripZodDefault(intersectionSchema._def.right)
+    case 'intersection': {
+      const def = getDef(schema)
+      const left = def?.left
+      const right = def?.right
+      const leftStripped = stripZodDefault(left)
+      const rightStripped = stripZodDefault(right)
       return z.intersection(leftStripped, rightStripped) as StripZodDefault<Schema>
     }
 
-    // For discriminated unions, strip each option and rebuild the discriminated union.
-    case z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
-      const discUnion = schema as any // treat as ZodDiscriminatedUnion
-      const strippedOptions = discUnion._def.options.map((option: z.ZodTypeAny) => stripZodDefault(option))
-      return z.discriminatedUnion(discUnion._def.discriminator, strippedOptions) as unknown as StripZodDefault<Schema>
+    case 'discriminated_union': {
+      const def = getDef(schema)
+      const discriminator = def?.discriminator
+      const options = (def?.options ?? def?.elements) as z.ZodTypeAny[]
+      const strippedOptions = options.map((opt) => stripZodDefault(opt))
+
+      return z.discriminatedUnion(discriminator, strippedOptions as any) as unknown as StripZodDefault<Schema>
     }
 
-    // For all other types (primitives, etc.), return the schema unchanged.
+    case 'readonly':
+    case 'nonoptional': {
+      const inner = unwrapInner(schema)
+      return stripZodDefault(inner) as StripZodDefault<Schema>
+    }
+
     default:
       return schema as StripZodDefault<Schema>
   }
 }
 
 /**
- * Re-applies ZodEffects to a `base` schema that was unwrapped.
- * @param original The original schema that holds the effects.
- * @param base The schema to which the effects should be reapplied.
+ * Re-applies transform/refinement/preprocess effects after unwrapping/stripping.
  */
-function reapplyEffects(original: z.ZodEffects<z.ZodTypeAny>, base: z.ZodTypeAny): z.ZodTypeAny {
-  const effect = (original as any)._def.effect as
+function reapplyEffects(original: z.ZodTypeAny, base: z.ZodTypeAny): z.ZodTypeAny {
+  const def = (original as any)?._zod?.def ?? (original as any)?.def ?? (original as any)?._def
+
+  // in Zod v4 effects are usually stored within `def.effect` for 'transform' wrappers.
+  const effect = def?.effect as
     | { type: 'transform'; transform: (arg: unknown, ctx: any) => unknown | Promise<unknown> }
     | { type: 'refinement'; refinement: (arg: unknown, ctx: any) => void | Promise<void> }
     | { type: 'preprocess'; transform: (arg: unknown) => unknown | Promise<unknown> }
     | undefined
 
-  if (!effect) {
-    return base
-  }
+  if (!effect) return base
 
   switch (effect.type) {
     case 'transform':
@@ -165,4 +224,8 @@ function reapplyEffects(original: z.ZodEffects<z.ZodTypeAny>, base: z.ZodTypeAny
     default:
       return base
   }
+}
+
+function unwrapPipe<TSchema extends z.ZodPipe>(pipedSchema: TSchema): TSchema['in'] {
+  return pipedSchema.in
 }

--- a/src/schemas/utils/stripZodDefaultValues.ts
+++ b/src/schemas/utils/stripZodDefaultValues.ts
@@ -186,10 +186,14 @@ export function stripZodDefault<Schema extends z.ZodTypeAny>(schema: Schema): St
       return z.discriminatedUnion(discriminator, strippedOptions as any) as unknown as StripZodDefault<Schema>
     }
 
-    case 'readonly':
+    case 'readonly': {
+      const inner = unwrapInner(schema)
+      return stripZodDefault(inner).readonly() as StripZodDefault<Schema>
+    }
+
     case 'nonoptional': {
       const inner = unwrapInner(schema)
-      return stripZodDefault(inner) as StripZodDefault<Schema>
+      return stripZodDefault(inner).nonoptional() as StripZodDefault<Schema>
     }
 
     default:

--- a/src/tests/integration/zod/basicSchemaInstantiations.ts
+++ b/src/tests/integration/zod/basicSchemaInstantiations.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from '@jest/globals'
+import z from 'zod'
+import schemaDefaults from '@/src/schemas/utils/schemaDefaults'
+
+describe('Basic Schemas Instantiations', () => {
+  it('Verify that basic person schema is instantiated correctly', () => {
+    const schema = z.object({
+      name: z.string().default('some name'),
+      hobbies: z.string(),
+      age: z.number().min(1),
+      degree: z.enum(['bachelor', 'master', 'phd', 'college']).default('college'),
+      gender: z.enum(['male', 'female']),
+      siblings: z.array(
+        z.object({
+          name: z.string().default('some name'),
+          age: z.number().min(1),
+        }),
+      ),
+    })
+
+    const data = schemaDefaults(schema)
+
+    expect(data.name).toEqual('some name')
+    expect(data.hobbies).toEqual('')
+    expect(data.age).toBeGreaterThanOrEqual(1)
+    expect(data.gender).not.toBeUndefined()
+    expect(data.gender === 'male' || data.gender === 'female').toBeTruthy()
+
+    expect(data.siblings.length).toBeGreaterThanOrEqual(1)
+    expect(data.siblings.reduce((sum, cur) => (sum += cur.age), 0)).toBeGreaterThanOrEqual(data.siblings.length)
+  })
+
+  it('Verify that default schema array size can be overridden', () => {
+    const schema = z.array(
+      z.object({
+        name: z.string().default('some name'),
+        age: z.number(),
+      }),
+    )
+
+    const data = schemaDefaults(schema, { overrideArraySize: 10 })
+
+    expect(data.length).toEqual(10)
+    expect(data[0].name).toEqual('some name')
+  })
+
+  it('Verify that effects are unwrapped when instantiating schema with effects', () => {
+    const schema = z
+      .object({
+        name: z.string().default('some name'),
+        age: z
+          .number()
+          .default(5)
+          .transform((v) => v),
+        gender: z.enum(['male', 'female']),
+      })
+      .transform((person) => ({ ...person, age: person.age * 5 }))
+
+    const data = schemaDefaults(schema)
+
+    expect(data.age).toEqual(5)
+    expect(schema.parse(data).age).toEqual(25)
+  })
+})

--- a/src/tests/integration/zod/defaultValueStripping.ts
+++ b/src/tests/integration/zod/defaultValueStripping.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from '@jest/globals'
+import z from 'zod'
+import { getUUID } from '@/src/lib/Shared/getUUID'
+import lorem from '@/src/lib/Shared/Lorem'
+import { stripZodDefault } from '@/src/schemas/utils/stripZodDefaultValues'
+
+describe('Stripping of zod Default values', () => {
+  it('Verify stripping of default-values from basic schema', () => {
+    const schema = stripZodDefault(
+      z.object({
+        name: z.string().default('some name'),
+        age: z.number().min(1),
+        degree: z.enum(['bachelor', 'master', 'phd', 'college']).default('college'),
+      }),
+    )
+
+    const dummy: Partial<z.output<typeof schema>> = {
+      name: 'some name',
+      age: 10,
+    }
+
+    // ensure that schema validation fails because `degree` is missing - thus the default value is correctly stripped
+    expect(() => schema.parse(dummy)).toThrow(
+      new RegExp(
+        `Invalid option: expected one of ${Array.from(schema.shape.degree._zod.values)
+          .map((enumValue) => `"${String(enumValue)}"`)
+          .join('|')}`,
+      ),
+    )
+  })
+
+  it('Verify stripping of default-values from complex schema', () => {
+    // #region Cloned complex (Question) schema
+    // copied `QuestionSchema` schema that uses intersections, discriminatedUnion, refinements and more
+    const AnswerId = z
+      .string()
+      .uuid('An answer must have an uuid to identify it!')
+      .catch(() => getUUID())
+
+    const baseQuestion = z.object({
+      id: z.string().uuid(),
+      points: z.number().positive(),
+      category: z.string().default('general'),
+
+      question: z
+        .string()
+        .refine((q) => q.split(' ').length > 2, 'Please reformulate your question to be at least 3 words long.')
+        .default(
+          lorem()
+            .substring(0, Math.floor(Math.random() * 100) + 20)
+            .split('\n')
+            .join(''),
+        ),
+
+      //* specifies how / in which environments the question should be displayed to users.
+      accessibility: z.enum(['all', 'practice-only', 'exam-only']).default('all').catch('all'),
+    })
+
+    const multipleChoiceAnswerSchema = z.object({
+      type: z.literal('multiple-choice'),
+      answers: z
+        .array(
+          z.object({
+            id: AnswerId,
+            answer: z.string().min(1, 'An answer must not be empty!'),
+            correct: z.boolean(),
+          }),
+        )
+        .min(1, 'Please provide at least one answer')
+        .refine((answers) => answers.find((answer) => answer.correct), { message: 'At least one answer has to be correct!' })
+        .default(() => [
+          { id: getUUID(), answer: 'Answer 1', correct: false },
+          { id: getUUID(), answer: 'Answer 2', correct: true },
+          { id: getUUID(), answer: 'Answer 3', correct: true },
+          { id: getUUID(), answer: 'Answer 4', correct: false },
+        ]),
+    })
+
+    const singleChoiceAnswerSchema = z.object({
+      type: z.literal('single-choice'),
+      answers: z
+        .array(
+          z.object({
+            id: AnswerId,
+            answer: z.string(),
+            correct: z.boolean(),
+          }),
+        )
+        .min(1, 'Please provide at least one answer')
+        .refine((answers) => answers.filter((answer) => answer.correct).length === 1, { message: 'A single-choice question must have *one* correct answer!' })
+        .default(() => [
+          { id: getUUID(), answer: 'Answer 1', correct: false },
+          { id: getUUID(), answer: 'Answer 2', correct: true },
+          { id: getUUID(), answer: 'Answer 3', correct: false },
+          { id: getUUID(), answer: 'Answer 4', correct: false },
+        ]),
+    })
+
+    const dragDropAnswerSchema = z.object({
+      type: z.literal('drag-drop'),
+      answers: z
+        .array(
+          z.object({
+            id: AnswerId,
+            answer: z.string(),
+            position: z.number().min(0, 'Position must be positive'),
+          }),
+        )
+        .default(() => [
+          { id: getUUID(), answer: 'Answer 1', position: 0 },
+          { id: getUUID(), answer: 'Answer 2', position: 1 },
+          { id: getUUID(), answer: 'Answer 3', position: 2 },
+          { id: getUUID(), answer: 'Answer 4', position: 3 },
+        ]),
+    })
+
+    const openAnswerSchema = z.object({
+      type: z.literal('open-question'),
+      expectation: z.string().optional(),
+    })
+
+    const questionAnswerTypes = z.discriminatedUnion('type', [singleChoiceAnswerSchema, multipleChoiceAnswerSchema, openAnswerSchema, dragDropAnswerSchema])
+
+    const questionSchema = z.intersection(baseQuestion, questionAnswerTypes)
+    // #endregion
+
+    const schema = stripZodDefault(questionSchema)
+
+    const dummy: Partial<z.output<typeof schema>> = {
+      id: getUUID(),
+      type: 'single-choice',
+      accessibility: 'all',
+      category: 'general',
+      points: 4,
+      question: 'some dummy question...',
+    }
+
+    // ensure that schema validation fails because `answers` is missing - thus the default value is correctly stripped
+    expect(() => schema.parse(dummy)).toThrow('Invalid input: expected array, received undefined')
+  })
+})

--- a/src/tests/integration/zod/defaultValueStripping.ts
+++ b/src/tests/integration/zod/defaultValueStripping.ts
@@ -38,7 +38,7 @@ describe('Stripping of zod Default values', () => {
       .catch(() => getUUID())
 
     const baseQuestion = z.object({
-      id: z.string().uuid(),
+      id: z.uuidv4(),
       points: z.number().positive(),
       category: z.string().default('general'),
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14062,7 +14062,7 @@ zod@3.23.8:
   resolved "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
 
-zod@^3.24.1, zod@^3.24.2:
+zod@^3.24.1:
   version "3.24.2"
   resolved "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz"
   integrity sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==
@@ -14071,6 +14071,11 @@ zod@^3.24.1, zod@^3.24.2:
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.12.tgz#64f1ea53d00eab91853195653b5af9eee68970f0"
   integrity sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==
+
+zod@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
 
 zustand@^5.0.3:
   version "5.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,10 +1363,10 @@
   resolved "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz"
   integrity sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==
 
-"@hookform/resolvers@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-4.1.3.tgz#97a20cc0e88d3b66c50e1e9fd6e089a94c689e07"
-  integrity sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ==
+"@hookform/resolvers@^5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-5.2.2.tgz#5ac16cd89501ca31671e6e9f0f5c5d762a99aa12"
+  integrity sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==
   dependencies:
     "@standard-schema/utils" "^0.3.0"
 


### PR DESCRIPTION
> [!NOTE]
> This pull request migrates the code-base from using zod@3 to zod@4. In doing so it overcomes some of the challenges discovered / addressed in #139. It slightly modifies the schema definitions by replacing deprecated operands like `string.().ipv4()` with `.ipv4()`  and re-arranging the order of `optional` and `.default` operands. 
>
> Apart from these slight schema changes it drastically changed zod-related utility functions like `schemaDefaults`, `stripZodDefault`, `stripEffects` as they heavily depend on internal zod structures to instantiate and unwrap a given schema. While the migration to zod@4 was discarded by #139 back then, all the discovered challenges like unwrapping effects (transform, ..) have been solved and implemented by this pull request. 

> [!TIP]
> By migrating to zod@4 the localization of zod schemas should be feasible at least partially. This was a major reason to migrate, since zod@3 does not come with localization options for built-in error messages. However, the localization of descriptions and default values will still remain a challenging aspect as of right now, as almost all schemas are used on both the client- and server- side. 

This pull request is primarily about migrating to  Zod v4. The most important changes are the fixes to schema instantiation, default-value handling and React Hook Form type compatibility, while the rest of the work focuses on completing the migration, preserving schema behavior, and introducing basic tests to verify robustness. There are no major user-facing features, but the successfully migrates to the new zod version. 

## Summary

* **Chores**

  * Migrated utility functions to zod v4 such as `schemaDefaults`, `stripZodDefault`, `stripEffects`, description extraction, issue-code handling, and safe-parse usage.
  * Updated surrounding dependencies and integrations, including React Hook Form resolvers and drizzle-zod default access.
  * Reworked schema composition details such as ordering of `.optional()`, `.default()`, transforms, `readonly`, and `nonoptional`, to preserve intended runtime and typing behavior.
  * Improved project setup by relaxing Jest test file naming requirements.

* **Fixes**

  * Fixed several schema instantiation bugs, especially around enums, discriminated union literals, and generated default values introduced by the migration.
  * Resolved issues where default options or schema defaults could be lost or become `undefined` during processing, introduced by the migration.
  * Fixed multiple zod v4 / React Hook Form typing problems by adjusting resolver and hook typing behavior.
  * Corrected handling of piped transforms and default-stripping, preventing broken unwrap/reapply behavior.



* **Refactors**

  * Cleaned up deprecated zod utilities and types to align the codebase with zod v4.
  * Refined internal utility typing and error-handling logic, especially around schema instantiation, server-error mapping and default/effect reapplication.
  * Improved effect stripping for more complex cases such as pipes, arrays, and nested effects, while also adding warnings where checks may be removed.

* **Tests**

  * Added a basic schema instantiation test suite.
  * Added tests for stripping zod default values, including more complex schema cases.

---
### Detailed Changelog

<details>
<summary>Changelog</summary>

[](https://google.com)

- **Fixes**:
  - Resolved missing enum value instantiation logic ([`8793eb01`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/8793eb01))
     
  - Resolved options default value loss ([`f82db5e7`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f82db5e7))
     Previously the `options` argument of the `schemaDefaults` function had it's default values declared in the function signature. This meant that when a user passed options to the function call these default-values were "lost". Now the user provided options are properly joined with default-option values.
  
  - Resolved instantiation of discriminated union literal ([`3f11de9c`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/3f11de9c))
     Previously the instantiation of literals yielded undefined instead of an actual value. For example, when instantiating a single-choice question then the type-literal was instantiated as undefined instead of as `single-choice`. This issue is now resolved.
  
  - Added type assertions for `zodResolver` usages ([`d507f63c`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/d507f63c))
     The reason for this change is that in zod@4 each schema has both an output and input type. When a schema uses `.default` operands e.g. on the root level of a schema. It's input type is typed as `T | undefined`, because an input that is undefined would get replaced by the default-value. This is also the reason why the rhf form instantiations shows type-errors because undefined does not satisfy the expected `FieldValues` type. This type assertion basically says treat the input as the respective Schema input (`T`) instead of `T | undefined`.
  
  - Added type assertion in `useRHF` to resolve input type ([`6ff3c778`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/6ff3c778))
     The reason for this type assertion is tied to the way zod@4 schemas type their input. When a schema uses the `.default` operand the input for that property / schema is typed as `T | undefined`. Since the schema used in the `useRHF` hook is also generic it may or may not use `.default` operands, which types the input as unknown which does not satisfy the `FieldValues` type. This type assertion basically tells the resolver that the schema-input conforms with the `FieldValues` type, thus the input type does not include `undefined`.
  
  - Added type assertion resolve input type in `CQD` ([`e4acfc41`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/e4acfc41))
     The reason for this is that the `QuestionSchema` uses a `.default` operand on the root level, which causes the zod-schema input-type to be typed as `T | undefined` which violates the `FieldValues` type. One way of resolving this issue would be to remove `default` operand or by telling the resolver that the schema-input type is just `T`. In this case `Question`.
  
  - Excluded transform effect from `stripZDefault` in pipe ([`e14582bd`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/e14582bd))
     The reason for this is that the output of a pipe that basically wraps e.g. an object in a transform operand does not properly unwrap, resulting in undefined. Then again. Since the stripping of a transform effect yields undefined an error will be thrown along the way when the pipe is re-applied with undefined instead of the transform-effect. Thus, the `stripZodDefault` function will not be called on piped transform effects but instead the output-transform will be re-used.
  

- **Chores**:
  - Installed `zod@4` dependency ([`54dd71e8`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/54dd71e8))
     
  - Migrated custom zodIssueCode usage ([`3332282f`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/3332282f))
     
  - Migrated `schemaDefaults` to zod@4 ([`0687089c`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/0687089c))
     While this migrated version successfully instantiates existing schemas, it still is very rough.
  
  - Migrated safe-parse return type usage ([`948ca695`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/948ca695))
     
  - Migrated `stripZodDefault` to zod@4 ([`b9c6002e`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/b9c6002e))
     
  - Re-applied piped effects after stripping defaults ([`b2e10a53`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/b2e10a53))
     Previously piped effects, such as transform handlers were silently removed by the `stripZodDefault` util function as they were not re-applied afters stripping the input schema from its default values.
  
  - Eliminated need for `.test` prefix to jest tests ([`f61de3c8`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f61de3c8))
     This way jest test files must not necessarily include `.test` prefix.
  
  - Migrated drizzle zod default value access ([`64e5d6f7`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/64e5d6f7))
     
  - Migrated deprecated `z.ZodIssueCode.custom` ([`67698066`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/67698066))
     
  - Migrated `stripEffects` utility function ([`29892a93`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/29892a93))
     This commit migrates the implementation of the `stripEffects` utility function to work with zod@4. Note that the respective `StripEffects` type does not yet properly remove all effects (e.g. piped effects).
  
  - Reworked `StripEffect` type to remove effects ([`3c0c156d`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/3c0c156d))
     This commit reworks the `StripEffects` type defined within the `stripEffects` module to remove effects from a given schema-type. Previously effects attached to a schema through a pipe were not removed. Now effects are properly removed from a given schema type.
  
  - Rearranged `.optional()` zod operand ([`0e69b070`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/0e69b070))
     The reason for this change is that by moving the `default()` after the `.optional()` flag types a given property as e.g. a boolean. When it is put before the `optional()` operand it would be typed as `boolean | undefined`.
  
  - Rearranged `.defautl()` zod operand ([`453b6fcb`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/453b6fcb))
     The reason for this change is that the order in which default values and effects are defined matters. For example, after transforming the `startDate` and `endDate` to a Date object the default value must be of type Date. To provide a default value in form of a string, the default-value must be moved before the `transform` operrand.
  
  - Migrated `extractDescriptions` to zod@4 ([`75a2eb93`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/75a2eb93))
     
  - Upgraded  rhf `resolver` dependencies ([`040b5ae2`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/040b5ae2))
     The reason for this is that with the upgrade from zod@3 to zod@4 the way errors are reported has changed. In order to restore the previous behavior of catching and displaying errors in a react-hook-form instance, the resolver dependency has been updated. This way errors are caught properly.
  
  - Updated `stripZodDefault` for pipe type ([`13bacaa6`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/13bacaa6))
     The reason for this commit that the `stripZodDefault` utility function would have removed the input of the pipe when the output was anything else than a transform. This commit basically re-applies the pipe but calls the strip-function on both the input and output. When the output of the pipe is undefined / not found it will only return the input of the pipe.
  
  - Re-applied `readonly`, `nonoptional` in `stripZDefault` ([`97e7c9c9`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/97e7c9c9))
     Previously the `stripZodDefault` function did not re-apply the `readonly` and `nonoptional` operand to a given property / schema which could modify the schema validation outcome.
  

- **Refactors**:
  - Migrated deprecated zod utils ([`4757af00`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/4757af00))
     
  - Added type assertion in schemaUtilities `instantiate` ([`0adf0cda`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/0adf0cda))
     The reason for this is that somewhere along the `schemaDefaults(stripZodDefault(schema)) chain the output type is typed as `unknown` instead of the respective schema-type.
  
  - Migrated manual server-error <-> form add logic ([`084e9ec8`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/084e9ec8))
     The reason for this change is that the `error` property returned by the `safeParse` function no longer holds the `formErrors` property. By using the new `.issues` property and slightly modifying the retrieval of the respective message this logic continues to work as expected.
  
  - Migrated deprecated `ZodSchema` type ([`88bf7f78`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/88bf7f78))
     
  - Added explicit zod@3 positive error message ([`1c6fef02`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/1c6fef02))
     From zod@3 to zod@4 the default error-message for the `positive` operand has slightly changed from "Number must be greater than 0" to "Too small: expected Number to be >0". This commit explicitly defines the error-message in this case, to ensure the same error message is used.
  
  - Migrated deprecated `.string().uuid()` operand ([`dc468827`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/dc468827))
     
  - Resolved potential enum instantiation issue ([`7fc1029a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/7fc1029a))
     Previously the instantiation of enum-values could have failed when the `values` array was empty as the randomIndex would have evaluated to `NaN`. At the same time the keys of the enum-entries were used instead of their values. While the key usually matches the value it must not always be the case.
  
  - Updated re-applying of `.default` in `stripEffecst` ([`fdc0be07`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/fdc0be07))
     Previously the `stripEffects` utility function re-applied the default-value which can be either a static value or a function, only as a value. Meaning that when the default-value would have been a function the `stripEffects` utility function would have re-applied the default-value with the result of the function instead of the function. By essentially re-applying the default-value of the unstripped-schema  this issue should be resolved and the behavior should be modified.
  
  - Added stripping of nested effects for arrays ([`e76af846`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/e76af846))
     Previously the `stripEffects` utility function with the strip option set to `effects-only` did not strip nested effects within an array. Note that, while this commits adds the stripping of effects it also removes all other checks, such as min, max, refinements which need to be re-applied in the future.
  
  - Added warning logs for stripping of checks ([`17d7c464`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/17d7c464))
     This way logs are printed to the console when checks are removed from an array, to simplify debugging down the line.
  

- **Tests**:
  - Created basic schema instantiation test-suite ([`f5e86b95`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f5e86b95))
     
  - Added simple zod default values stripping suite ([`e007a809`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/e007a809))
     This suite tests whether default values are correctly stripped from both basic and complex schemas.
  
</details>

