### PR TITLE
Feat: Update and introduce new course content renderings

### DIFF
--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import { getCourseById } from '@/database/course/select'
 import { NextContentButton, PreviousContentButton } from '@/src/components/courses/contents/[courseId]/ContentNavigationButtons'
 import { ContentProvider } from '@/src/components/courses/contents/[courseId]/ContentProvider'
@@ -7,13 +7,24 @@ import { ContentPageBreadcrumbs } from '@/src/components/courses/contents/[cours
 import { ContentSwitchButton } from '@/src/components/courses/contents/[courseId]/ContentSwitchButton'
 import PageHeading from '@/src/components/Shared/PageHeading'
 import { getScopedI18n } from '@/src/i18n/server-localization'
+import _logger from '@/src/lib/log/Logger'
+import getReferer from '@/src/lib/Shared/getReferer'
+
+const logger = _logger.createModuleLogger('/' + import.meta.url.split('/').reverse().slice(0, 2).reverse().join('/')!)
 
 export default async function CourseContentsPage({ params }: { params: Promise<{ courseId: string }> }) {
   const t = await getScopedI18n('Courses.Contents')
   const { courseId } = await params
   const course = await getCourseById(courseId)
+  const referer = await getReferer()
 
   if (!course) notFound()
+  if (course.contents.length === 0) {
+    logger.info(`Course (id: ${course.id}) has no contents, redirecting user back to ${referer ?? '/courses'} page.`)
+
+    // redirects users to where they came from when redirected by the app, or to the /courses page if user navigated manually.
+    redirect(referer ?? '/courses')
+  }
 
   return (
     <>

--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import { getCourseById } from '@/database/course/select'
 import { ContentProvider } from '@/src/components/courses/contents/[courseId]/ContentProvider'
 import { ContentRenderer } from '@/src/components/courses/contents/[courseId]/ContentRenderer'
+import { ContentPageBreadcrumbs } from '@/src/components/courses/contents/[courseId]/ContentsPageBreadcrumbs'
 import { ContentSwitchButton } from '@/src/components/courses/contents/[courseId]/ContentSwitchButton'
 import { Button } from '@/src/components/shadcn/button'
 import PageHeading from '@/src/components/Shared/PageHeading'
@@ -14,6 +15,7 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
 
   return (
     <>
+      <ContentPageBreadcrumbs course={course} />
       <PageHeading title='Course Contents' description='Read through the course contents to prepare for practice and examinations' />
 
       <ContentProvider initialProps={{ contents: course.contents }}>

--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -19,20 +19,20 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
       <PageHeading title='Course Contents' description='Read through the course contents to prepare for practice and examinations' />
 
       <ContentProvider initialProps={{ contents: course.contents }}>
-        <div className='flex flex-1 flex-col gap-6'>
-          <div className='flex flex-1 gap-8'>
+        <div className='flex flex-1 gap-8'>
+          <div className='flex flex-1 flex-col gap-6'>
             <ContentRenderer />
-            <div className='flex flex-col gap-2'>
-              <h2 className='font-semibold'>Available Contents</h2>
-              {course.contents.map((c) => (
-                <ContentSwitchButton content={c} key={c.categoryId} />
-              ))}
+            <div className='flex justify-between'>
+              <PreviousContentButton />
+              <NextContentButton />
             </div>
           </div>
 
-          <div className='flex justify-between'>
-            <PreviousContentButton />
-            <NextContentButton />
+          <div className='flex flex-col gap-2'>
+            <h2 className='font-semibold'>Available Contents</h2>
+            {course.contents.map((c) => (
+              <ContentSwitchButton content={c} key={c.categoryId} />
+            ))}
           </div>
         </div>
       </ContentProvider>

--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -16,9 +16,17 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
     <>
       <PageHeading title='Course Contents' description='Read through the course contents to prepare for practice and examinations' />
 
-      <div className='flex flex-1 flex-col'>
-        <div className='flex flex-1'>
+      <div className='flex flex-1 flex-col gap-6'>
+        <div className='flex flex-1 gap-8'>
           <ContentWrapper course={course} />
+          <div className='flex flex-col gap-2'>
+            <h2 className='font-semibold'>Available Contents</h2>
+            {course.contents.map((c) => (
+              <Button variant='link' className='w-fit max-w-48 text-ellipsis' key={c.categoryId}>
+                {c.title}
+              </Button>
+            ))}
+          </div>
         </div>
 
         <div className='flex justify-between'>

--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -6,8 +6,10 @@ import { ContentRenderer } from '@/src/components/courses/contents/[courseId]/Co
 import { ContentPageBreadcrumbs } from '@/src/components/courses/contents/[courseId]/ContentsPageBreadcrumbs'
 import { ContentSwitchButton } from '@/src/components/courses/contents/[courseId]/ContentSwitchButton'
 import PageHeading from '@/src/components/Shared/PageHeading'
+import { getScopedI18n } from '@/src/i18n/server-localization'
 
 export default async function CourseContentsPage({ params }: { params: Promise<{ courseId: string }> }) {
+  const t = await getScopedI18n('Courses.Contents')
   const { courseId } = await params
   const course = await getCourseById(courseId)
 
@@ -16,7 +18,7 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
   return (
     <>
       <ContentPageBreadcrumbs course={course} />
-      <PageHeading title='Course Contents' description='Read through the course contents to prepare for practice and examinations' />
+      <PageHeading title={t('title')} description={t('description')} />
 
       <ContentProvider initialProps={{ contents: course.contents }}>
         <div className='flex flex-1 gap-8'>
@@ -29,7 +31,7 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
           </div>
 
           <div className='flex flex-col gap-2'>
-            <h2 className='font-semibold'>Available Contents</h2>
+            <h2 className='font-semibold'>{t('Navigation.title')}</h2>
             {course.contents.map((c) => (
               <ContentSwitchButton content={c} key={c.categoryId} />
             ))}

--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -1,12 +1,10 @@
 import { notFound } from 'next/navigation'
 import { getCourseById } from '@/database/course/select'
 import { ContentProvider } from '@/src/components/courses/contents/[courseId]/ContentProvider'
+import { ContentRenderer } from '@/src/components/courses/contents/[courseId]/ContentRenderer'
 import { ContentSwitchButton } from '@/src/components/courses/contents/[courseId]/ContentSwitchButton'
 import { Button } from '@/src/components/shadcn/button'
 import PageHeading from '@/src/components/Shared/PageHeading'
-import { RichTextEditor } from '@/src/components/tiptap-examples/RichTextEditor'
-import { cn } from '@/src/lib/Shared/utils'
-import { Course } from '@/src/schemas/CourseSchema'
 
 export default async function CourseContentsPage({ params }: { params: Promise<{ courseId: string }> }) {
   const { courseId } = await params
@@ -21,7 +19,7 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
       <ContentProvider initialProps={{ contents: course.contents }}>
         <div className='flex flex-1 flex-col gap-6'>
           <div className='flex flex-1 gap-8'>
-            <ContentWrapper course={course} />
+            <ContentRenderer />
             <div className='flex flex-col gap-2'>
               <h2 className='font-semibold'>Available Contents</h2>
               {course.contents.map((c) => (
@@ -36,16 +34,6 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
           </div>
         </div>
       </ContentProvider>
-    </>
-  )
-}
-
-function ContentWrapper({ course }: { course: Course }) {
-  if (course.contents.length === 0 || !course.contents[0].content) return <>Course has no contents...</>
-
-  return (
-    <>
-      <RichTextEditor readOnly defaultContent={course.contents[0].content} editorPaneClassname={cn('border-dashed p-4')} />
     </>
   )
 }

--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -1,10 +1,10 @@
 import { notFound } from 'next/navigation'
 import { getCourseById } from '@/database/course/select'
+import { NextContentButton, PreviousContentButton } from '@/src/components/courses/contents/[courseId]/ContentNavigationButtons'
 import { ContentProvider } from '@/src/components/courses/contents/[courseId]/ContentProvider'
 import { ContentRenderer } from '@/src/components/courses/contents/[courseId]/ContentRenderer'
 import { ContentPageBreadcrumbs } from '@/src/components/courses/contents/[courseId]/ContentsPageBreadcrumbs'
 import { ContentSwitchButton } from '@/src/components/courses/contents/[courseId]/ContentSwitchButton'
-import { Button } from '@/src/components/shadcn/button'
 import PageHeading from '@/src/components/Shared/PageHeading'
 
 export default async function CourseContentsPage({ params }: { params: Promise<{ courseId: string }> }) {
@@ -31,8 +31,8 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
           </div>
 
           <div className='flex justify-between'>
-            <Button variant='outline'>Go back</Button>
-            <Button variant='primary'>Continue with</Button>
+            <PreviousContentButton />
+            <NextContentButton />
           </div>
         </div>
       </ContentProvider>

--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -30,7 +30,7 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
             </div>
           </div>
 
-          <div className='flex flex-col gap-2'>
+          <div className='hidden flex-col gap-2 @4xl:flex'>
             <h2 className='font-semibold'>{t('Navigation.title')}</h2>
             {course.contents.map((c) => (
               <ContentSwitchButton content={c} key={c.categoryId} />

--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 import { getCourseById } from '@/database/course/select'
 import { ContentProvider } from '@/src/components/courses/contents/[courseId]/ContentProvider'
+import { ContentSwitchButton } from '@/src/components/courses/contents/[courseId]/ContentSwitchButton'
 import { Button } from '@/src/components/shadcn/button'
 import PageHeading from '@/src/components/Shared/PageHeading'
 import { RichTextEditor } from '@/src/components/tiptap-examples/RichTextEditor'
@@ -24,9 +25,7 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
             <div className='flex flex-col gap-2'>
               <h2 className='font-semibold'>Available Contents</h2>
               {course.contents.map((c) => (
-                <Button variant='link' className='w-fit max-w-48 text-ellipsis' key={c.categoryId}>
-                  {c.title}
-                </Button>
+                <ContentSwitchButton content={c} key={c.categoryId} />
               ))}
             </div>
           </div>

--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 import { getCourseById } from '@/database/course/select'
+import { ContentProvider } from '@/src/components/courses/contents/[courseId]/ContentProvider'
 import { Button } from '@/src/components/shadcn/button'
 import PageHeading from '@/src/components/Shared/PageHeading'
 import { RichTextEditor } from '@/src/components/tiptap-examples/RichTextEditor'
@@ -16,24 +17,26 @@ export default async function CourseContentsPage({ params }: { params: Promise<{
     <>
       <PageHeading title='Course Contents' description='Read through the course contents to prepare for practice and examinations' />
 
-      <div className='flex flex-1 flex-col gap-6'>
-        <div className='flex flex-1 gap-8'>
-          <ContentWrapper course={course} />
-          <div className='flex flex-col gap-2'>
-            <h2 className='font-semibold'>Available Contents</h2>
-            {course.contents.map((c) => (
-              <Button variant='link' className='w-fit max-w-48 text-ellipsis' key={c.categoryId}>
-                {c.title}
-              </Button>
-            ))}
+      <ContentProvider initialProps={{ contents: course.contents }}>
+        <div className='flex flex-1 flex-col gap-6'>
+          <div className='flex flex-1 gap-8'>
+            <ContentWrapper course={course} />
+            <div className='flex flex-col gap-2'>
+              <h2 className='font-semibold'>Available Contents</h2>
+              {course.contents.map((c) => (
+                <Button variant='link' className='w-fit max-w-48 text-ellipsis' key={c.categoryId}>
+                  {c.title}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <div className='flex justify-between'>
+            <Button variant='outline'>Go back</Button>
+            <Button variant='primary'>Continue with</Button>
           </div>
         </div>
-
-        <div className='flex justify-between'>
-          <Button variant='outline'>Go back</Button>
-          <Button variant='primary'>Continue with</Button>
-        </div>
-      </div>
+      </ContentProvider>
     </>
   )
 }

--- a/src/app/[locale]/courses/contents/[courseId]/page.tsx
+++ b/src/app/[locale]/courses/contents/[courseId]/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from 'next/navigation'
+import { getCourseById } from '@/database/course/select'
+import { Button } from '@/src/components/shadcn/button'
+import PageHeading from '@/src/components/Shared/PageHeading'
+import { RichTextEditor } from '@/src/components/tiptap-examples/RichTextEditor'
+import { cn } from '@/src/lib/Shared/utils'
+import { Course } from '@/src/schemas/CourseSchema'
+
+export default async function CourseContentsPage({ params }: { params: Promise<{ courseId: string }> }) {
+  const { courseId } = await params
+  const course = await getCourseById(courseId)
+
+  if (!course) notFound()
+
+  return (
+    <>
+      <PageHeading title='Course Contents' description='Read through the course contents to prepare for practice and examinations' />
+
+      <div className='flex flex-1 flex-col'>
+        <div className='flex flex-1'>
+          <ContentWrapper course={course} />
+        </div>
+
+        <div className='flex justify-between'>
+          <Button variant='outline'>Go back</Button>
+          <Button variant='primary'>Continue with</Button>
+        </div>
+      </div>
+    </>
+  )
+}
+
+function ContentWrapper({ course }: { course: Course }) {
+  if (course.contents.length === 0 || !course.contents[0].content) return <>Course has no contents...</>
+
+  return (
+    <>
+      <RichTextEditor readOnly defaultContent={course.contents[0].content} editorPaneClassname={cn('border-dashed p-4')} />
+    </>
+  )
+}

--- a/src/components/courses/(hamburger-menu)/CourseActionMenu.tsx
+++ b/src/components/courses/(hamburger-menu)/CourseActionMenu.tsx
@@ -29,7 +29,7 @@ import { useSession } from '@/src/lib/auth/client'
 import { generateToken } from '@/src/lib/Shared/generateToken'
 import { Course } from '@/src/schemas/CourseSchema'
 
-export default function CourseActionMenu({ id, questions, share_key, owner_id, collaborators }: {} & Course) {
+export default function CourseActionMenu({ id, questions, share_key, owner_id, collaborators, contents }: {} & Course) {
   const t = useScopedI18n('Components.CourseActionMenu')
   const [menuOpen, setMenuOpen] = useState(false)
 
@@ -105,6 +105,18 @@ export default function CourseActionMenu({ id, questions, share_key, owner_id, c
             <ArrowUpRightIcon className='text-neutral-600 group-data-disabled:text-inherit dark:text-neutral-400 dark:group-data-disabled:text-inherit' />
           </DropdownMenuItem>
         </DropdownMenuGroup>
+
+        <DropdownMenuItem
+          className='group justify-between'
+          enableTooltip={contents.length === 0}
+          tooltipOptions={{ ...baseTooltipOptions, content: t('show_course_contents.tooltip') }}
+          onClick={() => {
+            router.push(`${window.location.origin}/courses/contents/${id}`)
+          }}
+          disabled={contents.length === 0}>
+          {t('show_course_contents.label')}
+          <ArrowUpRightIcon className='text-neutral-600 group-data-disabled:text-inherit dark:text-neutral-400 dark:group-data-disabled:text-inherit' />
+        </DropdownMenuItem>
 
         <DropdownMenuSub>
           <DropdownMenuSubTrigger enableTooltip={!hasQuestions} tooltipOptions={{ ...baseTooltipOptions, content: 'This course has no questions, sharing disabled.' }} disabled={!hasQuestions}>

--- a/src/components/courses/CourseCard.tsx
+++ b/src/components/courses/CourseCard.tsx
@@ -44,7 +44,7 @@ export function CourseCard(course: Course) {
         <span className='line-clamp-2 text-center text-sm text-balance text-neutral-500 dark:text-neutral-400'>{course.description}</span>
       </div>
       <div className='flex flex-wrap justify-evenly gap-8 px-6'>
-        <StatisticElement label={t('Statistics.questions_label')} value={course.questions.length} />
+        <StatisticElement label={t('Statistics.contents_label')} value={course.contents.length} />
         <StatisticElement
           label={t('Statistics.estimatedTime_label')}
           value={
@@ -53,7 +53,7 @@ export function CourseCard(course: Course) {
             </>
           }
         />
-        <StatisticElement label={t('Statistics.points_label')} value={course.questions.map((q) => q.points).reduce((prev, current) => (prev += current), 0)} />
+        <StatisticElement label={t('Statistics.questions_label')} value={course.questions.length} />
       </div>
       <Footer updatedAt={course.updatedAt} />
     </Card>

--- a/src/components/courses/contents/[courseId]/ContentNavigationButtons.tsx
+++ b/src/components/courses/contents/[courseId]/ContentNavigationButtons.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import { useContentContext } from '@/src/components/courses/contents/[courseId]/ContentProvider'
 import { Button } from '@/src/components/shadcn/button'
 
@@ -7,10 +8,13 @@ export function NextContentButton() {
   const { contents, currentContentIndex, setCurrentIndex } = useContentContext()
 
   if (contents.length <= currentContentIndex + 1) return <div />
-
   return (
-    <Button onClick={() => setCurrentIndex((prev) => prev + 1)} variant='link'>
-      Continue to {contents.at(currentContentIndex + 1)?.title}
+    <Button onClick={() => setCurrentIndex((prev) => prev + 1)} variant='ghost' className='group flex h-fit max-w-56 flex-col gap-1'>
+      <span className='self-start text-sm text-muted-foreground'>Next</span>
+      <div className='flex items-center gap-1 group-hover:text-primary group-hover:underline'>
+        {contents.at(currentContentIndex + 1)?.title}
+        <ChevronRightIcon className='transition-transform group-hover:scale-125' />
+      </div>
     </Button>
   )
 }
@@ -21,8 +25,12 @@ export function PreviousContentButton() {
   if (currentContentIndex - 1 < 0) return <div />
 
   return (
-    <Button onClick={() => setCurrentIndex((prev) => prev - 1)} variant='link'>
-      Go back to {contents.at(currentContentIndex - 1)?.title}
+    <Button onClick={() => setCurrentIndex((prev) => prev - 1)} variant='ghost' className='group flex h-fit max-w-56 flex-col gap-1'>
+      <span className='self-end text-right text-sm text-muted-foreground'>Previous </span>
+      <div className='flex items-center gap-1 group-hover:text-primary group-hover:underline'>
+        <ChevronLeftIcon className='transition-transform group-hover:scale-125' />
+        {contents.at(currentContentIndex - 1)?.title}
+      </div>
     </Button>
   )
 }

--- a/src/components/courses/contents/[courseId]/ContentNavigationButtons.tsx
+++ b/src/components/courses/contents/[courseId]/ContentNavigationButtons.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useContentContext } from '@/src/components/courses/contents/[courseId]/ContentProvider'
+import { Button } from '@/src/components/shadcn/button'
+
+export function NextContentButton() {
+  const { contents, currentContentIndex, setCurrentIndex } = useContentContext()
+
+  if (contents.length <= currentContentIndex + 1) return <div />
+
+  return (
+    <Button onClick={() => setCurrentIndex((prev) => prev + 1)} variant='link'>
+      Continue to {contents.at(currentContentIndex + 1)?.title}
+    </Button>
+  )
+}
+
+export function PreviousContentButton() {
+  const { contents, currentContentIndex, setCurrentIndex } = useContentContext()
+
+  if (currentContentIndex - 1 < 0) return <div />
+
+  return (
+    <Button onClick={() => setCurrentIndex((prev) => prev - 1)} variant='link'>
+      Go back to {contents.at(currentContentIndex - 1)?.title}
+    </Button>
+  )
+}

--- a/src/components/courses/contents/[courseId]/ContentNavigationButtons.tsx
+++ b/src/components/courses/contents/[courseId]/ContentNavigationButtons.tsx
@@ -3,14 +3,16 @@
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import { useContentContext } from '@/src/components/courses/contents/[courseId]/ContentProvider'
 import { Button } from '@/src/components/shadcn/button'
+import { useScopedI18n } from '@/src/i18n/client-localization'
 
 export function NextContentButton() {
+  const t = useScopedI18n('Courses.Contents.Navigation')
   const { contents, currentContentIndex, setCurrentIndex } = useContentContext()
 
   if (contents.length <= currentContentIndex + 1) return <div />
   return (
     <Button onClick={() => setCurrentIndex((prev) => prev + 1)} variant='ghost' className='group flex h-fit max-w-56 flex-col gap-1'>
-      <span className='self-start text-sm text-muted-foreground'>Next</span>
+      <span className='self-start text-sm text-muted-foreground'>{t('next_btn_label')}</span>
       <div className='flex items-center gap-1 group-hover:text-primary group-hover:underline'>
         {contents.at(currentContentIndex + 1)?.title}
         <ChevronRightIcon className='transition-transform group-hover:scale-125' />
@@ -20,13 +22,14 @@ export function NextContentButton() {
 }
 
 export function PreviousContentButton() {
+  const t = useScopedI18n('Courses.Contents.Navigation')
   const { contents, currentContentIndex, setCurrentIndex } = useContentContext()
 
   if (currentContentIndex - 1 < 0) return <div />
 
   return (
     <Button onClick={() => setCurrentIndex((prev) => prev - 1)} variant='ghost' className='group flex h-fit max-w-56 flex-col gap-1'>
-      <span className='self-end text-right text-sm text-muted-foreground'>Previous </span>
+      <span className='self-end text-right text-sm text-muted-foreground'>{t('previous_btn_label')}</span>
       <div className='flex items-center gap-1 group-hover:text-primary group-hover:underline'>
         <ChevronLeftIcon className='transition-transform group-hover:scale-125' />
         {contents.at(currentContentIndex - 1)?.title}

--- a/src/components/courses/contents/[courseId]/ContentProvider.tsx
+++ b/src/components/courses/contents/[courseId]/ContentProvider.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { createContext, SetStateAction, useContext, useState } from 'react'
+import { Course } from '@/src/schemas/CourseSchema'
+
+type ContextProps = {
+  currentContentIndex: number
+  setCurrentIndex: React.Dispatch<SetStateAction<number>>
+  contents: Course['contents']
+}
+
+const Context = createContext<ContextProps | null>(null)
+
+export function ContentProvider({ children, initialProps }: { children: React.ReactNode; initialProps?: Partial<ContextProps> }) {
+  const [currentIndex, setCurrentIndex] = useState(initialProps?.currentContentIndex ?? 0)
+
+  return <Context.Provider value={{ currentContentIndex: currentIndex, setCurrentIndex, contents: [], ...initialProps }}>{children}</Context.Provider>
+}
+
+export function useContentContext() {
+  const ctx = useContext(Context)
+
+  if (!ctx) throw new Error('useContentContext may only be used within a <ContentProvider />')
+
+  return ctx
+}

--- a/src/components/courses/contents/[courseId]/ContentRenderer.tsx
+++ b/src/components/courses/contents/[courseId]/ContentRenderer.tsx
@@ -7,5 +7,5 @@ import { cn } from '@/src/lib/Shared/utils'
 export function ContentRenderer() {
   const { contents, currentContentIndex } = useContentContext()
 
-  return <RichTextEditor readOnly defaultContent={contents.at(currentContentIndex)?.content} editorPaneClassname={cn('border-dashed p-4')} editorContainerClassname='max-h-[62dvh]' />
+  return <RichTextEditor readOnly defaultContent={contents.at(currentContentIndex)?.content} editorPaneClassname={cn('border-dashed p-4')} />
 }

--- a/src/components/courses/contents/[courseId]/ContentRenderer.tsx
+++ b/src/components/courses/contents/[courseId]/ContentRenderer.tsx
@@ -7,5 +7,5 @@ import { cn } from '@/src/lib/Shared/utils'
 export function ContentRenderer() {
   const { contents, currentContentIndex } = useContentContext()
 
-  return <RichTextEditor readOnly defaultContent={contents.at(currentContentIndex)?.content} editorPaneClassname={cn('border-dashed p-4')} />
+  return <RichTextEditor readOnly defaultContent={contents.at(currentContentIndex)?.content} editorPaneClassname={cn('border-dashed p-4')} editorContainerClassname='max-h-[62dvh]' />
 }

--- a/src/components/courses/contents/[courseId]/ContentRenderer.tsx
+++ b/src/components/courses/contents/[courseId]/ContentRenderer.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { useContentContext } from '@/src/components/courses/contents/[courseId]/ContentProvider'
+import { RichTextEditor } from '@/src/components/tiptap-examples/RichTextEditor'
+import { cn } from '@/src/lib/Shared/utils'
+
+export function ContentRenderer() {
+  const { contents, currentContentIndex } = useContentContext()
+
+  return <RichTextEditor readOnly defaultContent={contents.at(currentContentIndex)?.content} editorPaneClassname={cn('border-dashed p-4')} />
+}

--- a/src/components/courses/contents/[courseId]/ContentSwitchButton.tsx
+++ b/src/components/courses/contents/[courseId]/ContentSwitchButton.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { useMemo } from 'react'
+import { BookTextIcon } from 'lucide-react'
+import { useContentContext } from '@/src/components/courses/contents/[courseId]/ContentProvider'
+import { Button } from '@/src/components/shadcn/button'
+import { cn } from '@/src/lib/Shared/utils'
+import { Course } from '@/src/schemas/CourseSchema'
+
+/**
+ * Used to switch between available contents. Shows the title of a given content as the button-label in combination with an icon.
+ */
+export function ContentSwitchButton({ content }: { content: Course['contents'][number] }) {
+  const { contents, currentContentIndex, setCurrentIndex } = useContentContext()
+  const index = useMemo(() => contents.findIndex((c) => c.categoryId === content.categoryId), [content, contents])
+
+  return (
+    <Button variant='link' className={cn('w-fit text-ellipsis', index === currentContentIndex ? 'text-primary underline' : 'text-muted-foreground')} onClick={() => setCurrentIndex(index)}>
+      <BookTextIcon />
+      {content.title}
+    </Button>
+  )
+}

--- a/src/components/courses/contents/[courseId]/ContentSwitchButton.tsx
+++ b/src/components/courses/contents/[courseId]/ContentSwitchButton.tsx
@@ -14,7 +14,11 @@ export function ContentSwitchButton({ content }: { content: Course['contents'][n
   const index = useMemo(() => contents.findIndex((c) => c.categoryId === content.categoryId), [content, contents])
 
   return (
-    <Button variant='link' className={cn('w-fit text-ellipsis', index === currentContentIndex ? 'text-primary underline' : 'text-muted-foreground')} onClick={() => setCurrentIndex(index)}>
+    <Button
+      disabled={index === -1} // index retrieval was unsuccesful -> switching not possible
+      variant='link'
+      className={cn('w-fit text-ellipsis', index === currentContentIndex ? 'text-primary underline' : 'text-muted-foreground')}
+      onClick={() => setCurrentIndex(index)}>
       <BookTextIcon />
       {content.title}
     </Button>

--- a/src/components/courses/contents/[courseId]/ContentsPageBreadcrumbs.tsx
+++ b/src/components/courses/contents/[courseId]/ContentsPageBreadcrumbs.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link'
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/src/components/shadcn/breadcrumb'
+import { Course } from '@/src/schemas/CourseSchema'
+
+export function ContentPageBreadcrumbs({ course }: { course: Course }) {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href={`/`}>Home</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href={`/courses`}>Courses</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href={`/courses/edit/${course.id}`}>{course.name}</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+
+        <BreadcrumbPage>Contents</BreadcrumbPage>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/src/components/courses/create/(sections)/ContentSection.tsx
+++ b/src/components/courses/create/(sections)/ContentSection.tsx
@@ -9,7 +9,6 @@ import { CardStageJumpButton } from '@/src/components/Shared/CardStageJumpButton
 import ConfirmationDialog from '@/src/components/Shared/ConfirmationDialog/ConfirmationDialog'
 import { useScopedI18n } from '@/src/i18n/client-localization'
 import { cn } from '@/src/lib/Shared/utils'
-import { CourseContent } from '@/src/schemas/CourseContentSchema'
 
 export default function ContentSection({ jumpBackButton, disabled }: { jumpBackButton?: boolean; disabled?: boolean }) {
   const { contents } = useCourseStore((store) => store)
@@ -102,55 +101,5 @@ function EmptyCourseContentBody() {
       <Info className='size-16 text-neutral-400 dark:text-neutral-500' />
       <span className='text-center tracking-wide text-balance text-neutral-500 dark:text-neutral-400'>{'There are currently no contents associated to this course.'}</span>
     </div>
-  )
-}
-
-export function CourseContentOverview({ jumpBackButton = true }: { jumpBackButton?: boolean }) {
-  const { contents } = useCourseStore((store) => store)
-  const t = useScopedI18n('Courses.Create.ContentSection')
-
-  function Element(content: CourseContent) {
-    return (
-      <GenericCard disableInteractions className='flex flex-col gap-1 p-2'>
-        <h2 className='text-neutral-700 dark:text-neutral-300'>{content.title}</h2>
-        <p className='line-clamp-1 text-sm text-muted-foreground'>{content.description}</p>
-      </GenericCard>
-    )
-  }
-
-  if (contents.length === 0) {
-    return (
-      <GenericCard disableInteractions className='relative flex break-inside-avoid flex-col p-3'>
-        {jumpBackButton && <CardStageJumpButton targetStage={2} />}
-        <div className='-mx-3 -mt-3 flex flex-col rounded-t-md border-b border-neutral-400 bg-neutral-300 p-2 px-3 text-neutral-600 dark:border-neutral-500 dark:bg-neutral-700/60 dark:text-neutral-300'>
-          <div className='flex items-center justify-between'>
-            <h2 className=''>{t('title')}</h2>
-          </div>
-        </div>
-        <div className={cn('flex min-h-60 flex-1 flex-col items-center justify-center gap-6')}>
-          <Info className='size-16 text-neutral-400 dark:text-neutral-500' />
-          <span className='text-center tracking-wide text-balance text-neutral-500 dark:text-neutral-400'>{'There are currently no contents associated to this course.'}</span>
-        </div>
-      </GenericCard>
-    )
-  }
-
-  return (
-    <GenericCard disableInteractions className='relative flex break-inside-avoid flex-col p-3'>
-      {jumpBackButton && <CardStageJumpButton targetStage={2} />}
-      <div className='-mx-3 -mt-3 flex flex-col rounded-t-md border-b border-neutral-400 bg-neutral-300 p-2 px-3 text-neutral-600 dark:border-neutral-500 dark:bg-neutral-700/60 dark:text-neutral-300'>
-        <div className='flex items-center justify-between'>
-          <h2 className=''>{t('title')}</h2>
-        </div>
-      </div>
-
-      {contents.length === 0 && <div></div>}
-
-      <div className='mt-5 flex flex-col gap-6'>
-        {contents.map((c) => (
-          <Element key={c.categoryId} {...c} />
-        ))}
-      </div>
-    </GenericCard>
   )
 }

--- a/src/components/courses/create/(sections)/ContentSection.tsx
+++ b/src/components/courses/create/(sections)/ContentSection.tsx
@@ -1,34 +1,33 @@
 'use client'
 
-import { generateHTML } from '@tiptap/core'
-import { Info, PenIcon, Plus, TrashIcon } from 'lucide-react'
+import { Folder, Info, Pen, Plus, Trash2 } from 'lucide-react'
 import CourseContentDialog from '@/src/components/courses/create/(sections)/CourseContentDialog'
 import { useCourseStore } from '@/src/components/courses/create/CreateCourseProvider'
 import { Button } from '@/src/components/shadcn/button'
-import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from '@/src/components/shadcn/card'
 import GenericCard from '@/src/components/Shared/Card'
 import { CardStageJumpButton } from '@/src/components/Shared/CardStageJumpButton'
 import ConfirmationDialog from '@/src/components/Shared/ConfirmationDialog/ConfirmationDialog'
-import { RichTextEditor, RichTextEditorExtensions } from '@/src/components/tiptap-examples/RichTextEditor'
 import { useScopedI18n } from '@/src/i18n/client-localization'
 import { cn } from '@/src/lib/Shared/utils'
 import { CourseContent } from '@/src/schemas/CourseContentSchema'
 
-export default function ContentSection() {
+export default function ContentSection({ jumpBackButton, disabled }: { jumpBackButton?: boolean; disabled?: boolean }) {
   const { contents } = useCourseStore((store) => store)
   const t = useScopedI18n('Courses.Create.ContentSection')
 
   return (
-    <div className='flex flex-1 flex-col gap-10'>
-      <div className='flex flex-col gap-1'>
-        <h2 className='h-fit text-xl font-semibold'>{t('title')}</h2>
-        <span className='text-muted-foreground'>{t('description')}</span>
+    <GenericCard disableInteractions className='relative flex break-inside-avoid flex-col p-3'>
+      {jumpBackButton && <CardStageJumpButton targetStage={2} />}
+      <div className='-mx-3 -mt-3 flex flex-col rounded-t-md border-b border-neutral-400 bg-neutral-300 p-2 px-3 text-neutral-600 dark:border-neutral-500 dark:bg-neutral-700/60 dark:text-neutral-300'>
+        <div className='flex flex-col gap-0'>
+          <h2 className=''>{t('title')}</h2>
+        </div>
       </div>
 
-      {contents.length > 0 ? <CourseContentRenderer /> : <EmptyCourseContentBody />}
+      {contents.length > 0 ? <CourseContentRenderer disabled={disabled} /> : <EmptyCourseContentBody />}
 
-      <CreateContentButton />
-    </div>
+      <CreateContentButton disabled={disabled} />
+    </GenericCard>
   )
 }
 
@@ -47,45 +46,52 @@ function CreateContentButton({ disabled }: { disabled?: boolean }) {
   )
 }
 
-function CourseContentRenderer() {
+function CourseContentRenderer({ disabled }: { disabled?: boolean }) {
   const t = useScopedI18n('Courses.Create.ContentSection')
-  const { contents, removeCourseContent } = useCourseStore((store) => store)
+  const { contents, removeCourseContent, questionCategories } = useCourseStore((store) => store)
 
   return (
-    <div className='grid grid-cols-[repeat(auto-fill,minmax(380px,1fr))] gap-12'>
-      {contents.map((content) => {
-        const htmlContent = content.content ? generateHTML(content.content, RichTextEditorExtensions) : ''
+    <div className={cn('my-4 grid flex-1 grid-cols-1 gap-6')}>
+      {contents.map((content, i) => (
+        <GenericCard disableInteractions key={i + content.categoryId} className={cn('relative flex h-fit gap-3 p-2 first:mt-3 hover:bg-none')}>
+          <div className='flex flex-1 flex-col p-1'>
+            <div className='flex items-center justify-between'>
+              <h2 className='text-neutral-700 dark:text-neutral-300'>{content.title}</h2>
+              <span className='text-neutral-700 dark:text-neutral-300'>{}</span>
+            </div>
+            <div className='flex justify-between text-xs'>
+              <span className='text-neutral-500 lowercase dark:text-neutral-400'>{content.description}</span>
+              <div className='flex items-center gap-1 text-neutral-500 dark:text-neutral-400'>
+                <Folder className='size-3' />
+                <span className='lowercase'>{questionCategories.find((c) => c.id === content.categoryId)?.name}</span>
+              </div>
+            </div>
+          </div>
+          <CourseContentDialog mode='edit' courseContent={content}>
+            <Button
+              aria-label={t('Actions.edit_content_button_aria_label')}
+              size='icon'
+              variant='base'
+              type='button'
+              disabled={disabled}
+              className='group my-auto flex size-7.5 items-center gap-4 rounded-lg bg-neutral-300/50 p-1.5 ring-1 ring-neutral-400 hover:cursor-pointer hover:ring-[1.5px] hover:ring-ring-hover dark:bg-neutral-700 dark:ring-neutral-600 dark:hover:ring-ring-hover'>
+              <Pen className='size-4 text-orange-600/70 group-hover:stroke-3 dark:text-orange-400/70' />
+            </Button>
+          </CourseContentDialog>
 
-        return (
-          <Card key={content.categoryId} className=''>
-            <CardHeader>
-              <CardTitle>{content.title}</CardTitle>
-              <CardDescription>{content.description}</CardDescription>
-              <CardAction>
-                <CourseContentDialog mode='edit' courseContent={content}>
-                  <Button variant='link' asChild aria-label={t('Actions.edit_content_button_aria_label')} className='enabled:text-orange-400 dark:enabled:text-orange-300/80'>
-                    <PenIcon />
-                    {t('Actions.edit_content_button_label')}
-                  </Button>
-                </CourseContentDialog>
-
-                <ConfirmationDialog
-                  confirmAction={() => removeCourseContent(content.categoryId)}
-                  confirmLabel={t('Actions.delete_content_confirm_label')}
-                  body={t('Actions.delete_content_dialog_body')}>
-                  <Button variant='link' asChild aria-label={t('Actions.delete_content_button_aria_label')} className='enabled:text-destructive/80'>
-                    <TrashIcon />
-                    {t('Actions.delete_content_button_label')}
-                  </Button>
-                </ConfirmationDialog>
-              </CardAction>
-            </CardHeader>
-            <CardContent className='flex h-full px-4.5 **:[div]:[[role=presentation]]:max-h-42 **:[div]:[[role=presentation]]:min-h-auto **:[div]:[[role=presentation]]:cursor-default **:[div]:[[role=presentation]]:border-ring-subtle **:[div]:[[role=presentation]]:p-2.5'>
-              <RichTextEditor key={htmlContent} defaultContent={content.content} readOnly size='sm' />
-            </CardContent>
-          </Card>
-        )
-      })}
+          <ConfirmationDialog confirmAction={() => removeCourseContent(content.categoryId)} confirmLabel={t('Actions.delete_content_confirm_label')} body={t('Actions.delete_content_dialog_body')}>
+            <Button
+              size='icon'
+              variant='base'
+              aria-label={t('Actions.delete_content_button_aria_label')}
+              type='button'
+              disabled={disabled}
+              className='group my-auto flex size-7.5 items-center gap-4 rounded-lg bg-neutral-300/50 ring-1 ring-neutral-400 hover:cursor-pointer hover:ring-[1.5px] hover:ring-ring-hover dark:bg-neutral-700 dark:ring-neutral-600 dark:hover:ring-ring-hover'>
+              <Trash2 className='size-4 text-red-600/70 group-hover:stroke-[2.5] dark:text-red-400/70' />
+            </Button>
+          </ConfirmationDialog>
+        </GenericCard>
+      ))}
     </div>
   )
 }

--- a/src/components/courses/create/(sections)/ContentSection.tsx
+++ b/src/components/courses/create/(sections)/ContentSection.tsx
@@ -96,10 +96,11 @@ function CourseContentRenderer({ disabled }: { disabled?: boolean }) {
 }
 
 function EmptyCourseContentBody() {
+  const t = useScopedI18n('Courses.Create.ContentSection')
   return (
     <div className={cn('flex min-h-60 flex-1 flex-col items-center justify-center gap-6')}>
       <Info className='size-16 text-neutral-400 dark:text-neutral-500' />
-      <span className='text-center tracking-wide text-balance text-neutral-500 dark:text-neutral-400'>{'There are currently no contents associated to this course.'}</span>
+      <span className='text-center tracking-wide text-balance text-neutral-500 dark:text-neutral-400'>{t('empty_content_text')}</span>
     </div>
   )
 }

--- a/src/components/courses/create/(sections)/ContentSection.tsx
+++ b/src/components/courses/create/(sections)/ContentSection.tsx
@@ -1,14 +1,18 @@
 'use client'
 
 import { generateHTML } from '@tiptap/core'
-import { PenIcon, PlusCircleIcon, TrashIcon } from 'lucide-react'
+import { Info, PenIcon, PlusCircleIcon, TrashIcon } from 'lucide-react'
 import CourseContentDialog from '@/src/components/courses/create/(sections)/CourseContentDialog'
 import { useCourseStore } from '@/src/components/courses/create/CreateCourseProvider'
 import { Button } from '@/src/components/shadcn/button'
 import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from '@/src/components/shadcn/card'
+import GenericCard from '@/src/components/Shared/Card'
+import { CardStageJumpButton } from '@/src/components/Shared/CardStageJumpButton'
 import ConfirmationDialog from '@/src/components/Shared/ConfirmationDialog/ConfirmationDialog'
 import { RichTextEditor, RichTextEditorExtensions } from '@/src/components/tiptap-examples/RichTextEditor'
 import { useScopedI18n } from '@/src/i18n/client-localization'
+import { cn } from '@/src/lib/Shared/utils'
+import { CourseContent } from '@/src/schemas/CourseContentSchema'
 
 export default function ContentSection() {
   const { contents, removeCourseContent } = useCourseStore((store) => store)
@@ -64,5 +68,55 @@ export default function ContentSection() {
         })}
       </div>
     </div>
+  )
+}
+
+export function CourseContentOverview({ jumpBackButton = true }: { jumpBackButton?: boolean }) {
+  const { contents } = useCourseStore((store) => store)
+  const t = useScopedI18n('Courses.Create.ContentSection')
+
+  function Element(content: CourseContent) {
+    return (
+      <GenericCard disableInteractions className='flex flex-col gap-1 p-2'>
+        <h2 className='text-neutral-700 dark:text-neutral-300'>{content.title}</h2>
+        <p className='line-clamp-1 text-sm text-muted-foreground'>{content.description}</p>
+      </GenericCard>
+    )
+  }
+
+  if (contents.length === 0) {
+    return (
+      <GenericCard disableInteractions className='relative flex break-inside-avoid flex-col p-3'>
+        {jumpBackButton && <CardStageJumpButton targetStage={2} />}
+        <div className='-mx-3 -mt-3 flex flex-col rounded-t-md border-b border-neutral-400 bg-neutral-300 p-2 px-3 text-neutral-600 dark:border-neutral-500 dark:bg-neutral-700/60 dark:text-neutral-300'>
+          <div className='flex items-center justify-between'>
+            <h2 className=''>{t('title')}</h2>
+          </div>
+        </div>
+        <div className={cn('flex min-h-60 flex-1 flex-col items-center justify-center gap-6')}>
+          <Info className='size-16 text-neutral-400 dark:text-neutral-500' />
+          <span className='text-center tracking-wide text-balance text-neutral-500 dark:text-neutral-400'>{'There are currently no contents associated to this course.'}</span>
+        </div>
+      </GenericCard>
+    )
+  }
+
+  return (
+    <GenericCard disableInteractions className='relative flex break-inside-avoid flex-col p-3'>
+      {jumpBackButton && <CardStageJumpButton targetStage={2} />}
+      <div className='-mx-3 -mt-3 flex flex-col rounded-t-md border-b border-neutral-400 bg-neutral-300 p-2 px-3 text-neutral-600 dark:border-neutral-500 dark:bg-neutral-700/60 dark:text-neutral-300'>
+        <div className='flex items-center justify-between'>
+          <h2 className=''>{t('title')}</h2>
+        </div>
+      </div>
+
+      {contents.length === 0 && <div></div>}
+
+      <div className='mt-5 flex flex-col gap-6'>
+        {contents.map((c) => (
+          <Element key={c.categoryId} {...c} />
+        ))}
+      </div>
+    </GenericCard>
   )
 }

--- a/src/components/courses/create/(sections)/ContentSection.tsx
+++ b/src/components/courses/create/(sections)/ContentSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { generateHTML } from '@tiptap/core'
-import { Info, PenIcon, PlusCircleIcon, TrashIcon } from 'lucide-react'
+import { Info, PenIcon, Plus, TrashIcon } from 'lucide-react'
 import CourseContentDialog from '@/src/components/courses/create/(sections)/CourseContentDialog'
 import { useCourseStore } from '@/src/components/courses/create/CreateCourseProvider'
 import { Button } from '@/src/components/shadcn/button'
@@ -15,7 +15,7 @@ import { cn } from '@/src/lib/Shared/utils'
 import { CourseContent } from '@/src/schemas/CourseContentSchema'
 
 export default function ContentSection() {
-  const { contents, removeCourseContent } = useCourseStore((store) => store)
+  const { contents } = useCourseStore((store) => store)
   const t = useScopedI18n('Courses.Create.ContentSection')
 
   return (
@@ -25,48 +25,76 @@ export default function ContentSection() {
         <span className='text-muted-foreground'>{t('description')}</span>
       </div>
 
-      <div className='grid grid-cols-[repeat(auto-fill,minmax(380px,1fr))] gap-12'>
-        <CourseContentDialog mode='create'>
-          <Card className='flex h-full items-center justify-center'>
-            <CardContent className='flex gap-4 text-primary'>
-              <PlusCircleIcon /> {t('Actions.create_new_button_label')}
+      {contents.length > 0 ? <CourseContentRenderer /> : <EmptyCourseContentBody />}
+
+      <CreateContentButton />
+    </div>
+  )
+}
+
+function CreateContentButton({ disabled }: { disabled?: boolean }) {
+  const t = useScopedI18n('Courses.Create.ContentSection')
+
+  return (
+    <CourseContentDialog mode='create'>
+      <div className='flex justify-center gap-8'>
+        <Button variant='outline' size='lg' disabled={disabled}>
+          <Plus className='size-5' />
+          {t('Actions.create_new_button_label')}
+        </Button>
+      </div>
+    </CourseContentDialog>
+  )
+}
+
+function CourseContentRenderer() {
+  const t = useScopedI18n('Courses.Create.ContentSection')
+  const { contents, removeCourseContent } = useCourseStore((store) => store)
+
+  return (
+    <div className='grid grid-cols-[repeat(auto-fill,minmax(380px,1fr))] gap-12'>
+      {contents.map((content) => {
+        const htmlContent = content.content ? generateHTML(content.content, RichTextEditorExtensions) : ''
+
+        return (
+          <Card key={content.categoryId} className=''>
+            <CardHeader>
+              <CardTitle>{content.title}</CardTitle>
+              <CardDescription>{content.description}</CardDescription>
+              <CardAction>
+                <CourseContentDialog mode='edit' courseContent={content}>
+                  <Button variant='link' asChild aria-label={t('Actions.edit_content_button_aria_label')} className='enabled:text-orange-400 dark:enabled:text-orange-300/80'>
+                    <PenIcon />
+                    {t('Actions.edit_content_button_label')}
+                  </Button>
+                </CourseContentDialog>
+
+                <ConfirmationDialog
+                  confirmAction={() => removeCourseContent(content.categoryId)}
+                  confirmLabel={t('Actions.delete_content_confirm_label')}
+                  body={t('Actions.delete_content_dialog_body')}>
+                  <Button variant='link' asChild aria-label={t('Actions.delete_content_button_aria_label')} className='enabled:text-destructive/80'>
+                    <TrashIcon />
+                    {t('Actions.delete_content_button_label')}
+                  </Button>
+                </ConfirmationDialog>
+              </CardAction>
+            </CardHeader>
+            <CardContent className='flex h-full px-4.5 **:[div]:[[role=presentation]]:max-h-42 **:[div]:[[role=presentation]]:min-h-auto **:[div]:[[role=presentation]]:cursor-default **:[div]:[[role=presentation]]:border-ring-subtle **:[div]:[[role=presentation]]:p-2.5'>
+              <RichTextEditor key={htmlContent} defaultContent={content.content} readOnly size='sm' />
             </CardContent>
           </Card>
-        </CourseContentDialog>
-        {contents.map((content) => {
-          const htmlContent = content.content ? generateHTML(content.content, RichTextEditorExtensions) : ''
+        )
+      })}
+    </div>
+  )
+}
 
-          return (
-            <Card key={content.categoryId} className=''>
-              <CardHeader>
-                <CardTitle>{content.title}</CardTitle>
-                <CardDescription>{content.description}</CardDescription>
-                <CardAction>
-                  <CourseContentDialog mode='edit' courseContent={content}>
-                    <Button variant='link' asChild aria-label={t('Actions.edit_content_button_aria_label')} className='enabled:text-orange-400 dark:enabled:text-orange-300/80'>
-                      <PenIcon />
-                      {t('Actions.edit_content_button_label')}
-                    </Button>
-                  </CourseContentDialog>
-
-                  <ConfirmationDialog
-                    confirmAction={() => removeCourseContent(content.categoryId)}
-                    confirmLabel={t('Actions.delete_content_confirm_label')}
-                    body={t('Actions.delete_content_dialog_body')}>
-                    <Button variant='link' asChild aria-label={t('Actions.delete_content_button_aria_label')} className='enabled:text-destructive/80'>
-                      <TrashIcon />
-                      {t('Actions.delete_content_button_label')}
-                    </Button>
-                  </ConfirmationDialog>
-                </CardAction>
-              </CardHeader>
-              <CardContent className='flex h-full px-4.5 **:[div]:[[role=presentation]]:max-h-42 **:[div]:[[role=presentation]]:min-h-auto **:[div]:[[role=presentation]]:cursor-default **:[div]:[[role=presentation]]:border-ring-subtle **:[div]:[[role=presentation]]:p-2.5'>
-                <RichTextEditor key={htmlContent} defaultContent={content.content} readOnly size='sm' />
-              </CardContent>
-            </Card>
-          )
-        })}
-      </div>
+function EmptyCourseContentBody() {
+  return (
+    <div className={cn('flex min-h-60 flex-1 flex-col items-center justify-center gap-6')}>
+      <Info className='size-16 text-neutral-400 dark:text-neutral-500' />
+      <span className='text-center tracking-wide text-balance text-neutral-500 dark:text-neutral-400'>{'There are currently no contents associated to this course.'}</span>
     </div>
   )
 }

--- a/src/components/courses/create/(sections)/ContentSection.tsx
+++ b/src/components/courses/create/(sections)/ContentSection.tsx
@@ -34,14 +34,14 @@ function CreateContentButton({ disabled }: { disabled?: boolean }) {
   const t = useScopedI18n('Courses.Create.ContentSection')
 
   return (
-    <CourseContentDialog mode='create'>
-      <div className='flex justify-center gap-8'>
+    <div className='flex justify-center gap-8'>
+      <CourseContentDialog mode='create'>
         <Button variant='outline' size='lg' disabled={disabled}>
           <Plus className='size-5' />
           {t('Actions.create_new_button_label')}
         </Button>
-      </div>
-    </CourseContentDialog>
+      </CourseContentDialog>
+    </div>
   )
 }
 

--- a/src/components/courses/create/(sections)/OverviewSection.tsx
+++ b/src/components/courses/create/(sections)/OverviewSection.tsx
@@ -1,3 +1,4 @@
+import { CourseContentOverview } from '@/src/components/courses/create/(sections)/ContentSection'
 import GeneralSection from '@/src/components/courses/create/(sections)/GeneralSection'
 import QuestionsSection from '@/src/components/courses/create/(sections)/QuestionsSection'
 import SettingsSection from '@/src/components/courses/create/(sections)/SettingsSection'
@@ -14,6 +15,7 @@ export async function OverviewSection() {
       </div>
       <div className='grid gap-8 xl:grid-cols-2 **:[&_input]:ring-neutral-300/70 **:dark:[&_input]:ring-neutral-600/70 **:[&_textarea]:ring-neutral-300/70 **:dark:[&_textarea]:ring-neutral-600/70'>
         <GeneralSection disabled jumpBackButton />
+        <CourseContentOverview jumpBackButton />
         <QuestionsSection disabled jumpBackButton />
         <SettingsSection disabled jumpBackButtons className='xl:col-span-2' />
       </div>

--- a/src/components/courses/create/(sections)/OverviewSection.tsx
+++ b/src/components/courses/create/(sections)/OverviewSection.tsx
@@ -1,4 +1,4 @@
-import { CourseContentOverview } from '@/src/components/courses/create/(sections)/ContentSection'
+import ContentSection from '@/src/components/courses/create/(sections)/ContentSection'
 import GeneralSection from '@/src/components/courses/create/(sections)/GeneralSection'
 import QuestionsSection from '@/src/components/courses/create/(sections)/QuestionsSection'
 import SettingsSection from '@/src/components/courses/create/(sections)/SettingsSection'
@@ -15,7 +15,7 @@ export async function OverviewSection() {
       </div>
       <div className='grid gap-8 xl:grid-cols-2 **:[&_input]:ring-neutral-300/70 **:dark:[&_input]:ring-neutral-600/70 **:[&_textarea]:ring-neutral-300/70 **:dark:[&_textarea]:ring-neutral-600/70'>
         <GeneralSection disabled jumpBackButton />
-        <CourseContentOverview jumpBackButton />
+        <ContentSection disabled jumpBackButton />
         <QuestionsSection disabled jumpBackButton />
         <SettingsSection disabled jumpBackButtons className='xl:col-span-2' />
       </div>

--- a/src/components/tiptap-examples/RichTextEditor.tsx
+++ b/src/components/tiptap-examples/RichTextEditor.tsx
@@ -137,12 +137,14 @@ export function RichTextEditor({
   disabled,
   readOnly,
   size = 'md',
+  editorPaneClassname,
 }: {
   onUpdateAction?: (content: object) => void
   defaultContent?: Content
   disabled?: boolean
   readOnly?: boolean
   size?: 'sm' | 'md' | 'lg'
+  editorPaneClassname?: string
 }) {
   const t = useScopedI18n('Components.RichTextEditor')
   const isMobile = useIsBreakpoint()
@@ -199,7 +201,7 @@ export function RichTextEditor({
             }}
             editor={editor}
             role='presentation'
-            className={cn('rounded-md border border-input-ring', 'flex flex-1 flex-col', 'min-h-72 p-5', 'cursor-text overflow-auto')}
+            className={cn('rounded-md border border-input-ring', 'flex flex-1 flex-col', 'min-h-72 p-5', 'cursor-text overflow-auto', editorPaneClassname)}
           />
         </EditorContext.Provider>
       </div>

--- a/src/components/tiptap-examples/RichTextEditor.tsx
+++ b/src/components/tiptap-examples/RichTextEditor.tsx
@@ -138,6 +138,7 @@ export function RichTextEditor({
   readOnly,
   size = 'md',
   editorPaneClassname,
+  editorContainerClassname,
 }: {
   onUpdateAction?: (content: object) => void
   defaultContent?: Content
@@ -145,6 +146,7 @@ export function RichTextEditor({
   readOnly?: boolean
   size?: 'sm' | 'md' | 'lg'
   editorPaneClassname?: string
+  editorContainerClassname?: string
 }) {
   const t = useScopedI18n('Components.RichTextEditor')
   const isMobile = useIsBreakpoint()
@@ -182,7 +184,7 @@ export function RichTextEditor({
 
   return (
     <div data-slot='rich-text-editor-wrapper' className='flex flex-1 flex-col items-center'>
-      <div data-slot='rich-text-editor-container' className='@container/editor flex size-full max-h-[58dvh] flex-col'>
+      <div data-slot='rich-text-editor-container' className={cn('@container/editor flex size-full max-h-[58dvh] flex-col', editorContainerClassname)}>
         <EditorContext.Provider value={{ editor }}>
           <Toolbar className={cn(readOnly && 'hidden!')}>
             {mobileView === 'main' ? (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -343,6 +343,15 @@
         }
       },
       "title": "Ergebnisse deines Übungsversuchs"
+    },
+    "Contents": {
+      "title": "Kursinhalte",
+      "description": "Lesen Sie die Kursinhalte durch, um sich auf Übungen und Prüfungen vorzubereiten",
+      "Navigation": {
+        "title": "Verfügbare Inhalte",
+        "next_btn_label": "Nächster",
+        "previous_btn_label": "Vorheriger"
+      }
     }
   },
   "Examination": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -430,6 +430,10 @@
         "tooltip": "Übungs freigabelink erfolgreich in Zwischenablage kopiert.",
         "toast": "Erstellen des Übungslinks fehlgeschlagen."
       },
+      "show_course_contents": {
+        "label": "Kursinhalte anzeigen",
+        "tooltip": "Dieser Kurs hat keine Inhalte die angezeigt werden können."
+      },
       "edit_course": {
         "label": "Kurs bearbeiten",
         "tooltip": "Dir fehlen die Berechtigungen um diesen Kurs zu bearbeiten."

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -107,7 +107,8 @@
           },
           "submit_create_button_label": "Kursinhalt erstellen",
           "submit_update_button_label": "Inhalt aktualisieren"
-        }
+        },
+        "empty_content_text": "There are currently no contents associated to this course."
       },
       "QuestionSection": {
         "title": "Fragen",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -393,6 +393,7 @@
       "Statistics": {
         "questions_label": "Fragen",
         "estimatedTime_label": "geschätze Zeit",
+        "contents_label": "Inhalte",
         "points_label": "Punkte"
       },
       "user_role": {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -434,6 +434,10 @@ export default {
         tooltip: 'Übungs freigabelink erfolgreich in Zwischenablage kopiert.',
         toast: 'Erstellen des Übungslinks fehlgeschlagen.'
       },
+      show_course_contents: {
+        label: 'Kursinhalte anzeigen',
+        tooltip: 'Dieser Kurs hat keine Inhalte die angezeigt werden können.'
+      },
       edit_course: {
         label: 'Kurs bearbeiten',
         tooltip: 'Dir fehlen die Berechtigungen um diesen Kurs zu bearbeiten.'

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -397,6 +397,7 @@ export default {
       Statistics: {
         questions_label: 'Fragen',
         estimatedTime_label: 'geschätze Zeit',
+        contents_label: 'Inhalte',
         points_label: 'Punkte'
       },
       user_role: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -110,7 +110,8 @@ export default {
           },
           submit_create_button_label: 'Kursinhalt erstellen',
           submit_update_button_label: 'Inhalt aktualisieren'
-        }
+        },
+        empty_content_text: 'There are currently no contents associated to this course.'
       },
       QuestionSection: {
         title: 'Fragen',

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -346,6 +346,15 @@ export default {
         }
       },
       title: 'Ergebnisse deines Übungsversuchs'
+    },
+    Contents: {
+      title: 'Kursinhalte',
+      description: 'Lesen Sie die Kursinhalte durch, um sich auf Übungen und Prüfungen vorzubereiten',
+      Navigation: {
+        title: 'Verfügbare Inhalte',
+        next_btn_label: 'Nächster',
+        previous_btn_label: 'Vorheriger'
+      }
     }
   },
   Examination: {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -353,6 +353,15 @@
           "description": "Shows a detailed list of every question of this course to review your answers."
         }
       }
+    },
+    "Contents": {
+      "title": "Course Contents",
+      "description": "Read through the course contents to prepare for practice and examinations",
+      "Navigation": {
+        "title": "Available Contents",
+        "next_btn_label": "Next",
+        "previous_btn_label": "Previous"
+      }
     }
   },
   "Examination": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -440,6 +440,10 @@
         "tooltip": "This course has no questions, examination disabled.",
         "toast": "Unable to start Practice"
       },
+      "show_course_contents": {
+        "label": "Show Course Contents",
+        "tooltip": "This course has no contents, please create one first."
+      },
       "edit_course": {
         "label": "Edit Course",
         "tooltip": "You are not allowed to edit this course!"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -117,7 +117,8 @@
           },
           "submit_create_button_label": "Create Content",
           "submit_update_button_label": "Update Content"
-        }
+        },
+        "empty_content_text": "There are currently no contents associated to this course."
       },
       "QuestionSection": {
         "title": "Questions",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -403,6 +403,7 @@
       "Statistics": {
         "questions_label": "Questions",
         "estimatedTime_label": "estimatedTime",
+        "contents_label": "Contents",
         "points_label": "Points"
       },
       "user_role": {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -440,6 +440,10 @@ export default {
         tooltip: 'This course has no questions, examination disabled.',
         toast: 'Unable to start Practice'
       },
+      show_course_contents: {
+        label: 'Show Course Contents',
+        tooltip: 'This course has no contents, please create one first.'
+      },
       edit_course: {
         label: 'Edit Course',
         tooltip: 'You are not allowed to edit this course!'

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -117,7 +117,8 @@ export default {
           },
           submit_create_button_label: 'Create Content',
           submit_update_button_label: 'Update Content'
-        }
+        },
+        empty_content_text: 'There are currently no contents associated to this course.'
       },
       QuestionSection: {
         title: 'Questions',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -353,6 +353,15 @@ export default {
           description: 'Shows a detailed list of every question of this course to review your answers.'
         }
       }
+    },
+    Contents: {
+      title: 'Course Contents',
+      description: 'Read through the course contents to prepare for practice and examinations',
+      Navigation: {
+        title: 'Available Contents',
+        next_btn_label: 'Next',
+        previous_btn_label: 'Previous'
+      }
     }
   },
   Examination: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -403,6 +403,7 @@ export default {
       Statistics: {
         questions_label: 'Questions',
         estimatedTime_label: 'estimatedTime',
+        contents_label: 'Contents',
         points_label: 'Points'
       },
       user_role: {


### PR DESCRIPTION
> [!Note]
> This pull request implements missing parts of the recently introduces course-content feature. It adds the new `ContentSection` to the `OverviewSection` by externalizing and **redesigning** the `ContentSection`. Additionally, it introduces a new course-content page that shows the contents of a given course, accessible through a new `Show Contents` item in the `CourseActionMenu`.
> 
> <details>
> <summary>Redesigned `ContentSection`</summary>
> <img width="1276" height="967" alt="CleanShot 2026-04-01 at 10 26 25" src="https://github.com/user-attachments/assets/616202b6-838e-4912-b7e8-6d0447347436" />
> </details>
>
> <details>
> <summary>Updated `OverviewSection`</summary>
> <img width="1279" height="965" alt="CleanShot 2026-04-01 at 10 26 50" src="https://github.com/user-attachments/assets/36801e49-9eb7-4fb2-8a36-0fa8f4b41f71" />
> </details>
>
> <details>
> <summary>New course content page</summary>
> <img width="1278" height="966" alt="CleanShot 2026-04-01 at 10 27 55" src="https://github.com/user-attachments/assets/0539b60e-8686-4496-8b2b-92fd9a21c3af" />
> </details>

## Summary 

* **New Features**
  * Added a dedicated course contents page with next/previous navigation controls
  * Added "View Contents" option to the course action menu
  * Added custom breadcrumbs to new course contents page
  * Redesigned content section UI in course creation with improved visual layout and action buttons

* **Improvements**
  * Updated course card statistics to display content count
  * Added missing translation in `ContentSection` when section is empty

----
### Detailed Chagenlog

<details>
<summary>Changelog</summary>

[](https://google.com)

- **Features**:
  - Drafted `CourseContentOverview` component ([`ba67ddd4`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/ba67ddd4))
     This component may be used to show the contents associated to a given check, e.g. within the `OverviewSection` when creating a new course.
  
  - Drafted `/courses/contents/[courseId]` page ([`97a6bfca`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/97a6bfca))
     This new page is going to show the contents of a given course so that users can familiarize themselves with the contents associated to a given course.
  
  - Added "show contents" item to `CourseActionMenu` ([`57740ba5`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/57740ba5))
     This way users can view the course contents associated to a given course.
  
  - Redesigned `ContentSection` layout ([`510a43fd`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/510a43fd))
     This way the `ContentSection` now mimics the existing `QuetionsSection`. This means it shows the contents in a list instead of a grid. The reason for this change is that this eliminates sudden changes in the app's layout and also makes it easier to re-use this section in the `OverviewSection`.
  
  - Drafted course contents navigation panel ([`5248f24a`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/5248f24a))
     
  - Created `ContentProvider` component ([`5d0e918f`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/5d0e918f))
     This component is used to manage state about the content currently shown to the user and to switch between contents.
  
  - Introduced `ContentSwitchButton` component ([`7028762c`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/7028762c))
     This component is used to switch between the contents in the `/contents/[courseId]` page.
  
  - Added `ContentRenderer` component ([`9b53b647`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/9b53b647))
     This component renders the currently selected course content in a readOnly `RichtTextEditor`.
  
  - Created `ContentsPageBreadcrumbs` component ([`3ca2726c`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/3ca2726c))
     This component is rendered within the course contents page to define custom breadcrumbs for this page.
  
  - Added `ContentNavigationButtons` components ([`a7f39785`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/a7f39785))
     These new button components allow users to continue to the next content in line or go back to the previous content.
  
  - Redesigned course content navigation btn appearances ([`f6dfcf77`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f6dfcf77))
     This way the buttons show a label on top of the content title ("previous", "next") to indicate it as an call-to-action.
  

- **Refactors**:
  - Added course contents to `OverviewSection` ([`5c228594`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/5c228594))
     
  - Modularized `ContentSection` into subcomponents ([`f5a34b4d`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/f5a34b4d))
     Separated the rendering of the `ContentSection` into subcomponents to improve readability and maintainability.
  
  - Re-used `ContentSection` in `OverviewSection` ([`26bc7a18`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/26bc7a18))
     By redesigning the `ContentSection`'s layout it can be easily re-used in the `OverviewSection` for users to review their changes.
  
  - Added course content count to `CourseCard` ([`d5ff9496`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/d5ff9496))
     This way the amount of contents associated to a given course are displayed when discovering new or checks a user contributes to.
  
  - Updated course contents page layout ([`45fe45c0`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/45fe45c0))
     This way the navigation buttons are in the same "column" as the `RichTextEditor` which is visually more appealing.
  
  - Added `editorContainerClassname` arg to `RichTextEditor` ([`da8c70ae`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/da8c70ae))
     This way the classes of the container wrapping the `RichtTextEditor` can be easily adjusted. This is especially useful to dynamically update the max-height constraint when needed.
  
  - Adjusted `RichTextEditor` height in course content page ([`470cb208`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/470cb208))
     
  - Localized course contents page and components ([`d6989464`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/d6989464))
     
  - Removed contents navigation on small screens ([`62daab8e`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/62daab8e))
     This way users on mobile screens can use the navigation buttons below the editor to navigate between contents. The reason for this is that displaying the navigation next to the editor on small screens leads to both elements not being properly visible. Similarly, showing the navigation above or below the editor reduces the overall UX and appearance.
  
  - Added empty course page safeguard redirect ([`2ca081b7`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/2ca081b7))
     Previously, if users would navigate to a course page where the respective check has no contents, it would try to display contents that don't exist. This meant that the page looked kind of broken. By adding a safeguard that redirects users back to where they came from or to the courses page when the a course has no contents eliminates this edge-case.
  
  - Added safeguard against invalid index in `ContentSBtn` ([`b8815d02`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/b8815d02))
     The reason for this change is that when the index retrieval was unsuccessful the button previously would have switched to the invalid index (-1). Now the button is disabled when index retrieval is unsuccessful, thus when switching is not possible.
  
  - Added missing translation in `ContentSection` ([`1156afa5`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/1156afa5))
     Added a missing translation in the `EmptyCourseContentBody` subcomponent.
  
  - Restructured internal `CreateContentButton` component ([`70055012`](https://github.com/Master-Thesis-188199/KnowledgeCheckr/commit/70055012))
     The reason for this change is that in the wrapping div element that is the direct child of the DialogTrigger that in turn renders a button is considered the trigger. This would mean that the disabled state between button and trigger could be out-of-sync. However, the div wrapper was previously also consumed by the trigger, because it wasn't rendered. By moving the wrapping div outside the trigger, the potential issue is resolved anyhow.
  
</details>