### PR TITLE
Ref: Improve practice related appearances, behaviors to improve UX

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+@custom-variant hocus (&:is(:hover, :focus-visible));
 
 @theme {
   --breakpoint-3xl: 120rem;

--- a/src/components/Shared/drag-drop/DragDropItem.tsx
+++ b/src/components/Shared/drag-drop/DragDropItem.tsx
@@ -5,7 +5,7 @@ import { ItemSwapEvent } from '@/src/components/Shared/drag-drop/DragDropContain
 import { DragDropItemPositionCounter } from '@/src/components/Shared/drag-drop/DragDropPositionCounter'
 import { getUUID } from '@/src/lib/Shared/getUUID'
 
-interface DragDropItemProps extends Pick<React.ComponentProps<'div'>, 'onClick'> {
+interface DragDropItemProps extends React.ComponentProps<'div'> {
   children: React.ReactNode
   className?: string
   onSwap?: (e: ItemSwapEvent) => void

--- a/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
+++ b/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
@@ -1,7 +1,8 @@
-import { HTMLProps, useEffect, useState } from 'react'
+import React, { HTMLProps, useEffect, useState } from 'react'
 import { MessageCircleQuestionIcon } from 'lucide-react'
 import { useFormContext } from 'react-hook-form'
 import DisplayFeedbackText from '@/src/components/checks/[share_token]/practice/FeedbackText'
+import { Textarea } from '@/src/components/shadcn/textarea'
 import { usePracticeFeeback } from '@/src/hooks/checks/[share_token]/practice/usePracticeFeedback'
 import { useRHFContext } from '@/src/hooks/Shared/form/react-hook-form/RHFProvider'
 import { cn } from '@/src/lib/Shared/utils'
@@ -58,17 +59,18 @@ export function FeedbackOpenQuestion({
   )
 }
 
-export function OpenQuestionAnswer({ children, ...props }: { children?: React.ReactNode } & HTMLProps<HTMLTextAreaElement>) {
+export function OpenQuestionAnswer({ children, ...props }: { children?: React.ReactNode } & React.ComponentProps<typeof Textarea>) {
   const { register } = useFormContext<QuestionInput>()
 
   return (
     <div className='group relative *:w-full'>
-      <textarea
+      <Textarea
         {...props}
+        maxRows={-1}
         {...register('input')}
         className={cn(
-          'rounded-md bg-neutral-100/90 px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 dark:bg-neutral-800 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50',
-          'enabled:hover:cursor-text enabled:hover:ring-ring-hover enabled:focus:ring-[1.2px] enabled:focus:ring-ring-focus enabled:dark:hover:ring-ring-hover enabled:dark:focus:ring-ring-focus',
+          'rounded-md border border-neutral-400 bg-neutral-100/90 px-3 py-1.5 text-neutral-600 outline-none placeholder:text-neutral-400/90 dark:border-neutral-500 dark:bg-neutral-800 dark:text-neutral-300/80 dark:placeholder:text-neutral-400/50',
+          'enabled:hover:cursor-text enabled:hover:border-ring-hover enabled:focus:border-[1.2px] enabled:focus:border-ring-focus enabled:dark:hover:border-ring-hover enabled:dark:focus:border-ring-focus',
           'resize-none',
           'my-auto h-full min-h-32',
           props.className,

--- a/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
+++ b/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
@@ -41,8 +41,8 @@ export function FeedbackOpenQuestion({
       data-evaluation-result={isValidationComplete ? (isCorrect ? 'correct' : isIncorrect ? 'incorrect' : 'none') : 'none'}
       className={cn(
         isValidationComplete && 'relative ring-2',
-        isCorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-green-500/20 ring-green-400/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/15 dark:ring-green-500/70',
-        isIncorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-red-500/20 ring-red-500/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/15 dark:ring-red-400/70',
+        isCorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-success-200/50 ring-success-300 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/15 dark:ring-green-500/70',
+        isIncorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-destructive/10 ring-red-500/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/15 dark:ring-red-400/70',
         isValidationComplete && 'pr-8',
       )}>
       <div className={cn('group/tooltip absolute top-1 right-1.5 z-10 flex cursor-pointer flex-row-reverse gap-1.5')} onClick={() => setPinned((prev) => !prev)}>

--- a/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
+++ b/src/components/checks/[share_token]/(shared)/(questions)/OpenQuestionAnswer.tsx
@@ -35,27 +35,48 @@ export function FeedbackOpenQuestion({
     setPinned(true)
   }, [isValidationComplete])
 
+  const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (!isValidationComplete) return
+
+    // close the feedback-tooltip when escape is pressed while the option for which the feedback is shown is focussed
+    if (event.key === 'Escape' && isPinned) return setPinned(false)
+    if (event.key !== 'Enter' && event.key !== ' ') return
+
+    event.preventDefault()
+    setPinned((prev) => !prev)
+  }
+
   return (
-    <OpenQuestionAnswer
-      {...props}
-      disabled={isValidationComplete || props.disabled}
-      data-evaluation-result={isValidationComplete ? (isCorrect ? 'correct' : isIncorrect ? 'incorrect' : 'none') : 'none'}
+    <div
       className={cn(
-        isValidationComplete && 'relative ring-2',
-        isCorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-success-200/50 ring-success-300 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/15 dark:ring-green-500/70',
-        isIncorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-destructive/10 ring-red-500/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/15 dark:ring-red-400/70',
-        isValidationComplete && 'pr-8',
-      )}>
-      <div className={cn('group/tooltip absolute top-1 right-1.5 z-10 flex cursor-pointer flex-row-reverse gap-1.5')} onClick={() => setPinned((prev) => !prev)}>
-        <DisplayFeedbackText disabled={!isValidationComplete} pinned={isPinned} feedback={reasoning} side='right'>
-          <MessageCircleQuestionIcon
-            className={cn('size-4.5 text-warning', !isPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isValidationComplete && 'hidden', !reasoning && 'hidden')}
-          />
-        </DisplayFeedbackText>
-      </div>
-      {/* overlay to detect click-events in text-area while disabled */}
-      {isValidationComplete && <div className='absolute inset-0 cursor-pointer' onClick={() => setPinned((prev) => !prev)}></div>}
-    </OpenQuestionAnswer>
+        'group relative rounded-md *:w-full focus-visible:ring-[5px]',
+        isIncorrect && 'ring-destructive-300/40 dark:ring-destructive-400/40',
+        isCorrect && 'ring-success-300/40 dark:ring-success/40',
+      )}
+      onKeyDown={handleKeyDown}
+      tabIndex={isValidationComplete && !!reasoning ? 0 : -1}>
+      <OpenQuestionAnswer
+        {...props}
+        disabled={isValidationComplete || props.disabled}
+        data-evaluation-result={isValidationComplete ? (isCorrect ? 'correct' : isIncorrect ? 'incorrect' : 'none') : 'none'}
+        className={cn(
+          isValidationComplete && 'relative ring-2',
+          isCorrect &&
+            'bg-radial from-neutral-200/60 via-neutral-200/60 to-success-200/50 ring-success-300 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/15 dark:ring-green-500/70',
+          isIncorrect && 'bg-radial from-neutral-200/60 via-neutral-200/60 to-destructive/10 ring-red-500/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/15 dark:ring-red-400/70',
+          isValidationComplete && 'pr-8',
+        )}>
+        <div className={cn('group/tooltip absolute top-1 right-1.5 z-10 flex cursor-pointer flex-row-reverse gap-1.5')} onClick={() => setPinned((prev) => !prev)}>
+          <DisplayFeedbackText disabled={!isValidationComplete} pinned={isPinned} feedback={reasoning} side='right'>
+            <MessageCircleQuestionIcon
+              className={cn('size-4.5 text-warning', !isPinned ? 'not-group-hover/tooltip:group-hover:animate-scale' : 'scale-110', !isValidationComplete && 'hidden', !reasoning && 'hidden')}
+            />
+          </DisplayFeedbackText>
+        </div>
+        {/* overlay to detect click-events in text-area while disabled */}
+        {isValidationComplete && <div className='absolute inset-0 cursor-pointer' onClick={() => setPinned((prev) => !prev)}></div>}
+      </OpenQuestionAnswer>
+    </div>
   )
 }
 
@@ -63,7 +84,7 @@ export function OpenQuestionAnswer({ children, ...props }: { children?: React.Re
   const { register } = useFormContext<QuestionInput>()
 
   return (
-    <div className='group relative *:w-full'>
+    <>
       <Textarea
         {...props}
         maxRows={-1}
@@ -77,6 +98,6 @@ export function OpenQuestionAnswer({ children, ...props }: { children?: React.Re
         )}
       />
       {children}
-    </div>
+    </>
   )
 }

--- a/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/(shared)/QuestionNavigation.tsx
@@ -31,6 +31,7 @@ export default function QuestionNavigationMenu({
 
           return (
             <button
+              tabIndex={-1}
               aria-label={t('question_aria_label', { index: i + 1, status: t(`question_status_${status}`) })}
               data-selected={i === currentQuestionIndex || undefined}
               data-status-correct={status === 'correct' || undefined}

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -69,7 +69,7 @@ function DragDropAnswerOptions({ question }: { question: DragDropQuestion }) {
     <DragDropItem
       key={id}
       name={id}
-      className={cn(isValidationComplete && feedbackEvaluation.reasoning?.has(id) && 'cursor-pointer')}
+      className={cn(isValidationComplete && feedbackEvaluation.reasoning?.has(id) && 'cursor-pointer', isValidationComplete && !feedbackEvaluation.reasoning?.has(id) && 'pointer-events-none')}
       onClick={isValidationComplete ? () => setOpenFeedbacks((prev) => (prev.includes(id) ? prev.filter((prev_id) => prev_id !== id) : prev.concat([id]))) : undefined}
       data-evaluation-result={isValidationComplete ? (feedbackEvaluation.isCorrectlyPositioned(id) ? 'correct' : feedbackEvaluation.isFalslyPositioned(id) ? 'incorrect' : 'none') : undefined}>
       <DragDropItemPositionCounter initialIndex={position} />

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -65,26 +65,53 @@ function DragDropAnswerOptions({ question }: { question: DragDropQuestion }) {
     setOpenFeedbacks([options.find((o) => feedbackEvaluation.isFalslyPositioned(o.id))?.id ?? ''].filter(Boolean))
   }, [isValidationComplete])
 
-  return options.map(({ id, answer, position }, i) => (
-    <DragDropItem
-      key={id}
-      name={id}
-      className={cn(isValidationComplete && feedbackEvaluation.reasoning?.has(id) && 'cursor-pointer', isValidationComplete && !feedbackEvaluation.reasoning?.has(id) && 'pointer-events-none')}
-      onClick={isValidationComplete ? () => setOpenFeedbacks((prev) => (prev.includes(id) ? prev.filter((prev_id) => prev_id !== id) : prev.concat([id]))) : undefined}
-      data-evaluation-result={isValidationComplete ? (feedbackEvaluation.isCorrectlyPositioned(id) ? 'correct' : feedbackEvaluation.isFalslyPositioned(id) ? 'incorrect' : 'none') : undefined}>
-      <DragDropItemPositionCounter initialIndex={position} />
-      {answer}
-      <AnswerFeedback
-        openFeedbacks={openFeedbacks}
-        updateOpenFeedbacks={setOpenFeedbacks}
-        show={isValidationComplete}
-        isFeedbackPinned={openFeedbacks.includes(id)}
-        id={id}
-        feedbackEvaluation={feedbackEvaluation}
-        position={position}
-      />
-    </DragDropItem>
-  ))
+  return options.map(({ id, answer, position }, i) => {
+    const handleActivate = () => {
+      if (isValidationComplete) {
+        setOpenFeedbacks((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : prev.concat([id])))
+        return
+      }
+
+      const input = document.getElementById(id) as HTMLInputElement | null
+      if (!input || input.disabled) return
+
+      input.focus()
+      input.click()
+    }
+
+    const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
+      const answerId = event.currentTarget.dataset['swapyItem'] as string
+      // close the feedback-tooltip when escape is pressed while the option for which the feedback is shown is focussed
+      if (event.key === 'Escape' && openFeedbacks.includes(answerId)) return setOpenFeedbacks((prev) => prev.filter((id) => id !== answerId))
+      if (event.key !== 'Enter' && event.key !== ' ') return
+
+      event.preventDefault()
+      handleActivate()
+    }
+
+    return (
+      <DragDropItem
+        tabIndex={isValidationComplete && feedbackEvaluation.reasoning?.has(id) ? 0 : -1}
+        key={id}
+        name={id}
+        className={cn(isValidationComplete && feedbackEvaluation.reasoning?.has(id) && 'cursor-pointer', isValidationComplete && !feedbackEvaluation.reasoning?.has(id) && 'pointer-events-none')}
+        onClick={isValidationComplete ? handleActivate : undefined}
+        onKeyDown={handleKeyDown}
+        data-evaluation-result={isValidationComplete ? (feedbackEvaluation.isCorrectlyPositioned(id) ? 'correct' : feedbackEvaluation.isFalslyPositioned(id) ? 'incorrect' : 'none') : undefined}>
+        <DragDropItemPositionCounter initialIndex={position} />
+        {answer}
+        <AnswerFeedback
+          openFeedbacks={openFeedbacks}
+          updateOpenFeedbacks={setOpenFeedbacks}
+          show={isValidationComplete}
+          isFeedbackPinned={openFeedbacks.includes(id)}
+          id={id}
+          feedbackEvaluation={feedbackEvaluation}
+          position={position}
+        />
+      </DragDropItem>
+    )
+  })
 }
 
 function AnswerFeedback({

--- a/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
+++ b/src/components/checks/[share_token]/practice/DragDropAnswerOptions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { SetStateAction, useEffect, useState } from 'react'
 import { ArrowUpFromLineIcon, CheckIcon, MessageCircleQuestionIcon, XIcon } from 'lucide-react'
 import DisplayFeedbackText from '@/src/components/checks/[share_token]/practice/FeedbackText'
 import DragDropContainer from '@/src/components/Shared/drag-drop/DragDropContainer'
@@ -62,7 +62,7 @@ function DragDropAnswerOptions({ question }: { question: DragDropQuestion }) {
 
     // automatically display feedback texts for wrong positioned answers
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setOpenFeedbacks(options.filter((o) => feedbackEvaluation.isFalslyPositioned(o.id)).map((o) => o.id))
+    setOpenFeedbacks([options.find((o) => feedbackEvaluation.isFalslyPositioned(o.id))?.id ?? ''].filter(Boolean))
   }, [isValidationComplete])
 
   return options.map(({ id, answer, position }, i) => (
@@ -74,7 +74,15 @@ function DragDropAnswerOptions({ question }: { question: DragDropQuestion }) {
       data-evaluation-result={isValidationComplete ? (feedbackEvaluation.isCorrectlyPositioned(id) ? 'correct' : feedbackEvaluation.isFalslyPositioned(id) ? 'incorrect' : 'none') : undefined}>
       <DragDropItemPositionCounter initialIndex={position} />
       {answer}
-      <AnswerFeedback show={isValidationComplete} isFeedbackPinned={openFeedbacks.includes(id)} id={id} feedbackEvaluation={feedbackEvaluation} position={position} />
+      <AnswerFeedback
+        openFeedbacks={openFeedbacks}
+        updateOpenFeedbacks={setOpenFeedbacks}
+        show={isValidationComplete}
+        isFeedbackPinned={openFeedbacks.includes(id)}
+        id={id}
+        feedbackEvaluation={feedbackEvaluation}
+        position={position}
+      />
     </DragDropItem>
   ))
 }
@@ -84,12 +92,16 @@ function AnswerFeedback({
   position,
   feedbackEvaluation,
   isFeedbackPinned,
+  openFeedbacks,
+  updateOpenFeedbacks,
   id,
 }: {
   show: boolean
   id: DragDropQuestion['answers'][number]['id']
   feedbackEvaluation: DragDropFeedbackEvaluation
   isFeedbackPinned?: boolean
+  openFeedbacks: string[]
+  updateOpenFeedbacks: React.Dispatch<SetStateAction<string[]>>
   position: number
 }) {
   if (!show) return null
@@ -98,7 +110,14 @@ function AnswerFeedback({
   const answerFeedbackText = feedbackEvaluation.reasoning?.get(id)
 
   return (
-    <DisplayFeedbackText feedback={answerFeedbackText} side='right' pinned={isFeedbackPinned} answerIndex={correctPosition}>
+    <DisplayFeedbackText
+      answerId={id}
+      openTooltips={openFeedbacks}
+      updateOpenTooltips={updateOpenFeedbacks}
+      feedback={answerFeedbackText}
+      side='right'
+      pinned={isFeedbackPinned}
+      answerIndex={correctPosition}>
       <div className='drag-drop-feedback-indicators group/tooltip ml-auto flex cursor-pointer items-center gap-2'>
         {feedbackEvaluation.isCorrectlyPositioned(id) ? (
           <CheckIcon className='size-4 text-green-600 dark:text-green-500/70' />

--- a/src/components/checks/[share_token]/practice/FeedbackText.tsx
+++ b/src/components/checks/[share_token]/practice/FeedbackText.tsx
@@ -12,17 +12,42 @@ export type DisplayFeedbackTextProps = Pick<TooltipProps, 'side' | 'sideOffset' 
   children: React.ReactNode
   answerIndex?: number
   answerId?: string
-  onOpenChange?: (open: boolean, id: string) => void
+
+  openTooltips?: string[]
+  updateOpenTooltips?: React.Dispatch<React.SetStateAction<string[]>>
+  maxOpenTooltips?: number
 }
 
-export default function DisplayFeedbackText({ feedback, pinned: isPinned, children, answerId, answerIndex = 0, onOpenChange, ...props }: DisplayFeedbackTextProps) {
+export default function DisplayFeedbackText({
+  openTooltips,
+  updateOpenTooltips,
+  maxOpenTooltips = 1,
+  feedback,
+  pinned: isPinned,
+  children,
+  answerId,
+  answerIndex = 0,
+  ...props
+}: DisplayFeedbackTextProps) {
   const [hoverOpen, setHoverOpen] = useState(false)
   const open = isPinned || hoverOpen
   const prevOpen = usePrevious(open)
 
+  //* Automatically close feedback-tools to prevent overlaping when `maxOpenTooltips` limit is reached.
   useEffect(() => {
+    if (!openTooltips || !updateOpenTooltips) return
     if (prevOpen === open || !answerId) return
-    onOpenChange?.(open, answerId)
+    if (!open) return
+
+    // detect tooltip display limit for already opened tooltips (pinned)
+    if (openTooltips.includes(answerId) && openTooltips.length > maxOpenTooltips) {
+      updateOpenTooltips((openFeedbacks) => openFeedbacks.slice(openFeedbacks.length - maxOpenTooltips))
+    }
+
+    // detect tooltip display limit for new tooltips e.g. on hover
+    if (!openTooltips.includes(answerId) && openTooltips.length + 1 > maxOpenTooltips) {
+      updateOpenTooltips((openFeedbacks) => openFeedbacks.slice(openFeedbacks.length + 1 - maxOpenTooltips))
+    }
   }, [open])
 
   if (!feedback) return <>{children}</>

--- a/src/components/checks/[share_token]/practice/FeedbackText.tsx
+++ b/src/components/checks/[share_token]/practice/FeedbackText.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { usePrevious } from '@uidotdev/usehooks'
 import Tooltip, { TooltipProps } from '@/src/components/Shared/Tooltip'
 
 export type DisplayFeedbackTextProps = Pick<TooltipProps, 'side' | 'sideOffset' | 'disabled'> & {
@@ -10,11 +11,19 @@ export type DisplayFeedbackTextProps = Pick<TooltipProps, 'side' | 'sideOffset' 
   pinned?: boolean
   children: React.ReactNode
   answerIndex?: number
+  answerId?: string
+  onOpenChange?: (open: boolean, id: string) => void
 }
 
-export default function DisplayFeedbackText({ feedback, pinned: isPinned, children, answerIndex = 0, ...props }: DisplayFeedbackTextProps) {
+export default function DisplayFeedbackText({ feedback, pinned: isPinned, children, answerId, answerIndex = 0, onOpenChange, ...props }: DisplayFeedbackTextProps) {
   const [hoverOpen, setHoverOpen] = useState(false)
   const open = isPinned || hoverOpen
+  const prevOpen = usePrevious(open)
+
+  useEffect(() => {
+    if (prevOpen === open || !answerId) return
+    onOpenChange?.(open, answerId)
+  }, [open])
 
   if (!feedback) return <>{children}</>
 

--- a/src/components/checks/[share_token]/practice/PracticeCategorySelection.tsx
+++ b/src/components/checks/[share_token]/practice/PracticeCategorySelection.tsx
@@ -10,10 +10,10 @@ export function PracticeCategorySelection({ questions, share_token }: { question
   const categories = useMemo(() => Array.from(new Set(questions.map((q) => q.category))), [questions])
 
   const optionClasses = cn(
-    'cursor-pointer px-3 py-1.5 hover:rounded-md hover:bg-neutral-200/90 hover:ring-1 focus-visible:rounded-md focus-visible:bg-neutral-200/9 focus-visible:ring-1 dark:ring-neutral-400/70 dark:hover:bg-neutral-800 dark:focus-visible:bg-neutral-800',
+    'cursor-pointer px-3 py-1.5 dark:ring-neutral-400/70 hocus:rounded-md hocus:bg-neutral-200/90 hocus:ring-1 dark:hocus:bg-neutral-800',
     'active:bg-neutral-300/80 dark:active:bg-neutral-700',
-    'hover:ring-ring-hover focus-visible:ring-ring-hover dark:hover:ring-ring-hover dark:focus-visible:ring-ring-hover',
-    'border-b border-ring-subtle first:border-b-3 last:border-b-0 first:hover:border-b-transparent first:focus-visible:border-b-transparent dark:border-neutral-600',
+    'hocus:ring-ring-hover dark:hocus:ring-ring-hover',
+    'border-b border-ring-subtle first:border-b-3 last:border-b-0 dark:border-neutral-600 first:hocus:border-b-transparent',
     'outline-0',
   )
 
@@ -28,7 +28,7 @@ export function PracticeCategorySelection({ questions, share_token }: { question
           data-category='all'
           className={cn(
             optionClasses,
-            'rounded-t-md bg-neutral-200 hover:bg-neutral-300/80 focus-visible:bg-neutral-300/80 dark:bg-neutral-700/50 dark:hover:bg-neutral-700 dark:focus-visible:bg-neutral-700',
+            'rounded-t-md bg-neutral-200 focus-visible:bg-neutral-300/80 dark:bg-neutral-700/50 dark:focus-visible:bg-neutral-700 hocus:bg-neutral-300/80 dark:hocus:bg-neutral-700',
           )}
           href={{
             pathname: `/checks/${share_token}/practice`,

--- a/src/components/checks/[share_token]/practice/PracticeCategorySelection.tsx
+++ b/src/components/checks/[share_token]/practice/PracticeCategorySelection.tsx
@@ -10,10 +10,11 @@ export function PracticeCategorySelection({ questions, share_token }: { question
   const categories = useMemo(() => Array.from(new Set(questions.map((q) => q.category))), [questions])
 
   const optionClasses = cn(
-    'cursor-pointer px-3 py-1.5 hover:rounded-md hover:bg-neutral-200/90 hover:ring-1 dark:ring-neutral-400/70 dark:hover:bg-neutral-800',
+    'cursor-pointer px-3 py-1.5 hover:rounded-md hover:bg-neutral-200/90 hover:ring-1 focus-visible:rounded-md focus-visible:bg-neutral-200/9 focus-visible:ring-1 dark:ring-neutral-400/70 dark:hover:bg-neutral-800 dark:focus-visible:bg-neutral-800',
     'active:bg-neutral-300/80 dark:active:bg-neutral-700',
-    'hover:ring-ring-hover dark:hover:ring-ring-hover',
-    'border-b border-ring-subtle first:border-b-3 last:border-b-0 first:hover:border-b-transparent dark:border-neutral-600',
+    'hover:ring-ring-hover focus-visible:ring-ring-hover dark:hover:ring-ring-hover dark:focus-visible:ring-ring-hover',
+    'border-b border-ring-subtle first:border-b-3 last:border-b-0 first:hover:border-b-transparent first:focus-visible:border-b-transparent dark:border-neutral-600',
+    'outline-0',
   )
 
   return (
@@ -25,7 +26,10 @@ export function PracticeCategorySelection({ questions, share_token }: { question
       <ul className='flex flex-col rounded-md text-neutral-700 ring-2 ring-ring-subtle select-none dark:text-neutral-300 dark:ring-ring-subtle' id='category-selection'>
         <Link
           data-category='all'
-          className={cn(optionClasses, 'rounded-t-md bg-neutral-200 hover:bg-neutral-300/80 dark:bg-neutral-700/50 dark:hover:bg-neutral-700')}
+          className={cn(
+            optionClasses,
+            'rounded-t-md bg-neutral-200 hover:bg-neutral-300/80 focus-visible:bg-neutral-300/80 dark:bg-neutral-700/50 dark:hover:bg-neutral-700 dark:focus-visible:bg-neutral-700',
+          )}
           href={{
             pathname: `/checks/${share_token}/practice`,
             query: { category: '_none_' },

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -305,27 +305,32 @@ function ChoiceOption({
 }) {
   return (
     <label
-      tabIndex={0}
+      data-feedback={mode === 'feedback' ? (isCorrect ? 'correct' : isWrong ? 'incorrect' : isMissing ? 'missing' : undefined) : 'answering'}
+      tabIndex={mode === 'feedback' ? (isCorrect || isWrong || isMissing ? 0 : -1) : 0}
       {...props}
       className={cn(
-        'rounded-md bg-neutral-100/90 px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 dark:bg-neutral-800 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50',
-        'has-enabled:hover:cursor-pointer has-enabled:hover:ring-ring-hover has-enabled:dark:hover:ring-ring-hover',
-        'has-enabled:focus:ring-[1.2px] has-enabled:focus:ring-ring-focus has-enabled:dark:focus:ring-ring-focus',
+        'rounded-md border border-neutral-400 bg-neutral-100/90 px-3 py-1.5 text-neutral-600 outline-none placeholder:text-neutral-400/90 dark:border-neutral-500 dark:bg-neutral-800 dark:text-neutral-300/80 dark:placeholder:text-neutral-400/50',
+        'has-enabled:hover:cursor-pointer has-enabled:hover:border-ring-hover has-enabled:dark:hover:border-ring-hover',
+        'has-enabled:focus:border-[1.2px] has-enabled:focus:border-ring-focus has-enabled:dark:focus:border-ring-focus',
         'flex items-center justify-center',
         'resize-none select-none',
-        'has-enabled:has-checked:bg-neutral-200/60 has-enabled:has-checked:font-semibold has-enabled:has-checked:ring-[1.5px] has-enabled:has-checked:ring-ring-hover dark:has-enabled:has-checked:bg-neutral-700/60 dark:has-enabled:has-checked:ring-neutral-300',
+        'has-enabled:has-checked:border-[1.5px] has-enabled:has-checked:border-ring-hover has-enabled:has-checked:bg-neutral-200/60 has-enabled:has-checked:font-semibold dark:has-enabled:has-checked:border-neutral-300 dark:has-enabled:has-checked:bg-neutral-700/60',
+        'focus-visible:ring-[3px] data-[feedback=answering]:focus-visible:border-ring-hover data-[feedback=answering]:focus-visible:ring-ring-hover/50',
+        'data-[feedback=correct]:focus-visible:border-success-400 data-[feedback=correct]:focus-visible:ring-success-300/50',
+        'data-[feedback=incorrect]:focus-visible:border-destructive-300/80 data-[feedback=incorrect]:focus-visible:ring-destructive-300/50 dark:data-[feedback=incorrect]:focus-visible:border-destructive-400',
+        'data-[feedback=missing]:focus-visible:border-0 data-[feedback=missing]:focus-visible:border-warning-400 data-[feedback=missing]:focus-visible:ring-warning/60 dark:data-[feedback=missing]:focus-visible:ring-warning-300/50',
 
         mode === 'feedback' &&
           cn(
-            'relative ring-2',
+            'relative border-2',
             !!feedbackText && 'group cursor-pointer',
             isCorrect &&
-              'bg-radial from-neutral-200/60 via-neutral-100/60 to-success-200/50 to-99% font-semibold ring-success-300 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/20 dark:ring-green-500/70',
+              'border-success-300 bg-radial from-neutral-200/60 via-neutral-100/60 to-success-200/50 to-99% font-semibold dark:border-green-500/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/20',
 
             isWrong &&
-              'from-neutral-200/60 via-neutral-100/60 to-destructive/10 ring-red-500/70 has-checked:bg-radial has-checked:font-semibold dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/20 dark:ring-red-400/70',
+              'border-red-500/70 from-neutral-200/60 via-neutral-100/60 to-destructive/10 has-checked:bg-radial has-checked:font-semibold dark:border-red-400/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/20',
 
-            isMissing && 'ring-0 outline-2 outline-yellow-500 outline-dashed dark:outline-yellow-400/60',
+            isMissing && 'border-0 outline-2 outline-yellow-500 outline-dashed focus-visible:border dark:outline-yellow-400/60',
           ),
 
         props.className,

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -231,6 +231,9 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({ question, type }: { typ
     }
 
     const handleKeyDown: React.KeyboardEventHandler<HTMLLabelElement> = (event) => {
+      const answerId = event.currentTarget.htmlFor
+      // close the feedback-tooltip when escape is pressed while the option for which the feedback is shown is focussed
+      if (event.key === 'Escape' && openFeedbacks.includes(answerId)) return setOpenFeedbacks((prev) => prev.filter((id) => id !== answerId))
       if (event.key !== 'Enter' && event.key !== ' ') return
 
       event.preventDefault()

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -226,6 +226,7 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({ question, type }: { typ
         isWrong={isValidationComplete && isFalslySelected(a)}
         isMissing={isValidationComplete && isMissingSelection(a)}
         feedbackText={reasoning?.get(a.id)}
+        className={cn(isValidationComplete && !reasoning?.has(a.id) && 'pointer-events-none')}
         htmlFor={a.id}>
         {a.answer}
 
@@ -305,6 +306,8 @@ function ChoiceOption({
 
             isMissing && 'ring-0 outline-2 outline-yellow-500 outline-dashed dark:outline-yellow-400/60',
           ),
+
+        props.className,
       )}
     />
   )

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -275,6 +275,7 @@ function ChoiceOption({
 }) {
   return (
     <label
+      tabIndex={0}
       {...props}
       className={cn(
         'rounded-md bg-neutral-100/90 px-3 py-1.5 text-neutral-600 ring-1 ring-neutral-400 outline-none placeholder:text-neutral-400/90 dark:bg-neutral-800 dark:text-neutral-300/80 dark:ring-neutral-500 dark:placeholder:text-neutral-400/50',

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -213,7 +213,7 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({ question, type }: { typ
     if (openFeedbacks.length > 0) return
 
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setOpenFeedbacks([question.answers.find((a) => isFalslySelected(a))?.id ?? ''])
+    setOpenFeedbacks([question.answers.find((a) => isFalslySelected(a))?.id ?? ''].filter(Boolean))
   }, [isValidationComplete])
 
   return question.answers.map((a, i) => {
@@ -230,12 +230,8 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({ question, type }: { typ
         {a.answer}
 
         <DisplayFeedbackText
-          onOpenChange={(open, id) => {
-            if (!open) return
-
-            // close all feedback-tooltips except the one being open right now.
-            setOpenFeedbacks((feedbacks) => feedbacks.filter((i) => i === id))
-          }}
+          updateOpenTooltips={setOpenFeedbacks}
+          openTooltips={openFeedbacks}
           answerId={a.id}
           disabled={!isValidationComplete}
           answerIndex={i}

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -106,8 +106,8 @@ export function RenderPracticeQuestion() {
             title={!isValid ? 'Before checking this question you must first answer it' : undefined}
             disabled={!isValid}
             hidden={isValidationComplete}
-            className='mx-auto mt-2 bg-neutral-300/80 enabled:ring-1 enabled:ring-ring-subtle enabled:hover:bg-neutral-300 enabled:hover:ring-ring dark:bg-neutral-700 dark:enabled:ring-transparent dark:enabled:hover:bg-neutral-600 dark:enabled:hover:ring-ring'
-            variant='secondary'
+            className='mt-2'
+            variant='base'
             isLoading={isSubmitting || isPending}
             type='submit'>
             Check Answer

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -213,7 +213,7 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({ question, type }: { typ
     if (openFeedbacks.length > 0) return
 
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setOpenFeedbacks([...question.answers.filter((a) => isFalslySelected(a)).map((a) => a.id)])
+    setOpenFeedbacks([question.answers.find((a) => isFalslySelected(a))?.id ?? ''])
   }, [isValidationComplete])
 
   return question.answers.map((a, i) => {
@@ -229,7 +229,19 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({ question, type }: { typ
         htmlFor={a.id}>
         {a.answer}
 
-        <DisplayFeedbackText disabled={!isValidationComplete} answerIndex={i} pinned={openFeedbacks.includes(a.id)} feedback={reasoning?.get(a.id)} side={i % 2 === 1 ? 'right' : 'left'}>
+        <DisplayFeedbackText
+          onOpenChange={(open, id) => {
+            if (!open) return
+
+            // close all feedback-tooltips except the one being open right now.
+            setOpenFeedbacks((feedbacks) => feedbacks.filter((i) => i === id))
+          }}
+          answerId={a.id}
+          disabled={!isValidationComplete}
+          answerIndex={i}
+          pinned={openFeedbacks.includes(a.id)}
+          feedback={reasoning?.get(a.id)}
+          side={i % 2 === 1 ? 'right' : 'left'}>
           <div className={cn('group/tooltip absolute top-1 right-1.5 flex flex-row-reverse gap-1.5', i % 2 === 0 && 'left-1.5 flex-row justify-between')}>
             <MessageCircleQuestionIcon
               className={cn(

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -289,10 +289,10 @@ function ChoiceOption({
             'relative ring-2',
             !!feedbackText && 'group cursor-pointer',
             isCorrect &&
-              'bg-radial from-neutral-200/60 via-neutral-100/60 to-green-600/20 font-semibold ring-green-400/70 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/20 dark:ring-green-500/70',
+              'bg-radial from-neutral-200/60 via-neutral-100/60 to-success-200/50 to-99% font-semibold ring-success-300 dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-green-500/20 dark:ring-green-500/70',
 
             isWrong &&
-              'from-neutral-200/60 via-neutral-100/60 to-red-500/20 ring-red-500/70 has-checked:bg-radial has-checked:font-semibold dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/20 dark:ring-red-400/70',
+              'from-neutral-200/60 via-neutral-100/60 to-destructive/10 ring-red-500/70 has-checked:bg-radial has-checked:font-semibold dark:from-neutral-700/60 dark:via-neutral-700/60 dark:to-red-400/20 dark:ring-red-400/70',
 
             isMissing && 'ring-0 outline-2 outline-yellow-500 outline-dashed dark:outline-yellow-400/60',
           ),

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -309,7 +309,7 @@ function ChoiceOption({
   return (
     <label
       data-feedback={mode === 'feedback' ? (isCorrect ? 'correct' : isWrong ? 'incorrect' : isMissing ? 'missing' : undefined) : 'answering'}
-      tabIndex={mode === 'feedback' ? (isCorrect || isWrong || isMissing ? 0 : -1) : 0}
+      tabIndex={mode === 'input' ? 0 : mode === 'feedback' && !!feedbackText ? 0 : -1}
       {...props}
       className={cn(
         'rounded-md border border-neutral-400 bg-neutral-100/90 px-3 py-1.5 text-neutral-600 outline-none placeholder:text-neutral-400/90 dark:border-neutral-500 dark:bg-neutral-800 dark:text-neutral-300/80 dark:placeholder:text-neutral-400/50',

--- a/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
+++ b/src/components/checks/[share_token]/practice/RenderPracticeQuestion.tsx
@@ -217,10 +217,31 @@ function ChoiceAnswerOptions<Q extends ChoiceQuestion>({ question, type }: { typ
   }, [isValidationComplete])
 
   return question.answers.map((a, i) => {
+    const handleActivate = () => {
+      if (isValidationComplete) {
+        setOpenFeedbacks((prev) => (prev.includes(a.id) ? prev.filter((id) => id !== a.id) : prev.concat([a.id])))
+        return
+      }
+
+      const input = document.getElementById(a.id) as HTMLInputElement | null
+      if (!input || input.disabled) return
+
+      input.focus()
+      input.click()
+    }
+
+    const handleKeyDown: React.KeyboardEventHandler<HTMLLabelElement> = (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return
+
+      event.preventDefault()
+      handleActivate()
+    }
+
     return (
       <ChoiceOption
         key={a.id}
-        onClick={isValidationComplete ? () => setOpenFeedbacks((prev) => (prev.includes(a.id) ? prev.filter((id) => id !== a.id) : prev.concat([a.id]))) : undefined}
+        onClick={isValidationComplete ? handleActivate : undefined}
+        onKeyDown={handleKeyDown}
         mode={isValidationComplete ? 'feedback' : 'input'}
         isCorrect={isValidationComplete && isCorrectlySelected(a)}
         isWrong={isValidationComplete && isFalslySelected(a)}

--- a/src/components/i18n/LanguageSwitcher.tsx
+++ b/src/components/i18n/LanguageSwitcher.tsx
@@ -4,7 +4,7 @@ import DE from 'country-flag-icons/react/3x2/DE'
 import US from 'country-flag-icons/react/3x2/US'
 import { FileQuestionIcon } from 'lucide-react'
 import { Button } from '@/src/components/shadcn/button'
-import { Popover, PopoverContent, PopoverTrigger } from '@/src/components/Shared/Popover'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/src/components/shadcn/dropdown-menu'
 import { useChangeLocale, useCurrentLocale } from '@/src/i18n/client-localization'
 import { i18nLocale, locales } from '@/src/i18n/i18nConfig'
 
@@ -13,32 +13,30 @@ export default function LanguageSwitcher() {
   const { Icon } = useLocale(currentLocale, 'size-6')
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
         <Button aria-label='change app language' className='flex size-auto items-center p-1' variant='ghost' size='icon'>
           {Icon}
         </Button>
-      </PopoverTrigger>
-      <PopoverContent className='w-32 p-2 text-sm'>
-        <div className='grid gap-1'>
-          {locales.map((locale) => (
-            <LocaleButton key={locale} locale={locale} />
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent sideOffset={10} className={'w-32 p-2 text-sm'}>
+        {locales.map((locale) => (
+          <LocaleItem locale={locale} key={locale} />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 
-function LocaleButton({ locale }: { locale: i18nLocale }) {
+function LocaleItem({ locale }: { locale: i18nLocale }) {
   const { Icon, long } = useLocale(locale)
   const changeLocale = useChangeLocale()
 
   return (
-    <Button type='button' variant='ghost' onClick={() => changeLocale(locale)} className='flex items-center gap-2.5 capitalize *:[svg]:size-5'>
+    <DropdownMenuItem onClick={() => changeLocale(locale)} className='flex h-9 items-center gap-2.5 px-4 py-2 capitalize *:[svg]:size-5'>
       {Icon}
       <span>{long}</span>
-    </Button>
+    </DropdownMenuItem>
   )
 }
 

--- a/src/components/shadcn/button.tsx
+++ b/src/components/shadcn/button.tsx
@@ -26,8 +26,8 @@ const buttonVariants = cva(
           'enabled:hover:bg-neutral-400/30 enabled:hover:text-accent-foreground/60 enabled:active:ring-2 enabled:active:ring-accent dark:enabled:hover:bg-accent/60 dark:enabled:hover:text-accent-foreground/55 dark:enabled:active:bg-accent/90',
         link: 'text-primary underline-offset-4 enabled:hover:underline',
         base: cn(
-          'bg-neutral-100/80 ring-1 ring-ring-subtle dark:bg-neutral-700/40',
-          'enabled:hover:bg-neutral-50/80 enabled:hover:ring-ring enabled:active:bg-neutral-200/90 enabled:active:ring-ring-focus dark:enabled:hover:bg-neutral-700/70 dark:enabled:active:bg-neutral-700/90',
+          'border border-ring-subtle bg-neutral-100/80 dark:bg-neutral-700/40',
+          'enabled:hover:border-ring enabled:hover:bg-neutral-50/80 enabled:active:border-ring-focus enabled:active:bg-neutral-200/90 dark:enabled:hover:bg-neutral-700/70 dark:enabled:active:bg-neutral-700/90',
         ),
         input: cn(
           'border border-input-ring bg-input',


### PR DESCRIPTION
This pull request improves accessibility and the UX of practice related components. It introduces keyboard accessibility features, improves the visual appearance of feedback colors in light-mode, feedback tooltips were made more predictable (no overlap, keyboard/escape support). Overall it improved the visual appearance of feedback, tooltips in terms of overlapping and keyboard accessibility and respective styling.


* **Features**
  * Keyboard accessibility upgrades across choice answers, open questions, and drag-drop (better tab flow, space/enter interaction, keyboard-triggered feedback tooltips).
  * Improved Language Switcher behavior by using a dropdown that closes automatically after selecting a locale.
  * More robust feedback tooltip UX, including support for closing pinned tooltips by pressing _Escape_.

* **Fixes**

  * Prevented feedback tooltip overlap by ensuring only one feedback tooltip can be open at a time (applied to choice answers and extended to drag-drop).
  * Fixed missing/weak focus-visible and interaction cues (e.g., “check answer” button keyboard focus styling; open-question textarea focus styles by using the shared `Textarea` component).
  * Disabled interaction on options without feedback to avoid misleading clicks and simplify handling.

* **Chores**

  * Streamlined tab order and focus management (adjusted `tabIndex` users can tab through answer options).
  * Centralized tooltip overlap-prevention logic inside `FeedbackText` to reduce duplication.
  * Reduced style duplication by introducing a combined hover/focus-visible utility (`hocus`) and aligning focus outlines (ring → border) for consistency.

* **Styles**

  * Light-mode feedback colors improved for both choice and open-question feedback.
  * Focus-visible styles added/adjusted for choice options and category selection so keyboard users get clear visual emphasis.


---
### Detailed Changelog

<details>
<summary>Changelog</summary>

[](https://google.com)

- **Refactors**:
  - Defined `tabIndex` on choice answer options ([`f6d69358`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f6d69358))
     This way each answer-option label is accessibly through tabbing.
  
  - Removed `tabIndex` from `QuestioNav` elements ([`cb887091`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/cb887091))
     The reason for this is that this way users can easily tab through controls, like switching categories, answer-options and navigation buttons (next, prev).
  
  - Applied `DropDownMenu` in `LanguageSwitcher` ([`05ff6808`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/05ff6808))
     This way the drop-down menu automatically closes once a item, in this case, locale is selected. Previously, the popover remained open until it lost focus.
  
  - Eliminated feedback overlap for choice answers ([`18542419`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/18542419))
     The reason for this change is that previously the feedback tooltip would overlap when the feedback-tooltip was ope for multiple answer-options. This commit ensures that only one feedback-tooltip can be opened at once, for choice answer-options.
  
  - Integrated feedback overlap detection into `FeedbackTxt` ([`495542cf`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/495542cf))
     This way the automatic closing of feedback-tooltips is backed into the `FeedbackText` component to reduce code duplication.
  
  - Enabled feedback overlap prevention for drag-drop ([`80eab244`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/80eab244))
     
  - Added `pointer-events-none` to options w/o feedback ([`3c6cb3fe`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/3c6cb3fe))
     This way any interaction with answer-options that have no feedback are disabled. This way the `onClick` handler of said items must not be modified to only exist for items with feedback.
  
  - Added keyboard accessibility to choice options ([`1bc2a77d`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/1bc2a77d))
     Previously the `tabIndex` was set to 0 for choice-options. However, users were unable to e.g. select an option via space, or enter as one would expect. In other words users were able to focus an option via the keyboard but not interact with it. By externalizing the onClick handler it's logic can be used within the new `onKeyDown` handler.
  
  - Unified open-q answer textarea using `Textarea` ([`ab3120c8`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/ab3120c8))
     This component essentially applies the existing `Textarea` component in the `OpenQuestionAnswer.`. The reason for this change is that the previously used base-textarea was missing proper focus-visible styles, e.g. when it was accessed via the keyboard. By using the `Textarea` these styles must not be re-declared.
  
  - Added pinned feedback closure on escape ([`2a2eb77f`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/2a2eb77f))
     Previously when a feedback tooltip was pinned by the user then the tooltip could only be closed by unpinning it. Thus, pressing e.g. escape would not close the tooltip. On the other hand, when a tooltip was shown on hover and escape was pressed it would close. To resolve this UX discrapency the `onKeyDown` handler was updated to close the tooltip when the element for which the tooltip is shown is focussed and escape is pressed.
  
  - Added open-q tooltip keyboard accessibility ([`4d087ceb`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/4d087ceb))
     This way users can focus the open-question textarea input with their keyboard and toggle the feedback-tooltip appearance by using their keyboard.
  
  - Added drag-drop tooltip keyboard accessibility ([`4df9cc47`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/4df9cc47))
     This way users can focus drag-drop answer options  with their keyboard and toggle the feedback-tooltip appearance by using their keyboard, once submitted and when feedback is available for that given option.
  
  - Removed keyboard accessibility for options w/o feedback ([`825b9532`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/825b9532))
     This way users can not access answer-options with their keyboard that have no feedback.
  

- **Styles**:
  - Improved light-mode choice feedback colors ([`bcdc8ce3`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/bcdc8ce3))
     
  - Improved light-mode open-question feedback colors ([`02074bd8`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/02074bd8))
     
  - Added focus-visible styles to choice-options ([`56fbe565`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/56fbe565))
     This way choice-options that are e.g. focussed via the keyboard show emphasize the currently focussed item.
  
  - Changed base button ring to border styles ([`f188bbba`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f188bbba))
     The reason for this is that this way the interactive focus styles match the appearance of any other focussed element. In other words when an element is focused a opacified ring is shown as the focus-style. When the `ring` is used to outline a button that outline would be lost on focus, thus a border is used instead.
  
  - Fixed interactive styles for `check answer` btn ([`23f21a44`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/23f21a44))
     The reason for this change is that previously the `check answer` button did not show any interactive styles at all when it was focussed via the keyboard. By simply using a respective button variant and not overriding its styles this issue is resolved.
  
  - Added focus-visible styles to category selection ([`5b7c3a41`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/5b7c3a41))
     This way users that select a category through the keyboard will be shown the same interactive styles as if they would hover the respective element with the mouse.
  
  - Simplified focus-visible, hover styles using`hocus` ([`ed1ecd77`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/ed1ecd77))
     By introducing a new custom-variant called `hocus` which combines both the `hover` and `focus-visible` state class-duplication can be reduced.
  
</details>
