### PR TITLE
Chore: Reapply default, catch values in stripEffect for arrays

### DIFF
--- a/src/schemas/utils/stripEffects.ts
+++ b/src/schemas/utils/stripEffects.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment,@typescript-eslint/no-explicit-any */
 import { z } from 'zod'
+import { Any } from '@/types'
 
 type StripOptions = {
   /** Remove only refinements/transforms (effects), or also drop built-in checks like .min/.max/.regex */
@@ -172,18 +173,17 @@ export function stripEffects<T extends z.ZodTypeAny>(schema: T, opts: StripOptio
     if (type === 'array') {
       const def = getDef(s)
       const element = (s as any).element ?? def?.element ?? def?.items
+      let out = z.array(go(element))
 
-      if (strip === 'effects-only') {
-        const out = z.array(go(element))
-        // todo re-apply non-effects like (min, max) note that def.checks includes refinments as `type: 'custom'`
-        // for (const check of def?.checks ?? []) out = out.check(check)
-
-        console.warn('Warning stripping all checks and effects from array.')
+      if (strip !== 'all') {
+        // re-apply default and catch value is they exist
+        if (def?.defaultValue) out = out.default(def.defaultValue) as Any
+        if (def?.catch) out = out.catch(def.catch) as Any
 
         memo.set(s, out)
         return out
       }
-      const out = z.array(go(element))
+
       memo.set(s, out)
       return out
     }

--- a/src/tests/integration/zod/effectStripping.ts
+++ b/src/tests/integration/zod/effectStripping.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from '@jest/globals'
+import z from 'zod'
+import { stripEffects } from '@/src/schemas/utils/stripEffects'
+
+describe('Verify Stripping of effects from schemas', () => {
+  it('Verify that effects are properly stripped from objects', () => {
+    const schema = z
+      .object({
+        name: z.string(),
+        age: z.number().optional(),
+      })
+      .transform((obj) => ({
+        ...obj,
+        name: 'My name has been transformed...',
+      }))
+      .transform((obj) => ({ ...obj, age: 7 }))
+
+    const dummyData: z.output<typeof schema> = {
+      name: 'some name',
+      age: 3,
+    }
+
+    expect(stripEffects(schema).parse(dummyData).name).toBe(dummyData.name)
+    expect(stripEffects(schema).parse(dummyData).age).not.toBe(7)
+  })
+
+  it('Verify that effects are properly stripped from arrays', () => {
+    const schema = z
+      .array(
+        z
+          .object({
+            name: z.string(),
+            age: z.number().optional(),
+          })
+          .transform((obj) => ({
+            ...obj,
+            name: 'My name has been transformed...',
+          }))
+          .transform((obj) => ({ ...obj, age: 7 })),
+      )
+      .min(1, 'Array must have length of one.')
+      .default([
+        {
+          age: 0,
+          name: 'Default name',
+        },
+      ])
+
+    const dummyData: z.output<typeof schema> = [
+      {
+        name: 'some name',
+        age: 3,
+      },
+    ]
+
+    const stripped = stripEffects(schema)
+
+    expect(stripped.parse(dummyData)[0].name).toBe(dummyData[0].name)
+    expect(stripped.parse(dummyData)[0].age).not.toBe(7)
+    expect(() => stripped.parse([])).not.toThrow()
+    expect(stripped.parse(undefined)).toEqual([{ age: 0, name: 'Default name' }])
+  })
+})


### PR DESCRIPTION
This pull request essentially updates the `stripEffect` logic for arrays. Previously, it always stripped the everything from the array itself no matter what mode (`all`, `effects-only`) was set. Now it re-applies default and catch values to the array when the mode is not set to `all`.