### PR TITLE
Feat: Introduce practice result dummy page draft

### DIFF
--- a/src/app/[locale]/results/[checkId]/practice/page.tsx
+++ b/src/app/[locale]/results/[checkId]/practice/page.tsx
@@ -1,0 +1,54 @@
+import { notFound } from 'next/navigation'
+import { getKnowledgeCheckById } from '@/database/knowledgeCheck/select'
+import { QuestionCorrectnessPieChart } from '@/src/components/charts/QuestionCorrectnessPieChart'
+import { ExamQuestionDurationChart } from '@/src/components/charts/QuestionDurationChart'
+import { QuestionScorePlotCard } from '@/src/components/charts/QuestionScorePlot'
+import ExamQuestionResultTable from '@/src/components/checks/[share_token]/results/ExamQuestionResultTable'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/src/components/shadcn/card'
+import PageHeading from '@/src/components/Shared/PageHeading'
+import { getScopedI18n } from '@/src/i18n/server-localization'
+import requireAuthentication from '@/src/lib/auth/requireAuthentication'
+
+export default async function PracticeResultsPage({ params }: { params: Promise<{ checkId: string }> }) {
+  const { checkId } = await params
+  const { user } = await requireAuthentication()
+
+  const check = await getKnowledgeCheckById(checkId)
+
+  if (!check) notFound()
+  // todo verify that only the user that made a respective practice-attempt can view the attmept.
+  // if (check) forbidden()
+
+  const t = await getScopedI18n('Checks.ExaminatonResults')
+
+  return (
+    <>
+      <PageHeading title='Practice Attempt Results' />
+
+      <div className='mx-6 mt-2 flex flex-col gap-16'>
+        <div className='mx-0 flex flex-col gap-16'>
+          <div className='grid-container [--grid-column-count:3] [--grid-desired-gap:70px] [--grid-item-min-width:280px] @[360px]:[--grid-item-min-width:340px]'>
+            <QuestionCorrectnessPieChart title='Practice Performance' description='Shows the amount of questions that were answered in-, correctly or not at all.' />
+            <ExamQuestionDurationChart title={'Question Time Difference'} description={t('Charts.ExamQuestionDurationChart.description')} />
+          </div>
+
+          <div className='grid-container [--grid-column-count:2] [--grid-desired-gap:70px] [--grid-item-min-width:280px] @[550px]:[--grid-item-min-width:500px]'>
+            <QuestionScorePlotCard title='Performace Results per Question' description={'Shows the variance between the received question score and max-score by question'} />
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader className='-mt-6 flex flex-col items-stretch border-b bg-card pt-6 sm:flex-row'>
+            <div className='flex flex-1 flex-col justify-center gap-1 pb-3 sm:pb-0'>
+              <CardTitle>{'Question Overivew'}</CardTitle>
+              <CardDescription>{'Shows a detailed list of every question of this check to review your answers.'}</CardDescription>
+            </div>
+          </CardHeader>
+          <CardContent className='mt-auto'>
+            <ExamQuestionResultTable />
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  )
+}

--- a/src/app/[locale]/results/[checkId]/practice/page.tsx
+++ b/src/app/[locale]/results/[checkId]/practice/page.tsx
@@ -4,6 +4,7 @@ import { QuestionCorrectnessPieChart } from '@/src/components/charts/QuestionCor
 import { ExamQuestionDurationChart } from '@/src/components/charts/QuestionDurationChart'
 import { QuestionScorePlotCard } from '@/src/components/charts/QuestionScorePlot'
 import ExamQuestionResultTable from '@/src/components/checks/[share_token]/results/ExamQuestionResultTable'
+import { PracticeResultsBreadcrumbs } from '@/src/components/results/practice/PracticeResultsBreadcrumbs'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/src/components/shadcn/card'
 import PageHeading from '@/src/components/Shared/PageHeading'
 import { getScopedI18n } from '@/src/i18n/server-localization'
@@ -23,6 +24,7 @@ export default async function PracticeResultsPage({ params }: { params: Promise<
 
   return (
     <>
+      <PracticeResultsBreadcrumbs share_token={check.share_key!} />
       <PageHeading title='Practice Attempt Results' />
 
       <div className='mx-6 mt-2 flex flex-col gap-16'>

--- a/src/app/[locale]/results/[checkId]/practice/page.tsx
+++ b/src/app/[locale]/results/[checkId]/practice/page.tsx
@@ -20,30 +20,31 @@ export default async function PracticeResultsPage({ params }: { params: Promise<
   // todo verify that only the user that made a respective practice-attempt can view the attmept.
   // if (check) forbidden()
 
-  const t = await getScopedI18n('Checks.ExaminatonResults')
+  const tExamResults = await getScopedI18n('Checks.ExaminatonResults')
+  const t = await getScopedI18n('Checks.PracticeResults')
 
   return (
     <>
       <PracticeResultsBreadcrumbs share_token={check.share_key!} />
-      <PageHeading title='Practice Attempt Results' />
+      <PageHeading title={t('title')} />
 
       <div className='mx-6 mt-2 flex flex-col gap-16'>
         <div className='mx-0 flex flex-col gap-16'>
           <div className='grid-container [--grid-column-count:3] [--grid-desired-gap:70px] [--grid-item-min-width:280px] @[360px]:[--grid-item-min-width:340px]'>
-            <QuestionCorrectnessPieChart title='Practice Performance' description='Shows the amount of questions that were answered in-, correctly or not at all.' />
-            <ExamQuestionDurationChart title={'Question Time Difference'} description={t('Charts.ExamQuestionDurationChart.description')} />
+            <QuestionCorrectnessPieChart title={t('Charts.QuestionCorrectnessPieChart.title')} description={t('Charts.QuestionCorrectnessPieChart.description')} />
+            <ExamQuestionDurationChart title={t('Charts.DurationChart.title')} description={tExamResults('Charts.ExamQuestionDurationChart.description')} />
           </div>
 
           <div className='grid-container [--grid-column-count:2] [--grid-desired-gap:70px] [--grid-item-min-width:280px] @[550px]:[--grid-item-min-width:500px]'>
-            <QuestionScorePlotCard title='Performace Results per Question' description={'Shows the variance between the received question score and max-score by question'} />
+            <QuestionScorePlotCard title={t('Charts.QuestionScorePlot.title')} description={t('Charts.QuestionScorePlot.description')} />
           </div>
         </div>
 
         <Card>
           <CardHeader className='-mt-6 flex flex-col items-stretch border-b bg-card pt-6 sm:flex-row'>
             <div className='flex flex-1 flex-col justify-center gap-1 pb-3 sm:pb-0'>
-              <CardTitle>{'Question Overivew'}</CardTitle>
-              <CardDescription>{'Shows a detailed list of every question of this check to review your answers.'}</CardDescription>
+              <CardTitle>{t('Charts.DataTable.title')}</CardTitle>
+              <CardDescription>{t('Charts.DataTable.description')}</CardDescription>
             </div>
           </CardHeader>
           <CardContent className='mt-auto'>

--- a/src/components/charts/QuestionCorrectnessPieChart.tsx
+++ b/src/components/charts/QuestionCorrectnessPieChart.tsx
@@ -5,8 +5,10 @@ import React from 'react'
 import { Label, Pie, PieChart } from 'recharts'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/src/components/shadcn/card'
 import { ChartConfig, ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent } from '@/src/components/shadcn/chart'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 
 export function QuestionCorrectnessPieChart({ title, description }: { title: string; description?: string }) {
+  const t = useScopedI18n('Checks.PracticeResults.Charts.QuestionCorrectnessPieChart')
   const totalQuestionsCount = Math.max(Math.round(Math.random() * 150), Math.round(Math.max(48, Math.random() * 120)))
 
   const passedRate = Math.min(0.6, Math.max(0.4, Math.random()))
@@ -25,15 +27,15 @@ export function QuestionCorrectnessPieChart({ title, description }: { title: str
   const chartConfig = React.useMemo(
     (): ChartConfig => ({
       correct: {
-        label: 'Correct',
+        label: t('correct_label'),
         color: 'var(--chart-2)',
       },
       incorrect: {
-        label: 'Incorrect',
+        label: t('incorrect_label'),
         color: 'var(--chart-5)',
       },
       unanswered: {
-        label: 'Unanswered',
+        label: t('unanswered_label'),
         color: 'var(--chart-3)',
       },
     }),
@@ -96,7 +98,7 @@ export function QuestionCorrectnessPieChart({ title, description }: { title: str
                           {totalUsers.toLocaleString()}
                         </tspan>
                         <tspan x={viewBox.cx} y={(viewBox.cy || 0) + 24} className='fill-muted-foreground capitalize'>
-                          Questions
+                          {t('questions_inner_label')}
                         </tspan>
                       </text>
                     )

--- a/src/components/charts/QuestionCorrectnessPieChart.tsx
+++ b/src/components/charts/QuestionCorrectnessPieChart.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable react-hooks/purity */
+'use client'
+
+import React from 'react'
+import { Label, Pie, PieChart } from 'recharts'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/src/components/shadcn/card'
+import { ChartConfig, ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent } from '@/src/components/shadcn/chart'
+
+export function QuestionCorrectnessPieChart({ title, description }: { title: string; description?: string }) {
+  const totalQuestionsCount = Math.max(Math.round(Math.random() * 150), Math.round(Math.max(48, Math.random() * 120)))
+
+  const passedRate = Math.min(0.6, Math.max(0.4, Math.random()))
+  const correctQuestionsCount = Math.round(totalQuestionsCount * passedRate)
+
+  const remainingCount = totalQuestionsCount - correctQuestionsCount
+  const incorrectCount = Math.floor(remainingCount * 0.65)
+  const unansweredCount = totalQuestionsCount - (correctQuestionsCount + incorrectCount)
+
+  const data = [
+    { type: 'correct', count: correctQuestionsCount, fill: 'var(--color-correct)' },
+    { type: 'unanswered', count: unansweredCount, fill: 'var(--color-unanswered)' },
+    { type: 'incorrect', count: incorrectCount, fill: 'var(--color-incorrect)' },
+  ]
+
+  const chartConfig = React.useMemo(
+    (): ChartConfig => ({
+      correct: {
+        label: 'Correct',
+        color: 'var(--chart-2)',
+      },
+      incorrect: {
+        label: 'Incorrect',
+        color: 'var(--chart-5)',
+      },
+      unanswered: {
+        label: 'Unanswered',
+        color: 'var(--chart-3)',
+      },
+    }),
+    [],
+  )
+
+  const totalUsers = React.useMemo(() => {
+    return data.reduce((acc, curr) => acc + curr.count, 0)
+  }, [data])
+
+  return (
+    <Card className='flex flex-col'>
+      <CardHeader className='items-center pb-0'>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className='pb-0'>
+        <ChartContainer config={chartConfig} className='mx-auto max-h-[250px]'>
+          <PieChart>
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  hideLabel
+                  formatter={(value, name) => {
+                    return (
+                      <div className='flex flex-col gap-1'>
+                        <div className='flex flex-col gap-1.5'>
+                          <div className='flex items-center justify-between gap-4'>
+                            <div className='flex items-center gap-2'>
+                              <div
+                                className='size-2.5 shrink-0 rounded-[2px] bg-(--color-bg)'
+                                style={
+                                  {
+                                    '--color-bg': `var(--color-${name})`,
+                                  } as React.CSSProperties
+                                }
+                              />
+                              {chartConfig[name as keyof typeof chartConfig]?.label || name}
+                            </div>
+                            <div className='flex flex-1 items-baseline justify-end gap-1 text-right font-mono font-medium text-foreground tabular-nums'>
+                              {value}
+                              <span className='font-normal text-muted-foreground lowercase'>Questions</span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )
+                  }}
+                />
+              }
+            />
+            <Pie data={data} dataKey='count' nameKey='type' innerRadius={'55%'} strokeWidth={5} className=''>
+              <Label
+                content={({ viewBox }) => {
+                  if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
+                    return (
+                      <text x={viewBox.cx} y={viewBox.cy} textAnchor='middle' dominantBaseline='middle'>
+                        <tspan x={viewBox.cx} y={viewBox.cy} className='fill-foreground text-3xl font-bold'>
+                          {totalUsers.toLocaleString()}
+                        </tspan>
+                        <tspan x={viewBox.cx} y={(viewBox.cy || 0) + 24} className='fill-muted-foreground capitalize'>
+                          Questions
+                        </tspan>
+                      </text>
+                    )
+                  }
+                }}
+              />
+            </Pie>
+            <ChartLegend content={<ChartLegendContent nameKey='type' />} className='-translate-y-2 flex-wrap gap-6 *:basis-1/4 *:justify-center' />
+          </PieChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/charts/QuestionScorePlot.tsx
+++ b/src/components/charts/QuestionScorePlot.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import * as React from 'react'
+import { CartesianGrid, Line, LineChart, XAxis, YAxis } from 'recharts'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shadcn/card'
+import { type ChartConfig, ChartContainer, ChartLegend, ChartTooltip, ChartTooltipContent } from '@/shadcn/chart'
+import { useScopedI18n } from '@/src/i18n/client-localization'
+import { cn } from '@/src/lib/Shared/utils'
+import { Any } from '@/types'
+
+type ChartData = {
+  questionIndex: number
+  score: number
+  maxScore: number
+}
+
+const data: ChartData[] = [
+  { questionIndex: 0, score: 5, maxScore: 5 },
+  { questionIndex: 1, score: 6, maxScore: 7 },
+  { questionIndex: 2, score: 7, maxScore: 14 },
+  { questionIndex: 3, score: 9, maxScore: 9 },
+  { questionIndex: 4, score: 11, maxScore: 14 },
+  { questionIndex: 5, score: 3, maxScore: 4 },
+  { questionIndex: 6, score: 2, maxScore: 2 },
+  { questionIndex: 7, score: 12, maxScore: 12 },
+  { questionIndex: 8, score: 15, maxScore: 16 },
+  { questionIndex: 9, score: 17, maxScore: 18 },
+  { questionIndex: 10, score: 5, maxScore: 5 },
+  { questionIndex: 11, score: 3, maxScore: 7 },
+  { questionIndex: 12, score: 2, maxScore: 12 },
+  { questionIndex: 13, score: 5, maxScore: 6 },
+  { questionIndex: 14, score: 10, maxScore: 14 },
+]
+
+export function QuestionScorePlotCard({ title, description }: { title: string; description?: string }) {
+  return (
+    <Card>
+      <CardHeader className='flex flex-col items-stretch border-b sm:flex-row'>
+        <div className='flex flex-1 flex-col justify-center gap-1 pb-3 sm:pb-0'>
+          <CardTitle>{title}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </div>
+      </CardHeader>
+      <CardContent className='mt-auto px-2'>
+        <QuestionScorePlot />
+      </CardContent>
+    </Card>
+  )
+}
+
+export function QuestionScorePlot({ data: initialData = data, className }: { data?: ChartData[]; className?: string }) {
+  const t = useScopedI18n('Checks.ExaminatonResults.Charts.QuestionScoresLineChartCard')
+
+  const chartConfig = React.useMemo(
+    (): ChartConfig => ({
+      maxScore: {
+        label: t('maxScore_label'),
+      },
+      score: {
+        label: t('score_label'),
+      },
+    }),
+    [t],
+  )
+  return (
+    <ChartContainer config={chartConfig} className={cn('aspect-auto h-[250px] w-full', className)}>
+      <LineChart
+        accessibilityLayer
+        data={initialData}
+        margin={{
+          right: 12,
+          bottom: 5,
+        }}>
+        <CartesianGrid vertical={true} horizontal={false} />
+        <YAxis width={15} axisLine={false} tick={() => <></>} tickLine={false} />
+        <XAxis
+          //* shows every second tick-label
+          tick={({ payload, ...props }) => {
+            if (payload.value % 2 !== 0) return <></>
+
+            return (
+              <text x={props.x} textAnchor='middle' y={props.y + props.height / 3} className='' fill='gray'>
+                {payload.value + 1}
+              </text>
+            )
+          }}
+          label={({ viewBox: { x, y, width, height } }: Any) => (
+            <text x={x + width / 2 - 20} y={y + height + 3} className='' fill='gray'>
+              {t('x_axis_label')}
+            </text>
+          )}
+          dataKey='questionIndex'
+          tickLine={false}
+        />
+        <defs>
+          <linearGradient id='fillScore' x1='0' y1='0' x2='0' y2='1'>
+            <stop offset='5%' stopColor='var(--chart-2)' stopOpacity={0.9} />
+            <stop offset='95%' stopColor='var(--chart-2)' stopOpacity={0.3} />
+          </linearGradient>
+          <linearGradient id='fillMaxScore' x1='0' y1='0' x2='0' y2='1'>
+            <stop offset='5%' stopColor='var(--color-chart-3)' stopOpacity={0.9} />
+            <stop offset='95%' stopColor='var(--color-chart-3)' stopOpacity={0.3} />
+          </linearGradient>
+        </defs>
+
+        <ChartTooltip content={<ChartTooltipContent hideLabel className='w-[150px]' />} />
+        <Line type='step' label={'Question Points'} dataKey={'maxScore'} stroke={`var(--chart-3)`} strokeWidth={3} dot={false} fill='url(#fillMaxScore)' />
+        <Line type='step' dataKey={'score'} stroke={`var(--chart-2)`} strokeWidth={3} dot={true} fill='url(#fillScore)' />
+        <ChartLegend formatter={(val: 'score' | 'maxScore') => t(`${val}_label`)} wrapperStyle={{ bottom: '-10px', left: '25px', margin: '0px 15px 0px 25px', width: 'stretch' }} />
+      </LineChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/checks/[share_token]/practice/PracticeQuestionNavigation.tsx
+++ b/src/components/checks/[share_token]/practice/PracticeQuestionNavigation.tsx
@@ -11,7 +11,7 @@ import { useScopedI18n } from '@/src/i18n/client-localization'
 import { computeQuestionInputScore } from '@/src/lib/checks/computeQuestionScore'
 
 export function PracticeQuestionNavigation() {
-  const { practiceQuestions, navigateToQuestion, currentQuestionIndex, startedAt, results } = usePracticeStore((store) => store)
+  const { practiceQuestions, navigateToQuestion, currentQuestionIndex, startedAt, results, checkId } = usePracticeStore((store) => store)
   const t = useScopedI18n('Practice.PracticeQuestionNavigation')
 
   return (
@@ -47,7 +47,7 @@ export function PracticeQuestionNavigation() {
             body={t('EndPractice_ConfirmDialog.body')}
             confirmAction={() => {
               //! For testing purposes users can navigate back to the practice-page when the app is not in production.
-              redirect('/checks', process.env.NEXT_PUBLIC_MODE !== 'production' ? RedirectType.push : RedirectType.replace)
+              redirect(`/results/${checkId}/practice`, process.env.NEXT_PUBLIC_MODE !== 'production' ? RedirectType.push : RedirectType.replace)
             }}>
             <Button variant='link' type='button' size='sm' rippleClassname='bg-destructive/60' className='text-muted-foreground ring-ring-subtle/80 dark:ring-ring-subtle/80'>
               <SquareIcon className='text-destructive/70' />

--- a/src/components/results/practice/PracticeResultsBreadcrumbs.tsx
+++ b/src/components/results/practice/PracticeResultsBreadcrumbs.tsx
@@ -1,0 +1,32 @@
+import { DetailedHTMLProps, HTMLAttributes } from 'react'
+import Link from 'next/link'
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/src/components/shadcn/breadcrumb'
+export function PracticeResultsBreadcrumbs({ share_token, ...props }: { share_token: string } & DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>) {
+  return (
+    <Breadcrumb {...props}>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href={`/`}>Home</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href={`/checks`}>Checks</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href={`/checks/${share_token}/practice`}>Practice</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbPage>
+          <BreadcrumbItem>Results</BreadcrumbItem>
+        </BreadcrumbPage>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -275,6 +275,30 @@
         "score_slider_label": "Fragenergebnis",
         "title": "Details zur Antwort auf die Prüfungsfrage"
       }
+    },
+    "PracticeResults": {
+      "Charts": {
+        "QuestionCorrectnessPieChart": {
+          "correct_label": "Richtig",
+          "description": "Zeigt die Anzahl der Fragen an, die richtig, richtig oder gar nicht beantwortet wurden.",
+          "incorrect_label": "Falsch",
+          "title": "Übungsleistung",
+          "unanswered_label": "Unbeantwortet",
+          "questions_inner_label": "Fragen"
+        },
+        "DataTable": {
+          "description": "Zeigt eine detaillierte Liste aller Fragen dieser Prüfung an, um Ihre Antworten zu überprüfen.",
+          "title": "Fragenübersicht"
+        },
+        "DurationChart": {
+          "title": "Zeitunterschied zwischen Fragen"
+        },
+        "QuestionScorePlot": {
+          "description": "Zeigt die Abweichung zwischen der erhaltenen Fragepunktzahl und der maximalen Punktzahl pro Frage an",
+          "title": "Punkte unterschiede pro Frage"
+        }
+      },
+      "title": "Ergebnisse deines Übungsversuchs"
     }
   },
   "Examination": {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -151,7 +151,8 @@ export default {
     },
     Discover: {
       title: 'Entdecken Sie neue Wissenschecks',
-      no_checks_found_base: 'Keine Wissensüberprüfungen gefunden. \n' + 'Erstellen Sie Ihren eigenen KnowledgeCheck',
+      no_checks_found_base: 'Keine Wissensüberprüfungen gefunden. \n' +
+        'Erstellen Sie Ihren eigenen KnowledgeCheck',
       no_checks_found_link: 'hier',
       FilterFields: {
         filter_operand_menu_label: 'Filter Operatoren',
@@ -276,6 +277,30 @@ export default {
         score_slider_label: 'Fragenergebnis',
         title: 'Details zur Antwort auf die Prüfungsfrage'
       }
+    },
+    PracticeResults: {
+      Charts: {
+        QuestionCorrectnessPieChart: {
+          correct_label: 'Richtig',
+          description: 'Zeigt die Anzahl der Fragen an, die richtig, richtig oder gar nicht beantwortet wurden.',
+          incorrect_label: 'Falsch',
+          title: 'Übungsleistung',
+          unanswered_label: 'Unbeantwortet',
+          questions_inner_label: 'Fragen'
+        },
+        DataTable: {
+          description: 'Zeigt eine detaillierte Liste aller Fragen dieser Prüfung an, um Ihre Antworten zu überprüfen.',
+          title: 'Fragenübersicht'
+        },
+        DurationChart: {
+          title: 'Zeitunterschied zwischen Fragen'
+        },
+        QuestionScorePlot: {
+          description: 'Zeigt die Abweichung zwischen der erhaltenen Fragepunktzahl und der maximalen Punktzahl pro Frage an',
+          title: 'Punkte unterschiede pro Frage'
+        }
+      },
+      title: 'Ergebnisse deines Übungsversuchs'
     }
   },
   Examination: {
@@ -300,8 +325,7 @@ export default {
         confirm_button_label: 'Beenden',
         cancel_button_label: 'Fortsezten',
         title: 'Mit dem Üben aufhören?',
-        body:
-          'Nachdem Sie Ihren aktuellen Übungsversuch beendet haben, werden Ihre Ergebnisse übermittelt und sind für andere zugänglich. \n' +
+        body: 'Nachdem Sie Ihren aktuellen Übungsversuch beendet haben, werden Ihre Ergebnisse übermittelt und sind für andere zugänglich. \n' +
           'Bitte beachten Sie, dass Sie genau diesen Übungsversuch nicht fortsetzen können, nachdem Sie sie beendet haben.'
       }
     }
@@ -361,14 +385,15 @@ export default {
       },
       remove_share_token: {
         tooltip: 'Dieser Check hat keinen Freigabe schlüssel.',
-        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird das Share-Token dauerhaft aus diesem KnowledgeCheck gelöscht.',
+        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
+          'Dadurch wird das Share-Token dauerhaft aus diesem KnowledgeCheck gelöscht.',
         toast_deletion_successful: 'Freigabe token erfolgreich gelöscht',
         toast_deletion_failure: 'Löschen des freigabge tokens fehlgeschlagen!'
       },
       delete_knowledgeCheck: {
         label: 'Check löschen',
-        confirmation_dialog_body:
-          'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird dieser KnowledCheck dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
+        confirmation_dialog_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
+          'Dadurch wird dieser KnowledCheck dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
         toast_deletion_successful: 'KnowledgeCheck erfolgreich gelöscht',
         toast_deletion_failure: 'Löschen des KnowledgeChecks fehlgeschlagen!'
       },
@@ -379,7 +404,8 @@ export default {
     },
     ConfirmationDialog: {
       default_title: 'Bist du absolut sicher?',
-      default_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' + 'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
+      default_body: 'Diese Aktion kann nicht rückgängig gemacht werden. \n' +
+        'Dadurch wird dieses Element dauerhaft aus Ihrem Konto gelöscht und seine Daten von unseren Servern entfernt.',
       default_cancel_label: 'Abbrechen',
       default_confirm_label: 'Weiter'
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -284,6 +284,30 @@
         "title": "Examination Attempt Results",
         "description": "Shows all the details of the respective examination attempt of {name}"
       }
+    },
+    "PracticeResults": {
+      "title": "Practice Attempt Results",
+      "Charts": {
+        "QuestionCorrectnessPieChart": {
+          "title": "Practice Performance",
+          "description": "Shows the amount of questions that were answered in-, correctly or not at all.",
+          "correct_label": "Correct",
+          "incorrect_label": "Incorrect",
+          "unanswered_label": "Unanswered",
+          "questions_inner_label": "Questions"
+        },
+        "DurationChart": {
+          "title": "Question Time Difference"
+        },
+        "QuestionScorePlot": {
+          "title": "Performance Results per Question",
+          "description": "Shows the variance between the received question score and max-score by question"
+        },
+        "DataTable": {
+          "title": "Question Overview",
+          "description": "Shows a detailed list of every question of this check to review your answers."
+        }
+      }
     }
   },
   "Examination": {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -285,6 +285,30 @@ export default {
         title: 'Examination Attempt Results',
         description: 'Shows all the details of the respective examination attempt of {name}'
       }
+    },
+    PracticeResults: {
+      title: 'Practice Attempt Results',
+      Charts: {
+        QuestionCorrectnessPieChart: {
+          title: 'Practice Performance',
+          description: 'Shows the amount of questions that were answered in-, correctly or not at all.',
+          correct_label: 'Correct',
+          incorrect_label: 'Incorrect',
+          unanswered_label: 'Unanswered',
+          questions_inner_label: 'Questions'
+        },
+        DurationChart: {
+          title: 'Question Time Difference'
+        },
+        QuestionScorePlot: {
+          title: 'Performance Results per Question',
+          description: 'Shows the variance between the received question score and max-score by question'
+        },
+        DataTable: {
+          title: 'Question Overview',
+          description: 'Shows a detailed list of every question of this check to review your answers.'
+        }
+      }
     }
   },
   Examination: {


### PR DESCRIPTION

> [!NOTE]
> This pull request introduces a new page and set of charts for showing practice results to users. When a user ends / finishes a practice-attempt the user will be redirected to `[locale]/results/[checkId]/practice`. This page then shows three charts (question correctness pie chart, question time difference and score difference per question) as well as the (Examination-) AttemptTable which lists shows a detailed overview of the questions. 
>
> This is what the page looks right now.
> <img width="1206" height="1859" alt="CleanShot 2026-03-09 at 07 04 19" src="https://github.com/user-attachments/assets/6857ca06-1d4a-4082-926a-984a67782e78" />
>

> [!Caution]
> Note that this page is currently for dummy purposes only. It does not show any real data for a given practice run. Also, to show said results of a practice run it would need another sub-directory `[practiceId]` to identify and load practice results. Additionally, the page would need to verify that only users can view their own practice run results or check-administrators. However, since this page is just for exemplary purposes only these tasks are not of upmost importance. 



## Summary 

* **New Features**
  * Added a new practice results page displaying performance metrics through interactive charts (correctness distribution and score performance)
  * Added practice results breadcrumb component to show current nested location.
  * Updated end-practice navigation to direct users to the new results page

---
### Detailed Changelog

<details>
<summary>Changelog</summary>

[](https://google.com)

- **Features**:
  - Introduced `QuestionCorrectnessPieChart` ([`bf8f2701`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/bf8f2701))
     This chart component shows a pie chart with dummy data about how many questions were answered: correctly, incorrectly or not at all.
  
  - Introduced `QuestionScorePlot` component ([`adead766`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/adead766))
     This component renders a line chart showing the points a user has reached and the discrepancy to the maximum points the user could have achieved.
  
  - Drafted practice results page `root/results/practice` ([`7f1890a7`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/7f1890a7))
     
  - Added custom practice results breadcrumbs ([`38d12897`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/38d12897))
     

- **Refactors**:
  - Updated practice results location in `EndPractice` btn ([`b82587d2`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/b82587d2))
     This way users are redirected to the practice results page after finishing their practice run.
  
  - Added translations to practice results page ([`33c97e2a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/33c97e2a))
     
</details>
